### PR TITLE
長さ0の文字列をdraw_stringすると、NULL以降のメモリまで読んでしまうのを修正

### DIFF
--- a/src/lgfx/lgfx_font_support.hpp
+++ b/src/lgfx/lgfx_font_support.hpp
@@ -279,6 +279,7 @@ namespace lgfx
       std::int32_t right = 0;
       do {
         std::uint16_t uniCode = *string;
+        if (!uniCode) break;
         if (_text_style.utf8) {
           do {
             uniCode = decodeUTF8(*string);
@@ -864,6 +865,7 @@ namespace lgfx
         auto tmp = string;
         do {
           std::uint16_t uniCode = *tmp;
+          if (!tmp) break;
           if (_text_style.utf8) {
             do {
               uniCode = decodeUTF8(*tmp); 
@@ -913,6 +915,7 @@ namespace lgfx
       _filled_x = 0;
       do {
         std::uint16_t uniCode = *string;
+        if (!uniCode) break;
         if (_text_style.utf8) {
           do {
             uniCode = decodeUTF8(*string);


### PR DESCRIPTION
# 概要
表題のとおりですが、GUIsliceのTextboxの最下部になにか残るなーと思って調べたところ、バッファの先頭にNULL文字があると、無視して次のNULL文字まで読んでしまう不具合（バッファオーバーラン）を発見しました。

# 劇的
## before
<img width="320" src="https://user-images.githubusercontent.com/1535808/85519227-226bbb00-b63c-11ea-9a29-88bd9aff6f1d.JPG">

## after
<img width="320" src="https://user-images.githubusercontent.com/1535808/85519332-4af3b500-b63c-11ea-9653-df544fe1a16d.JPG">
