### PR TITLE
fix: Fix Autodetect crash on ESP-IDF SPI

### DIFF
--- a/src/lgfx/platforms/LGFX_SPI_ESP32.hpp
+++ b/src/lgfx/platforms/LGFX_SPI_ESP32.hpp
@@ -301,8 +301,10 @@ namespace lgfx
 #if defined (ARDUINO) // Arduino ESP32
       spiStopBus(_spi_handle);
 #elif defined (CONFIG_IDF_TARGET_ESP32) // ESP-IDF
-      spi_bus_remove_device(_spi_handle);
-      spi_bus_free(_spi_host);
+      if (_spi_handle != nullptr) {
+        spi_bus_remove_device(_spi_handle);
+        spi_bus_free(_spi_host);
+      }
 #endif
       _spi_handle = nullptr;
     }


### PR DESCRIPTION
Autodetect can call releaseBus() without initBus() and that would cause
invalid handle passed to spi_bus_remove_device().