### PR TITLE
Revert "Prohibit copy construcing LGFXBase."

### DIFF
--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -33,7 +33,6 @@ namespace lgfx
   friend LGFX_Sprite;
   public:
     LGFXBase() {}
-    LGFXBase(const LGFXBase&) = delete;
     virtual ~LGFXBase() {}
 
 // color param format:
@@ -599,9 +598,7 @@ namespace lgfx
   #ifdef LGFX_FONT_SUPPORT_HPP_
      >
   #endif
-  {
-
-  };
+  {};
 
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
Reverts lovyan03/LovyanGFX#49 to avoid disabling Sprite move constructor.