### PR TITLE
Prohibit copy construcing LGFXBase.

### DIFF
--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -33,6 +33,7 @@ namespace lgfx
   friend LGFX_Sprite;
   public:
     LGFXBase() {}
+    LGFXBase(const LGFXBase&) = delete;
     virtual ~LGFXBase() {}
 
 // color param format:
@@ -598,7 +599,9 @@ namespace lgfx
   #ifdef LGFX_FONT_SUPPORT_HPP_
      >
   #endif
-  {};
+  {
+
+  };
 
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
staticc LGFX& get_lcd();
...
auto lcd_ref = get_lcd();
```

みたいなコードを書いてLGFXがコピーされてハマった。
正しくは

```
auto& lcd_ref = get_lcd();
```

だが、LGFXBaseのコピーコンストラクタを無効化しておけばコンパイルエラーになるので、対策しておく。