### PR TITLE
Include gpio_struct.h to support IDF 4.0

### DIFF
--- a/src/lgfx/platforms/esp32_common.hpp
+++ b/src/lgfx/platforms/esp32_common.hpp
@@ -11,7 +11,7 @@
 #else
   #include <freertos/FreeRTOS.h>
   #include <freertos/task.h>
-
+  #include <soc/gpio_struct.h>
   static inline void delay(std::uint32_t ms) { vTaskDelay(ms / portTICK_PERIOD_MS); }
 #endif
 


### PR DESCRIPTION
Before ESP-IDF  v4.0, `soc/gpio_struct.h`, which contains the definition of `GPIO`  struct, was included from some IDF headers.
But after ESP-IDF v4.0, `soc/gpio_struct.h` is not included anymore.

Therefore we have to include it manually.