### PR TITLE
0.2.6

### DIFF
--- a/.github/Workflows/onrelease.yml
+++ b/.github/Workflows/onrelease.yml
@@ -1,0 +1,35 @@
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      versiontype:
+        description: 'Version upgrade type (p)atch/(m)inor/(M)ajor/(F)orced'
+        required: true
+        default: 'p'
+      versionforced:
+        description: 'Optional (F)orced version, leave blank for auto-raise'
+        required: false
+        default: ''
+jobs:
+  on_release_semver_next:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master # this must match the main/master branch name !!
+      - name: Semver-Iterator
+        run: |
+          chmod +x $GITHUB_WORKSPACE/.github/scripts/semver.sh
+          echo "Running $GITHUB_WORKSPACE/.github/scripts/semver.sh -${{ github.event.inputs.versiontype }} ${{ github.event.inputs.versionforced }} "
+          $GITHUB_WORKSPACE/.github/scripts/semver.sh -${{ github.event.inputs.versiontype }} ${{ github.event.inputs.versionforced }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "raising version"
+          title: "Semver-Iterator auto-raise"
+          body: |
+            A version change occured

--- a/.github/scripts/semver.sh
+++ b/.github/scripts/semver.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+
+function patchpropertyfiles {
+
+  old_tag=$1
+  new_tag=$2
+
+  echo "Patching property/json/tag files $old_tag => $new_tag"
+
+  if [ -f "$GITHUB_WORKSPACE/library.json" ]; then
+    sed -i -e "s/\"$old_tag\"/\"$new_tag\"/g" $GITHUB_WORKSPACE/library.json
+    cat $GITHUB_WORKSPACE/library.json
+  fi
+
+  if [ -f "$GITHUB_WORKSPACE/library.properties" ]; then
+    sed -i -e "s/version=$old_tag/version=$new_tag/g" $GITHUB_WORKSPACE/library.properties
+    cat $GITHUB_WORKSPACE/library.properties
+  fi
+
+  if [ -f "$GITHUB_WORKSPACE/src/gitTagVersion.h" ]; then
+    sed -i -e "s/\"$old_tag\"/\"$new_tag\"/g" $GITHUB_WORKSPACE/src/gitTagVersion.h
+    cat $GITHUB_WORKSPACE/src/gitTagVersion.h
+  fi
+
+}
+
+
+
+if [ $GITHUB_EVENT_NAME == "workflow_dispatch" ]; then
+
+  echo "Workflow dispatched event, guessing version from properties file"
+  localtag=`cat $GITHUB_WORKSPACE/library.properties | grep version`
+  RELEASE_TAG=${localtag//version=/ }
+  minor=true
+
+else
+
+  if [ ! $GITHUB_EVENT_NAME == "release" ]; then
+      echo "Wrong event '$GITHUB_EVENT_NAME'!"
+      exit 1
+  fi
+
+  EVENT_JSON=`cat $GITHUB_EVENT_PATH`
+
+  action=`echo $EVENT_JSON | jq -r '.action'`
+  if [ ! $action == "published" ]; then
+      echo "Wrong action '$action'. Exiting now..."
+      exit 0
+  fi
+
+  draft=`echo $EVENT_JSON | jq -r '.release.draft'`
+  if [ $draft == "true" ]; then
+      echo "It's a draft release. Exiting now..."
+      exit 0
+  fi
+
+  RELEASE_PRE=`echo $EVENT_JSON | jq -r '.release.prerelease'`
+  RELEASE_TAG=`echo $EVENT_JSON | jq -r '.release.tag_name'`
+  RELEASE_BRANCH=`echo $EVENT_JSON | jq -r '.release.target_commitish'`
+  RELEASE_ID=`echo $EVENT_JSON | jq -r '.release.id'`
+  RELEASE_BODY=`echo $EVENT_JSON | jq -r '.release.body'`
+
+  echo "Event: $GITHUB_EVENT_NAME, Repo: $GITHUB_REPOSITORY, Path: $GITHUB_WORKSPACE, Ref: $GITHUB_REF"
+  echo "Action: $action, Branch: $RELEASE_BRANCH, ID: $RELEASE_ID"
+  echo "Tag: $RELEASE_TAG, Draft: $draft, Pre-Release: $RELEASE_PRE"
+
+fi
+
+
+# Increment a version string using Semantic Versioning (SemVer) terminology.
+major=false;
+minor=false;
+patch=false;
+
+while getopts ":MmpF:" Option
+do
+  case $Option in
+    M ) major=true;;
+    m ) minor=true;;
+    p ) patch=true;;
+    F )
+      version=${OPTARG}
+      if [ "$version" == "auto" ]; then
+        # default to patch
+        patch=true
+      else
+        forcedversion=true
+        echo "Forcing version to $version"
+      fi
+    ;;
+    * ) echo "NOTHING TO DO";;
+  esac
+done
+
+if [ $OPTIND -eq 1 ]; then
+  echo "No options were passed, assuming patch level"
+  patch=true
+fi
+
+
+if [ -z ${RELEASE_TAG} ]
+then
+    echo "Couldn't determine version"
+    exit 1
+fi
+
+
+if [ "$forcedversion" != "true" ]; then
+
+  # Build array from version string.
+
+  a=( ${RELEASE_TAG//./ } )
+  major_version=0
+  # If version string is missing or has the wrong number of members, show usage message.
+
+  if [ ${#a[@]} -ne 3 ]; then
+    echo "usage: $(basename $0) [-Mmp] major.minor.patch"
+    exit 1
+  fi
+
+  # Increment version numbers as requested.
+
+  if [ $major == "true" ]; then
+    echo "Raising MAJOR"
+    # Check for v in version (e.g. v1.0 not just 1.0)
+    if [[ ${a[0]} =~ ([vV]?)([0-9]+) ]]; then
+      v="${BASH_REMATCH[1]}"
+      major_version=${BASH_REMATCH[2]}
+      ((major_version++))
+      a[0]=${v}${major_version}
+    else
+      ((a[0]++))
+      major_version=a[0]
+    fi
+
+    a[1]=0
+    a[2]=0
+  fi
+
+  if [ $minor == "true" ]; then
+    echo "Raising MINOR"
+    ((a[1]++))
+    a[2]=0
+  fi
+
+  if [ $patch == "true"  ]; then
+    echo "Raising PATCH"
+    ((a[2]++))
+  fi
+
+  version=$(echo "${a[0]}.${a[1]}.${a[2]}")
+
+fi
+
+patchpropertyfiles $RELEASE_TAG $version
+

--- a/examples/HowToUse/5_images/5_images.ino
+++ b/examples/HowToUse/5_images/5_images.ino
@@ -129,7 +129,7 @@ setAddrWindow は描画範囲外が指定された場合は範囲内に調整さ
   lcd.pushImage(   0, 0, image_width, image_height, (uint16_t*)rgb565); // RGB565の16bit画像データを描画。
 
   // データとバイト順変換の指定が一致していない場合、色化けします。
-  lcd.pushImage(   0, 40, image_width, image_height, (uint16_t*)swap565); // ビッグエンディアンの16bit画像データは色が化ける。
+  lcd.pushImage(   0, 40, image_width, image_height, (uint16_t*)swap565); // NG. バイト順変換済みデータにバイト順変換を行うと色化けする。
 
   // 描画範囲が画面外にはみ出すなどした場合でも、描画結果が崩れることはありません。
   lcd.pushImage(-1, 80, image_width, image_height, (uint16_t*)rgb565); // X座標-1（画面外）を指定しても描画は乱れない。
@@ -160,8 +160,8 @@ setAddrWindow は描画範囲外が指定された場合は範囲内に調整さ
   lcd.pushImage(120,   0, image_width, image_height, (lgfx:: rgb332_t*) rgb332); // good  8bitデータ
   lcd.pushImage(120,  40, image_width, image_height, (lgfx:: rgb565_t*) rgb565); // good 16bitデータ
   lcd.pushImage(120,  80, image_width, image_height, (lgfx:: rgb888_t*) rgb888); // good 24bitデータ
-  lcd.pushImage(120, 120, image_width, image_height, (lgfx::swap565_t*)swap565); // good スワップ済み16bitデータ
-  lcd.pushImage(120, 160, image_width, image_height, (lgfx:: bgr888_t*) bgr888); // good スワップ済み24bitデータ
+  lcd.pushImage(120, 120, image_width, image_height, (lgfx::swap565_t*)swap565); // good バイト順変換済み16bitデータ
+  lcd.pushImage(120, 160, image_width, image_height, (lgfx:: bgr888_t*) bgr888); // good バイト順変換済み24bitデータ
 
 // 第６引数で透過色を指定できます。透過指定された色のある部分は描画されません。
   lcd.pushImage(160,   0, image_width, image_height, (lgfx:: rgb332_t*) rgb332, 0);                   // 黒を透過指定

--- a/examples/Sprite/RotateDial/RotateDial.ino
+++ b/examples/Sprite/RotateDial/RotateDial.ino
@@ -1,0 +1,172 @@
+#include <LovyanGFX.hpp>
+
+static LGFX lcd;
+static LGFX_Sprite sp;
+static LGFX_Sprite sprites[2];
+static bool flip;
+static int sprite_height;
+
+inline uint16_t getBackColor(int x, int y)
+{
+  return lcd.swap565(abs((x&31)-16)<<3, 0, abs((y&31)-16)<<3);
+//return lcd.swap565(x, 0, y);
+}
+
+void setup(void)
+{
+  lcd.init();
+
+  if (lcd.width() < lcd.height()) { lcd.setRotation(lcd.getRotation()^1); }
+
+  for (int i = 0; i < 2; i++)
+  {
+    sprites[i].setColorDepth(lcd.getColorDepth());
+    sprites[i].setFont(&fonts::Font2);
+    sprites[i].setTextColor(TFT_WHITE);
+    sprites[i].setTextDatum(textdatum_t::top_right);
+  }
+
+  int div = 1;
+  for (;;)
+  {
+    sprite_height = (lcd.height() + div - 1) / div;
+    bool fail = false;
+    for (int i = 0; !fail && i < 2; ++i)
+    {
+      fail = !sprites[i].createSprite(lcd.width(), sprite_height);
+    }
+    if (!fail) break;
+    for (int i = 0; i < 2; ++i)
+    {
+      sprites[i].deleteSprite();
+    }
+    div++;
+  }
+
+  sp.setColorDepth(8);
+  sp.setFont(&fonts::Font2);
+  sp.setTextDatum(textdatum_t::middle_center);
+
+  lcd.startWrite();
+}
+
+void loop(void)
+{
+  static int count;
+  static int prev_sec;
+  static int prev_fps;
+  static int fps;
+  ++fps;
+  int sec = millis() / 1000;
+  if (prev_sec != sec)
+  {
+    prev_sec = sec;
+    prev_fps = fps;
+    fps = 0;
+  }
+  count++;
+
+  float y_center = (std::max(lcd.width(), lcd.height()));
+  float distance;
+  float zoom_x, zoom_y;
+
+  for (int div_y = 0; div_y < lcd.height(); div_y += sprite_height)
+  {
+    float angle = (float)(count * 36) / 100;
+//  sprites[flip].clear();
+//* // draw background
+    std::uint16_t* rawbuf = (std::uint16_t*)sprites[flip].getBuffer();
+    for (int y = 0; y < sprite_height; y++)
+    {
+      std::uint16_t* rawline = &rawbuf[y * lcd.width()];
+      for (int x = 0; x < lcd.width(); x++)
+      {
+        rawline[x] = getBackColor(x, div_y + y);
+      }
+    }
+//*/
+
+    sp.setTextColor(TFT_WHITE, TFT_BLACK);
+    if (div_y == 0)
+    {
+      // draw fps and counter
+      sprites[flip].setCursor(0,0);
+      sprites[flip].printf("fps:%03d", prev_fps);
+      sprites[flip].drawNumber(count, lcd.width(), 0);
+
+      distance = y_center;
+      zoom_x = distance / 512.0f;
+      zoom_y = distance / 256.0f;
+      sp.createSprite(21, 11);
+      sp.fillTriangle(0, 0, 20, 0, 10, 10, TFT_WHITE);
+      sp.setPivot(10, distance / zoom_y - 0.5);
+      sp.pushRotateZoomWithAA(&sprites[flip], lcd.width() / 2, y_center - div_y, 0, zoom_x, zoom_y, 0);
+    }
+
+
+    // draw outer dial
+    distance = y_center * 0.95;
+    zoom_y = distance / 30;
+    sp.createSprite(1, 1);
+    sp.clear(TFT_WHITE);
+    for (int i = 0; i < 100; i++)
+    {
+      float a = fmodf(360.0f + angle - i * 3.6f, 360.0f);
+      if (a > 40 && a < 320) continue;
+
+      zoom_x = distance / (i%5 ? 50 : 30);
+      zoom_y = distance / (i%5 ? 30 : ((i % 10) ? 20 : 15));
+      sp.setPivot(0, distance / zoom_y - 0.5);
+      sp.pushRotateZoomWithAA(&sprites[flip], lcd.width() / 2, y_center - div_y, a, zoom_x, zoom_y, 0);
+    }
+
+    // draw outer number
+    distance *= 0.92;
+    zoom_x = distance / 128.0f;
+    zoom_y = distance / 128.0f;
+    sp.createSprite(18, 14);
+    sp.setPivot((float)sp.width() / 2, distance / zoom_y);
+    for (int i = 0; i < 100; i += 10)
+    {
+      float a = fmodf(360.0f + angle - i * 3.6f, 360.0f);
+      if (a > 50 && a < 310) continue;
+      sp.drawNumber(i, sp.width()>>1, sp.height()>>1);
+      sp.pushRotateZoomWithAA(&sprites[flip], lcd.width() / 2, y_center - div_y, a, zoom_x, zoom_y, 0);
+    }
+
+
+    // draw inner dial
+    angle /= 10;
+    distance *= 0.85;
+    sp.createSprite(1, 1);
+    sp.setTextColor(TFT_YELLOW, TFT_BLACK);
+    sp.clear(TFT_YELLOW);
+    for (int i = 0; i < 100; i++)
+    {
+      float a = fmodf(360.0f + angle - i * 3.6f, 360.0f);
+      if (a > 60 && a < 300) continue;
+
+      zoom_x = distance / (i%5 ? 50 : 30);
+      zoom_y = distance / (i%5 ? 30 : ((i % 10) ? 20 : 15));
+      sp.setPivot(0, distance / zoom_y - 0.5);
+      sp.pushRotateZoomWithAA(&sprites[flip], lcd.width() / 2, y_center - div_y, a, zoom_x, zoom_y, 0);
+    }
+
+    // draw inner number
+    distance *= 0.9;
+    zoom_x = distance / 128.0f;
+    zoom_y = distance / 128.0f;
+    sp.createSprite(21, 14);
+    sp.setPivot((float)sp.width() / 2, distance / zoom_y);
+    for (int i = 0; i < 100; i += 10)
+    {
+      float a = fmodf(360.0f + angle - i * 3.6f, 360.0f);
+      if (a > 70 && a < 290) continue;
+      sp.drawFloat(float(i)/100, 1, sp.width()>>1, sp.height()>>1);
+      sp.pushRotateZoomWithAA(&sprites[flip], lcd.width() / 2, y_center - div_y, a, zoom_x, zoom_y, 0);
+    }
+
+    sprites[flip].pushSprite(&lcd, 0, div_y);
+    flip = !flip;
+  }
+}

--- a/examples/Standard/Graph/Graph.ino
+++ b/examples/Standard/Graph/Graph.ino
@@ -1,0 +1,90 @@
+#include <LovyanGFX.hpp>
+
+#include <vector>
+
+#define LINE_COUNT 6
+
+static LGFX lcd;
+
+static std::vector<int> points[LINE_COUNT];
+static int colors[] = { TFT_RED, TFT_GREEN, TFT_BLUE, TFT_CYAN, TFT_MAGENTA, TFT_YELLOW };
+static int xoffset, yoffset, point_count;
+
+int getBaseColor(int x, int y)
+{
+  return ((x^y)&3 || ((x-xoffset)&31 && y&31) ? TFT_BLACK : ((!y || x == xoffset) ? TFT_WHITE : TFT_DARKGREEN));
+}
+
+void setup(void)
+{
+  lcd.init();
+
+  if (lcd.width() < lcd.height()) lcd.setRotation(lcd.getRotation() ^ 1);
+
+  yoffset = lcd.height() >> 1;
+  xoffset = lcd.width()  >> 1;
+  point_count = lcd.width() + 1;
+
+  for (int i = 0; i < LINE_COUNT; i++)
+  {
+    points[i].resize(point_count);
+  }
+
+  lcd.startWrite();
+  lcd.setAddrWindow(0, 0, lcd.width(), lcd.height());
+  for (int y = 0; y < lcd.height(); y++)
+  {
+    for (int x = 0; x < lcd.width(); x++)
+    {
+      lcd.writeColor(getBaseColor(x, y - yoffset), 1);
+    }
+  }
+  lcd.endWrite();
+}
+
+void loop(void)
+{
+  static int prev_sec;
+  static int fps;
+  ++fps;
+  int sec = millis() / 1000;
+  if (prev_sec != sec)
+  {
+    prev_sec = sec;
+    lcd.setCursor(0,0);
+    lcd.printf("fps:%03d", fps);
+    fps = 0;
+  }
+
+  static int count;
+
+  for (int i = 0; i < LINE_COUNT; i++)
+  {
+    points[i][count % point_count] = (sinf((float)count / (10 + 30 * i))+sinf((float)count / (13 + 37 * i))) * (lcd.height() >> 2);
+  }
+
+  ++count;
+
+  lcd.startWrite();
+  int index1 = count % point_count;
+  for (int x = 0; x < point_count-1; x++)
+  {
+    int index0 = index1;
+    index1 = (index0 +1) % point_count;
+    for (int i = 0; i < LINE_COUNT; i++)
+    {
+      int y = points[i][index0];
+      if (y != points[i][index1])
+      {
+        lcd.writePixel(x, y + yoffset, getBaseColor(x, y));
+      }
+    }
+
+    for (int i = 0; i < LINE_COUNT; i++)
+    {
+      int y = points[i][index1];
+      lcd.writePixel(x, y + yoffset, colors[i]);
+    }
+  }
+  lcd.endWrite();
+}

--- a/examples/Standard/SaveBMP/SaveBMP.ino
+++ b/examples/Standard/SaveBMP/SaveBMP.ino
@@ -1,0 +1,148 @@
+#if defined (ARDUINO_WIO_TERMINAL)
+  #include <Seeed_FS.h>
+  #include <SD/Seeed_SD.h>
+#else
+  #include <SD.h>
+  #include <SPIFFS.h>
+#endif
+
+#include <LovyanGFX.hpp>
+
+static LGFX lcd;
+
+static constexpr char filename[] = "/lovyangfx_test.bmp";
+
+#ifndef SDCARD_SS_PIN
+#define SDCARD_SS_PIN 4
+#endif
+
+#ifndef SDCARD_SPI
+#define SDCARD_SPI SPI
+#endif
+
+
+bool saveToSD_16bit()
+{
+  std::size_t dlen;
+
+  bool result = false;
+  File file = SD.open(filename, "w");
+  if (file)
+  {
+    int width  = lcd.width();
+    int height = lcd.height();
+
+    int rowSize = (2 * width + 3) & ~ 3;
+
+    lgfx::bitmap_header_t bmpheader;
+    bmpheader.bfType = 0x4D42;
+    bmpheader.bfSize = rowSize * height + sizeof(bmpheader);
+    bmpheader.bfOffBits = sizeof(bmpheader);
+
+    bmpheader.biSize = 40;
+    bmpheader.biWidth = width;
+    bmpheader.biHeight = height;
+    bmpheader.biPlanes = 1;
+    bmpheader.biBitCount = 16;
+    bmpheader.biCompression = 3;
+
+    file.write((std::uint8_t*)&bmpheader, sizeof(bmpheader));
+    std::uint8_t buffer[rowSize];
+    memset(&buffer[rowSize - 4], 0, 4);
+    for (int y = lcd.height() - 1; y >= 0; y--)
+    {
+      lcd.readRect(0, y, lcd.width(), 1, (lgfx::rgb565_t*)buffer);
+      file.write(buffer, rowSize);
+    }
+    file.close();
+    result = true;
+  }
+  else
+  {
+    Serial.print("error:file open failure\n");
+  }
+
+  return result;
+}
+
+bool saveToSD_24bit()
+{
+  std::size_t dlen;
+
+  bool result = false;
+  File file = SD.open(filename, "w");
+  if (file)
+  {
+    int width  = lcd.width();
+    int height = lcd.height();
+
+    int rowSize = (3 * width + 3) & ~ 3;
+
+    lgfx::bitmap_header_t bmpheader;
+    bmpheader.bfType = 0x4D42;
+    bmpheader.bfSize = rowSize * height + sizeof(bmpheader);
+    bmpheader.bfOffBits = sizeof(bmpheader);
+
+    bmpheader.biSize = 40;
+    bmpheader.biWidth = width;
+    bmpheader.biHeight = height;
+    bmpheader.biPlanes = 1;
+    bmpheader.biBitCount = 24;
+    bmpheader.biCompression = 0;
+
+    file.write((std::uint8_t*)&bmpheader, sizeof(bmpheader));
+    std::uint8_t buffer[rowSize];
+    memset(&buffer[rowSize - 4], 0, 4);
+    for (int y = lcd.height() - 1; y >= 0; y--)
+    {
+      lcd.readRect(0, y, lcd.width(), 1, (lgfx::rgb888_t*)buffer);
+      file.write(buffer, rowSize);
+    }
+    file.close();
+    result = true;
+  }
+  else
+  {
+    Serial.print("error:file open failure\n");
+  }
+
+  return result;
+}
+
+void setup()
+{
+  lcd.init();
+
+  Serial.begin(115200);
+
+  lcd.setColorDepth(16);
+
+  lcd.setColor(TFT_WHITE);
+  lcd.startWrite();
+  lcd.setAddrWindow(0, 0, lcd.width(), lcd.height());
+  for (int y = 0; y < lcd.height(); ++y)
+  {
+    for (int x = 0; x < lcd.width(); ++x)
+    {
+      lcd.writeColor( lcd.color888(x << 1, x + y, y << 1), 1);
+    }
+  }
+  lcd.print("BMP save test\n");
+  lcd.endWrite();
+
+  do {
+    SD.end();
+    delay(1000);
+
+    SD.begin(SDCARD_SS_PIN, SDCARD_SPI, 25000000);
+
+  } while (!saveToSD_16bit());
+
+
+  lcd.print("BMP save success.");
+}
+
+void loop(void)
+{
+  lcd.drawBmpFile(SD, filename, random(-20,20), random(-20, 20));
+}

--- a/examples/Standard/SavePNG/SavePNG.ino
+++ b/examples/Standard/SavePNG/SavePNG.ino
@@ -65,11 +65,12 @@ void setup()
 
   lcd.setColor(TFT_WHITE);
   lcd.startWrite();
-  for (int x = 0; x < 128; ++x)
+  lcd.setAddrWindow(0, 0, lcd.width(), lcd.height());
+  for (int y = 0; y < lcd.height(); ++y)
   {
-    for (int y = 0; y < 128; ++y)
+    for (int x = 0; x < lcd.width(); ++x)
     {
-      lcd.writePixel(x, y, lcd.color888(x << 1, x + y, y << 1));
+      lcd.writeColor( lcd.color888(x << 1, x + y, y << 1), 1);
     }
   }
   lcd.print("PNG save test\n");
@@ -89,5 +90,5 @@ void setup()
 
 void loop(void)
 {
-  delay(1000);
+  lcd.drawPngFile(SD, filename, random(-20,20), random(-20, 20));
 }

--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/lovyan03/LovyanGFX"
   },
-  "version": "0.2.5",
+  "version": "0.2.6",
   "framework": "arduino, espidf",
   "platforms": "espressif32, atmelsam",
   "build": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LovyanGFX
-version=0.2.5
+version=0.2.6
 author=lovyan03
 maintainer=Lovyan <42724151+lovyan03@users.noreply.github.com>
 sentence=LCD Graphics driver with touch for ESP32 and SAMD51

--- a/src/gitTagVersion.h
+++ b/src/gitTagVersion.h
@@ -1,1 +1,1 @@
-#define LOVYANGFX_VERSION F("0.2.5")
+#define LOVYANGFX_VERSION F("0.2.6")

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -1124,9 +1124,9 @@ namespace lgfx
     }
 
     {
-      std::int32_t offset_y32 = matrix[5] * (1 << FP_SCALE);
-      min_y = std::max(_clip_t, (offset_y32 + min_y) >> FP_SCALE);
-      max_y = std::min(_clip_b, (offset_y32 + max_y) >> FP_SCALE) + 1;
+      std::int32_t offset_y32 = matrix[5] * (1 << FP_SCALE) + (1 << (FP_SCALE-1));
+      min_y = std::max(_clip_t    , (offset_y32 + min_y) >> FP_SCALE);
+      max_y = std::min(_clip_b + 1, (offset_y32 + max_y) >> FP_SCALE);
       if (min_y >= max_y) return;
     }
 
@@ -1157,19 +1157,17 @@ namespace lgfx
     std::int32_t y = min_y - max_y;
 
     startWrite();
-    do {
+    do
+    {
       iA[2] += iA[1];
       iA[5] += iA[4];
       std::int32_t left  = std::max(cl, std::max((iA[2] + xs1) / div1, (iA[5] + ys1) / div2));
       std::int32_t right = std::min(cr, std::min((iA[2] + xs2) / div1, (iA[5] + ys2) / div2));
-      if (left < right) {
+      if (left < right)
+      {
         pc->src_x32 = iA[2] + left * iA[0];
-        if (static_cast<std::uint32_t>(pc->src_x) < pc->src_width) {
-          pc->src_y32 = iA[5] + left * iA[3];
-          if (static_cast<std::uint32_t>(pc->src_y) < pc->src_height) {
-            pushImage_impl(left, y + max_y, right - left, 1, pc, true);
-          }
-        }
+        pc->src_y32 = iA[5] + left * iA[3];
+        pushImage_impl(left, y + max_y, right - left, 1, pc, true);
       }
     } while (++y);
     endWrite();
@@ -1190,9 +1188,9 @@ namespace lgfx
     }
 
     {
-      std::int32_t offset_y32 = matrix[5] * (1 << FP_SCALE);
-      min_y = std::max(_clip_t, (offset_y32 + min_y) >> FP_SCALE);
-      max_y = std::min(_clip_b, (offset_y32 + max_y) >> FP_SCALE) + 1;
+      std::int32_t offset_y32 = matrix[5] * (1 << FP_SCALE) + (1 << (FP_SCALE-1));
+      min_y = std::max(_clip_t    , (offset_y32 + min_y) >> FP_SCALE);
+      max_y = std::min(_clip_b + 1, (offset_y32 + max_y) >> FP_SCALE);
       if (min_y >= max_y) return;
     }
 
@@ -1208,13 +1206,13 @@ namespace lgfx
     iA[2] += ((iA[0] + iA[1] * offset) >> 1);
     iA[5] += ((iA[3] + iA[4] * offset) >> 1);
 
-    std::int32_t scale_w = (pc->src_width + 1) << FP_SCALE;
-    std::int32_t xs1 = (iA[0] < 0 ?   - scale_w :   1) - iA[0] + (1 << (FP_SCALE - 1));
-    std::int32_t xs2 = (iA[0] < 0 ? 0 : (1 - scale_w)) - iA[0] + (1 << (FP_SCALE - 1));
+    std::int32_t scale_w = (pc->src_width << FP_SCALE) + (x32_diff << 1);
+    std::int32_t xs1 = (iA[0] < 0 ?   - scale_w :   1) - iA[0] + x32_diff;
+    std::int32_t xs2 = (iA[0] < 0 ? 0 : (1 - scale_w)) - iA[0] + x32_diff;
 
-    std::int32_t scale_h = (pc->src_height + 1) << FP_SCALE;
-    std::int32_t ys1 = (iA[3] < 0 ?   - scale_h :   1) - iA[3] + (1 << (FP_SCALE - 1));
-    std::int32_t ys2 = (iA[3] < 0 ? 0 : (1 - scale_h)) - iA[3] + (1 << (FP_SCALE - 1));
+    std::int32_t scale_h = (pc->src_height << FP_SCALE) + (y32_diff << 1);
+    std::int32_t ys1 = (iA[3] < 0 ?   - scale_h :   1) - iA[3] + y32_diff;
+    std::int32_t ys2 = (iA[3] < 0 ? 0 : (1 - scale_h)) - iA[3] + y32_diff;
 
     std::int32_t cl = _clip_l    ;
     std::int32_t cr = _clip_r + 1;
@@ -1225,12 +1223,14 @@ namespace lgfx
     std::int32_t div2 = iA[3] ? - iA[3] : -1;
 
     startWrite();
-    do {
+    do
+    {
       iA[2] += iA[1];
       iA[5] += iA[4];
       std::int32_t left  = std::max(cl, std::max((iA[2] + xs1) / div1, (iA[5] + ys1) / div2));
       std::int32_t right = std::min(cr, std::min((iA[2] + xs2) / div1, (iA[5] + ys2) / div2));
-      if (left < right) {
+      if (left < right)
+      {
         std::int32_t len = right - left;
 
         std::uint32_t xs = iA[2] + left * iA[0];

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -1125,8 +1125,8 @@ namespace lgfx
 
     {
       std::int32_t offset_y32 = matrix[5] * (1 << FP_SCALE) + (1 << (FP_SCALE-1));
-      min_y = std::max(_clip_t    , (offset_y32 + min_y) >> FP_SCALE);
-      max_y = std::min(_clip_b + 1, (offset_y32 + max_y) >> FP_SCALE);
+      min_y = std::max(_clip_t    , (offset_y32 + min_y - 1) >> FP_SCALE);
+      max_y = std::min(_clip_b + 1, (offset_y32 + max_y    ) >> FP_SCALE);
       if (min_y >= max_y) return;
     }
 
@@ -1189,8 +1189,8 @@ namespace lgfx
 
     {
       std::int32_t offset_y32 = matrix[5] * (1 << FP_SCALE) + (1 << (FP_SCALE-1));
-      min_y = std::max(_clip_t    , (offset_y32 + min_y) >> FP_SCALE);
-      max_y = std::min(_clip_b + 1, (offset_y32 + max_y) >> FP_SCALE);
+      min_y = std::max(_clip_t    , (offset_y32 + min_y - 1) >> FP_SCALE);
+      max_y = std::min(_clip_b + 1, (offset_y32 + max_y    ) >> FP_SCALE);
       if (min_y >= max_y) return;
     }
 

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -1225,11 +1225,13 @@ namespace lgfx
       if (left < right)
       {
         pc->src_x32 = iA[2] + left * iA[0];
-        if (pc->src_x >= 0)
+        if (static_cast<std::uint32_t>(pc->src_x) < pc->src_width)
         {
           pc->src_y32 = iA[5] + left * iA[3];
-          if (pc->src_y >= 0)
+          if (static_cast<std::uint32_t>(pc->src_y) < pc->src_height)
+          {
             pushImage_impl(left, y + max_y, right - left, 1, pc, true);
+          }
         }
       }
     } while (++y);

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -2371,7 +2371,7 @@ namespace lgfx
 
     auto p = (png_file_decoder_t*)lgfx_pngle_get_user_data(pngle);
 
-    if (p->scale != 1.0) {
+    if (p->scale != 1.0f) {
       w = ceilf(w * p->scale);
       h = ceilf(h * p->scale);
     }

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -1030,7 +1030,7 @@ namespace lgfx
     result[5] =  dst_y - src_x * result[3] - src_y * result[4];
   }
 
-  static bool make_invert_affine32(std::int32_t result[6], float matrix[6])
+  static bool make_invert_affine32(std::int32_t* __restrict__ result, const float* __restrict__ matrix)
   {
     float det = matrix[0] * matrix[4] - matrix[1] * matrix[3];
     if (det == 0.0) return false;
@@ -1057,7 +1057,7 @@ namespace lgfx
     push_image_affine_aa(matrix, w, h, pc);
   }
 
-  void LGFXBase::push_image_affine(float *matrix, std::int32_t w, std::int32_t h, pixelcopy_t *pc)
+  void LGFXBase::push_image_affine(const float* matrix, std::int32_t w, std::int32_t h, pixelcopy_t* pc)
   {
     pc->no_convert = false;
     pc->src_height = h;
@@ -1072,7 +1072,7 @@ namespace lgfx
     push_image_affine(matrix, pc);
   }
 
-  void LGFXBase::push_image_affine_aa(float *matrix, std::int32_t w, std::int32_t h, pixelcopy_t *pc)
+  void LGFXBase::push_image_affine_aa(const float* matrix, std::int32_t w, std::int32_t h, pixelcopy_t* pc)
   {
     pc->no_convert = false;
     pc->src_height = h;
@@ -1109,7 +1109,7 @@ namespace lgfx
     push_image_affine_aa(matrix, pc, &pc_post);
   }
 
-  void LGFXBase::push_image_affine(float *matrix, pixelcopy_t *pc)
+  void LGFXBase::push_image_affine(const float* matrix, pixelcopy_t* pc)
   {
     std::int32_t min_y = matrix[3] * (pc->src_width  << FP_SCALE);
     std::int32_t max_y = matrix[4] * (pc->src_height << FP_SCALE);
@@ -1173,7 +1173,7 @@ namespace lgfx
     endWrite();
   }
 
-  void LGFXBase::push_image_affine_aa(float *matrix, pixelcopy_t *pc, pixelcopy_t *pc2)
+  void LGFXBase::push_image_affine_aa(const float* matrix, pixelcopy_t* pc, pixelcopy_t* pc2)
   {
     std::int32_t min_y = matrix[3] * (pc->src_width  << FP_SCALE);
     std::int32_t max_y = matrix[4] * (pc->src_height << FP_SCALE);

--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -121,6 +121,9 @@ namespace lgfx
     template<typename T> inline void paint    ( std::int32_t x, std::int32_t y, const T& color) { setColor(color); floodFill(x, y); }
                          inline void paint    ( std::int32_t x, std::int32_t y                ) {                  floodFill(x, y); }
 
+    template<typename T> inline void fillAffine(const float matrix[6], std::int32_t w, std::int32_t h, const T& color) { setColor(color); fillAffine(matrix, w, h); }
+                                void fillAffine(const float matrix[6], std::int32_t w, std::int32_t h);
+
     template<typename T> inline void drawGradientHLine( std::int32_t x, std::int32_t y, std::int32_t w, const T& colorstart, const T& colorend ) { drawGradientLine( x, y, x + w - 1, y, colorstart, colorend ); }
     template<typename T> inline void drawGradientVLine( std::int32_t x, std::int32_t y, std::int32_t h, const T& colorstart, const T& colorend ) { drawGradientLine( x, y, x, y + h - 1, colorstart, colorend ); }
     template<typename T> inline void drawGradientLine ( std::int32_t x0, std::int32_t y0, std::int32_t x1, std::int32_t y1, const T& colorstart, const T& colorend ) { draw_gradient_line( x0, y0, x1, y1, convert_to_rgb888(colorstart), convert_to_rgb888(colorend) ); }
@@ -310,28 +313,28 @@ namespace lgfx
 //----------------------------------------------------------------------------
 
     template<typename T>
-    void pushImageAffine(float matrix[6], std::int32_t w, std::int32_t h, const T* data)
+    void pushImageAffine(const float matrix[6], std::int32_t w, std::int32_t h, const T* data)
     {
       auto pc = create_pc(data);
       push_image_affine(matrix, w, h, &pc);
     }
 
     template<typename T1, typename T2>
-    void pushImageAffine(float matrix[6], std::int32_t w, std::int32_t h, const T1* data, const T2& transparent)
+    void pushImageAffine(const float matrix[6], std::int32_t w, std::int32_t h, const T1* data, const T2& transparent)
     {
       auto pc = create_pc_tr(data, transparent);
       push_image_affine(matrix, w, h, &pc);
     }
 
     template<typename T>
-    void pushImageAffine(float matrix[6], std::int32_t w, std::int32_t h, const void* data, color_depth_t depth, const T* palette)
+    void pushImageAffine(const float matrix[6], std::int32_t w, std::int32_t h, const void* data, color_depth_t depth, const T* palette)
     {
       auto pc = create_pc_palette(data, palette, depth);
       push_image_affine(matrix, w, h, &pc);
     }
 
     template<typename T>
-    void pushImageAffine(float matrix[6], std::int32_t w, std::int32_t h, const void* data, std::uint32_t transparent, color_depth_t depth, const T* palette)
+    void pushImageAffine(const float matrix[6], std::int32_t w, std::int32_t h, const void* data, std::uint32_t transparent, color_depth_t depth, const T* palette)
     {
       auto pc = create_pc_palette(data, palette, depth, transparent);
       push_image_affine(matrix, w, h, &pc);
@@ -339,28 +342,28 @@ namespace lgfx
 
 
     template<typename T>
-    void pushImageAffineWithAA(float matrix[6], std::int32_t w, std::int32_t h, const T* data)
+    void pushImageAffineWithAA(const float matrix[6], std::int32_t w, std::int32_t h, const T* data)
     {
       auto pc = create_pc_antialias(data);
       push_image_affine_aa(matrix, w, h, &pc);
     }
 
     template<typename T1, typename T2>
-    void pushImageAffineWithAA(float matrix[6], std::int32_t w, std::int32_t h, const T1* data, const T2& transparent)
+    void pushImageAffineWithAA(const float matrix[6], std::int32_t w, std::int32_t h, const T1* data, const T2& transparent)
     {
       auto pc = create_pc_tr_antialias(data, transparent);
       push_image_affine_aa(matrix, w, h, &pc);
     }
 
     template<typename T>
-    void pushImageAffineWithAA(float matrix[6], std::int32_t w, std::int32_t h, const void* data, color_depth_t depth, const T* palette)
+    void pushImageAffineWithAA(const float matrix[6], std::int32_t w, std::int32_t h, const void* data, color_depth_t depth, const T* palette)
     {
       auto pc = create_pc_antialias(data, palette, depth);
       push_image_affine_aa(matrix, w, h, &pc);
     }
 
     template<typename T>
-    void pushImageAffineWithAA(float matrix[6], std::int32_t w, std::int32_t h, const void* data, std::uint32_t transparent, color_depth_t depth, const T* palette)
+    void pushImageAffineWithAA(const float matrix[6], std::int32_t w, std::int32_t h, const void* data, std::uint32_t transparent, color_depth_t depth, const T* palette)
     {
       auto pc = create_pc_antialias(data, palette, depth, transparent);
       push_image_affine_aa(matrix, w, h, &pc);

--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -629,7 +629,7 @@ namespace lgfx
       data.set(jpg_data, jpg_len);
       return this->draw_jpg(&data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
-    bool drawPng(const std::uint8_t *png_data, std::uint32_t png_len, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, double scale = 1.0)
+    bool drawPng(const std::uint8_t *png_data, std::uint32_t png_len, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0)
     {
       PointerWrapper data;
       data.set(png_data, png_len);
@@ -642,7 +642,7 @@ namespace lgfx
     inline bool drawJpg(DataWrapper *data, std::int32_t x=0, std::int32_t y=0, std::int32_t maxWidth=0, std::int32_t maxHeight=0, std::int32_t offX=0, std::int32_t offY=0, jpeg_div::jpeg_div_t scale=jpeg_div::jpeg_div_t::JPEG_DIV_NONE) {
       return this->draw_jpg(data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
-    inline bool drawPng(DataWrapper *data, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, double scale = 1.0) {
+    inline bool drawPng(DataWrapper *data, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0) {
       return this->draw_png(data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 
@@ -896,7 +896,7 @@ namespace lgfx
 
     bool draw_bmp(DataWrapper* data, std::int32_t x, std::int32_t y);
     bool draw_jpg(DataWrapper* data, std::int32_t x, std::int32_t y, std::int32_t maxWidth, std::int32_t maxHeight, std::int32_t offX, std::int32_t offY, jpeg_div::jpeg_div_t scale);
-    bool draw_png(DataWrapper* data, std::int32_t x, std::int32_t y, std::int32_t maxWidth, std::int32_t maxHeight, std::int32_t offX, std::int32_t offY, double scale);
+    bool draw_png(DataWrapper* data, std::int32_t x, std::int32_t y, std::int32_t maxWidth, std::int32_t maxHeight, std::int32_t offX, std::int32_t offY, float scale);
 
 
     virtual void setWindow_impl(std::int32_t xs, std::int32_t ys, std::int32_t xe, std::int32_t ye) = 0;

--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -883,10 +883,10 @@ namespace lgfx
     void draw_xbitmap(std::int32_t x, std::int32_t y, const std::uint8_t *bitmap, std::int32_t w, std::int32_t h, std::uint32_t fg_rawcolor, std::uint32_t bg_rawcolor = ~0u);
     void push_image_rotate_zoom(float dst_x, float dst_y, float src_x, float src_y, float angle, float zoom_x, float zoom_y, std::int32_t w, std::int32_t h, pixelcopy_t* pc);
     void push_image_rotate_zoom_aa(float dst_x, float dst_y, float src_x, float src_y, float angle, float zoom_x, float zoom_y, std::int32_t w, std::int32_t h, pixelcopy_t* pc);
-    void push_image_affine(float* matrix, std::int32_t w, std::int32_t h, pixelcopy_t *pc);
-    void push_image_affine(float* matrix, pixelcopy_t *pc);
-    void push_image_affine_aa(float* matrix, std::int32_t w, std::int32_t h, pixelcopy_t *pc);
-    void push_image_affine_aa(float* matrix, pixelcopy_t *pre_pc, pixelcopy_t *post_pc);
+    void push_image_affine(const float* matrix, std::int32_t w, std::int32_t h, pixelcopy_t *pc);
+    void push_image_affine(const float* matrix, pixelcopy_t *pc);
+    void push_image_affine_aa(const float* matrix, std::int32_t w, std::int32_t h, pixelcopy_t *pc);
+    void push_image_affine_aa(const float* matrix, pixelcopy_t *pre_pc, pixelcopy_t *post_pc);
 
     std::uint16_t decodeUTF8(std::uint8_t c);
 

--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -632,7 +632,7 @@ namespace lgfx
       data.set(jpg_data, jpg_len);
       return this->draw_jpg(&data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
-    bool drawPng(const std::uint8_t *png_data, std::uint32_t png_len, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0)
+    bool drawPng(const std::uint8_t *png_data, std::uint32_t png_len, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f)
     {
       PointerWrapper data;
       data.set(png_data, png_len);
@@ -645,7 +645,7 @@ namespace lgfx
     inline bool drawJpg(DataWrapper *data, std::int32_t x=0, std::int32_t y=0, std::int32_t maxWidth=0, std::int32_t maxHeight=0, std::int32_t offX=0, std::int32_t offY=0, jpeg_div::jpeg_div_t scale=jpeg_div::jpeg_div_t::JPEG_DIV_NONE) {
       return this->draw_jpg(data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
-    inline bool drawPng(DataWrapper *data, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0) {
+    inline bool drawPng(DataWrapper *data, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f) {
       return this->draw_png(data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 

--- a/src/lgfx/LGFX_Device.hpp
+++ b/src/lgfx/LGFX_Device.hpp
@@ -327,7 +327,6 @@ namespace lgfx
       param->fp_copy(dmabuf, 0, w, param);
       this->writePixelsDMA_impl(dmabuf, w);
       return;
-      pixelcopy_t p(nullptr, static_cast<color_depth_t>(_write_conv.depth), _read_conv.depth);
 //*/
       pixelcopy_t pc_read(nullptr, static_cast<color_depth_t>(_write_conv.depth), _read_conv.depth);
       for (;;)

--- a/src/lgfx/LGFX_Sprite.hpp
+++ b/src/lgfx/LGFX_Sprite.hpp
@@ -463,6 +463,7 @@ namespace lgfx
       {
         this->release();
         void* buffer = nullptr;
+        _source = source;
         switch (source)
         {
           default:
@@ -498,7 +499,6 @@ namespace lgfx
 
     SpriteBuffer _img;
     SpriteBuffer _palette;
-    //bgr888_t* _palette = nullptr;
 
     std::int32_t _bitwidth;
     std::int32_t _xptr;

--- a/src/lgfx/LGFX_Sprite.hpp
+++ b/src/lgfx/LGFX_Sprite.hpp
@@ -475,6 +475,11 @@ namespace lgfx
             break;
           case AllocationSource::Psram:
             buffer = heap_alloc_psram(length);
+            if (!buffer)
+            {
+              _source = AllocationSource::Dma;
+              buffer = heap_alloc_dma(length);
+            }
             break;
         }
         _buffer = reinterpret_cast<std::uint8_t*>(buffer);

--- a/src/lgfx/lgfx_common.hpp
+++ b/src/lgfx/lgfx_common.hpp
@@ -969,10 +969,10 @@ namespace lgfx
         param->src_y32 += param->src_y32_add;
         param->src_ye32 += param->src_y32_add;
 
+        std::int32_t x = param->src_x;
+        std::int32_t y = param->src_y;
         if (param->src_x == param->src_xe && param->src_y == param->src_ye)
         {
-          std::uint32_t x = param->src_x;
-          std::uint32_t y = param->src_y;
           std::uint32_t i = (x + y * src_bitwidth) * src_bits;
           std::uint32_t raw = (s[i >> 3] >> (-(i + src_bits) & 7)) & src_mask;
           if (!(raw == transp))
@@ -989,11 +989,8 @@ namespace lgfx
           std::uint32_t rgbt[4] = {0};
           std::uint32_t a = 0;
           {
-            std::uint32_t rate_x = (param->src_x == param->src_xe) ? 256u : (256u - (param->src_x_lo >> 8));
-            std::uint32_t rate_y = (param->src_y == param->src_ye) ? 256u : (256u - (param->src_y_lo >> 8));
-
-            std::int32_t x = param->src_x;
-            std::int32_t y = param->src_y;
+            std::uint32_t rate_x = 256u - (param->src_x_lo >> 8);
+            std::uint32_t rate_y = 256u - (param->src_y_lo >> 8);
             std::uint32_t rate = rate_x;
             for (;;)
             {
@@ -1062,10 +1059,10 @@ namespace lgfx
         param->src_y32 += param->src_y32_add;
         param->src_ye32 += param->src_y32_add;
 
+        std::int32_t x = param->src_x;
+        std::int32_t y = param->src_y;
         if (param->src_x == param->src_xe && param->src_y == param->src_ye)
         {
-          std::uint32_t x = param->src_x;
-          std::uint32_t y = param->src_y;
           std::uint32_t i = x + y * src_width;
           if (!(s[i] == transp))
           {
@@ -1081,11 +1078,8 @@ namespace lgfx
           std::uint32_t rgbt[4] = {0};
           std::uint32_t a = 0;
           {
-            std::uint32_t rate_x = (param->src_x == param->src_xe) ? 256u : (256u - (param->src_x_lo >> 8));
-            std::uint32_t rate_y = (param->src_y == param->src_ye) ? 256u : (256u - (param->src_y_lo >> 8));
-
-            std::int32_t x = param->src_x;
-            std::int32_t y = param->src_y;
+            std::uint32_t rate_x = 256u - (param->src_x_lo >> 8);
+            std::uint32_t rate_y = 256u - (param->src_y_lo >> 8);
             std::uint32_t rate = rate_x;
             for (;;)
             {
@@ -1152,7 +1146,7 @@ namespace lgfx
         std::uint_fast16_t a = s[index].a;
         if (a)
         {
-          std::uint32_t raw = (s[index].R8() + s[index].G8() + s[index].B8()) / 3;
+          std::uint32_t raw = (s[index].R8() + (s[index].G8()<<1) + s[index].B8()) >> 2;
           if (a != 255)
           {
             std::uint_fast16_t inv = (256 - a) * k;

--- a/src/lgfx/lgfx_common.hpp
+++ b/src/lgfx/lgfx_common.hpp
@@ -168,7 +168,7 @@ namespace lgfx
   __attribute__ ((always_inline)) inline static std::uint16_t color565(std::uint8_t r, std::uint8_t g, std::uint8_t b) { return (r >> 3) <<11 | (g >> 2) << 5 | b >> 3; }
   __attribute__ ((always_inline)) inline static std::uint32_t color888(std::uint8_t r, std::uint8_t g, std::uint8_t b) { return  r << 16 | g << 8 | b; }
   __attribute__ ((always_inline)) inline static std::uint16_t swap565( std::uint8_t r, std::uint8_t g, std::uint8_t b) { r >>= 3; r = (r << 3) + (g >> 5); return r | (((g >> 2) << 5) | (b >> 3)) << 8; }
-  __attribute__ ((always_inline)) inline static std::uint32_t swap888( std::uint8_t r, std::uint8_t g, std::uint8_t b) { return (b << 16) | (g << 8) | r; }
+  __attribute__ ((always_inline)) inline static std::uint32_t swap888( std::uint8_t r, std::uint8_t g, std::uint8_t b) { return b << 16 | g << 8 | r; }
 
   __attribute__ ((always_inline)) inline static std::uint16_t getSwap16(std::uint16_t c) { return __builtin_bswap16(c); }
   __attribute__ ((always_inline)) inline static std::uint32_t getSwap24(std::uint32_t c) { return ((std::uint8_t)c)<<16 | ((std::uint8_t)(c>>8))<<8 | (std::uint8_t)(c>>16); }
@@ -240,7 +240,7 @@ namespace lgfx
     inline rgb332_t& operator=(const swap565_t&);
     inline rgb332_t& operator=(const bgr666_t&);
     inline rgb332_t& operator=(const bgr888_t&);
-    inline rgb332_t& operator=(std::uint8_t rgb332) { raw = rgb332; return *this; }
+    inline rgb332_t& operator=(std::uint8_t rgb332) { *reinterpret_cast<std::uint8_t*>(this) = rgb332; return *this; }
     explicit inline operator std::uint8_t() const { return raw; }
 //  explicit inline operator std::uint32_t() const { return raw; }
     explicit inline operator bool() const { return raw; }
@@ -259,7 +259,7 @@ namespace lgfx
     inline void R8(std::uint8_t r8) { r = r8 >> 5; }
     inline void G8(std::uint8_t g8) { g = g8 >> 5; }
     inline void B8(std::uint8_t b8) { b = b8 >> 6; }
-    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { raw = color332(r8,g8,b8); }
+    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { *reinterpret_cast<std::uint8_t*>(this) = color332(r8,g8,b8); }
   };
 
   struct rgb565_t {
@@ -284,7 +284,7 @@ namespace lgfx
     inline rgb565_t& operator=(const swap565_t&);
     inline rgb565_t& operator=(const bgr666_t&);
     inline rgb565_t& operator=(const bgr888_t&);
-    inline rgb565_t& operator=(std::uint16_t rgb565) { raw = rgb565; return *this; }
+    inline rgb565_t& operator=(std::uint16_t rgb565) { *reinterpret_cast<std::uint16_t*>(this) = rgb565; return *this; }
     explicit inline operator std::uint16_t() const { return raw; }
     explicit inline operator bool() const { return raw; }
     //inline operator rgb332_t() const { return rgb332_t(r<<3,g<<2,b<<3); }
@@ -302,7 +302,7 @@ namespace lgfx
     inline void R8(std::uint8_t r8) { r = r8 >> 3; }
     inline void G8(std::uint8_t g8) { g = g8 >> 2; }
     inline void B8(std::uint8_t b8) { b = b8 >> 3; }
-    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { raw = color565(r8,g8,b8); }
+    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { *reinterpret_cast<std::uint16_t*>(this) = color565(r8,g8,b8); }
   };
 
   struct rgb888_t {
@@ -362,7 +362,7 @@ namespace lgfx
     static constexpr color_depth_t depth = argb8888_4Byte;
     argb8888_t() : raw(0) {}
     argb8888_t(const argb8888_t&) = default;
-    argb8888_t(std::uint8_t r, std::uint8_t g, std::uint8_t b) : b(b),g(g),r(r),a(0) {}
+    argb8888_t(std::uint8_t r, std::uint8_t g, std::uint8_t b) : b(b),g(g),r(r),a(255) {}
     argb8888_t(std::uint32_t argb8888) : raw(argb8888) {}
     inline argb8888_t& operator=(const rgb332_t&);
     inline argb8888_t& operator=(const rgb565_t&);
@@ -370,7 +370,7 @@ namespace lgfx
     inline argb8888_t& operator=(const swap565_t&);
     inline argb8888_t& operator=(const bgr666_t&);
     inline argb8888_t& operator=(const bgr888_t&);
-    inline argb8888_t& operator=(std::uint32_t argb8888) { raw = argb8888; return *this; }
+    inline argb8888_t& operator=(std::uint32_t argb8888) { *reinterpret_cast<std::uint32_t*>(this) = argb8888; return *this; }
 //  explicit inline operator std::uint32_t() const { return raw; }
     explicit inline operator bool() const { return raw; }
     //inline operator rgb332_t() const { return rgb332_t(r,g,b); }
@@ -385,10 +385,12 @@ namespace lgfx
     inline std::uint8_t R6() const { return r>>2; }
     inline std::uint8_t G6() const { return g>>2; }
     inline std::uint8_t B6() const { return b>>2; }
+    inline void A8(std::uint8_t a8) { a = a8; }
     inline void R8(std::uint8_t r8) { r = r8; }
     inline void G8(std::uint8_t g8) { g = g8; }
     inline void B8(std::uint8_t b8) { b = b8; }
-    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { r = r8; g = g8; b = b8; }
+    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { a = 255; r = r8; g = g8; b = b8; }
+    inline void set(std::uint8_t a8, std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { a = a8; r = r8; g = g8; b = b8; }
   };
 
   struct swap565_t {
@@ -406,9 +408,10 @@ namespace lgfx
     static constexpr color_depth_t depth = rgb565_2Byte;
     swap565_t() : raw(0) {}
     swap565_t(const swap565_t&) = default;
-    swap565_t(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) : gh(g8>>5),r(r8>>3),b(b8>>3),gl(g8>>2) {}
+    swap565_t(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) : raw(swap565(r8,g8,b8)) {}
+    //swap565_t(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) : gh(g8>>5),r(r8>>3),b(b8>>3),gl(g8>>2) {}
 //    swap565_t(std::uint16_t raw) : raw(raw) {}
-    inline swap565_t& operator=(std::uint32_t rhs) { raw = rhs; return *this; }
+    inline swap565_t& operator=(std::uint16_t rhs) { *reinterpret_cast<std::uint16_t*>(this) = rhs; return *this; }
     inline swap565_t& operator=(const rgb332_t& rhs);
     inline swap565_t& operator=(const rgb565_t& rhs);
     inline swap565_t& operator=(const rgb888_t& rhs);
@@ -417,7 +420,7 @@ namespace lgfx
     inline swap565_t& operator=(const bgr888_t& rhs);
     //explicit inline operator std::uint16_t() const { return raw; }
 //  explicit inline operator std::uint32_t() const { return raw; }
-    explicit inline operator bool() const { return r||gh||gl||b; }
+    explicit inline operator bool() const { return raw; }
     //inline operator rgb565_t() const { return rgb565_t(raw<<8 | raw>>8); }
     //inline operator bgr888_t() const;
     static constexpr std::uint8_t A8() { return 255; }
@@ -430,7 +433,7 @@ namespace lgfx
     inline void R8(std::uint8_t r8) { r = r8 >> 3; }
     inline void G8(std::uint8_t g8) { gh = g8 >> 5; gl = g8 >> 2;}
     inline void B8(std::uint8_t b8) { b = b8 >> 3; }
-    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { raw = swap565(r8,g8,b8); }
+    inline void set(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8) { *reinterpret_cast<std::uint16_t*>(this) = swap565(r8,g8,b8); }
   };
 
   struct bgr666_t {
@@ -493,10 +496,10 @@ namespace lgfx
     inline bgr888_t& operator=(const argb8888_t&);
     inline bgr888_t& operator=(const swap565_t&);
     inline bgr888_t& operator=(const bgr666_t&);
-    explicit inline operator bool() const { return r||g||b; }
+    explicit inline operator bool() const { return rg||b; }
     explicit inline operator std::uint32_t() const { return *(std::uint32_t*)this & ((1<<24)-1); }
     //inline operator rgb332_t() const { return rgb332_t(r,g,b); }
-    explicit inline operator rgb565_t() const { return rgb565_t(r,g,b); }
+    //explicit inline operator rgb565_t() const { return rgb565_t(r,g,b); }
     //inline operator rgb888_t() const { return rgb888_t(r,g,b); }
     //inline operator swap565_t() const { return swap565_t(r,g,b); }
     static constexpr std::uint8_t A8() { return 255; }
@@ -530,7 +533,7 @@ namespace lgfx
     raw_color_t() : raw(0) {}
     raw_color_t(const raw_color_t&) = default;
     raw_color_t(const std::uint32_t& rhs) : raw(rhs) {}
-    inline operator bool() const { return raw & 0x00FFFFFF; }
+    inline operator bool() const { return raw & ((1<<24)-1); }
   };
 
   struct get_depth_impl {
@@ -611,15 +614,16 @@ namespace lgfx
     void setColorDepth(color_depth_t bpp, bool has_palette = false)
     {
       x_mask = 0;
-      if (     bpp > 18) { bpp = rgb888_3Byte; bytes = 3; bits = 24; }
-      else if (bpp > 16) { bpp = rgb666_3Byte; bytes = 3; bits = 24; }
-      else if (bpp >  8) { bpp = rgb565_2Byte; bytes = 2; bits = 16; }
-      else if (bpp >  4) { bpp = rgb332_1Byte; bytes = 1; bits =  8; }
-      else if (bpp == 4) { bpp = palette_4bit; bytes = 0; bits =  4; x_mask = 0b0001; }
-      else if (bpp == 2) { bpp = palette_2bit; bytes = 0; bits =  2; x_mask = 0b0011; }
-      else               { bpp = palette_1bit; bytes = 0; bits =  1; x_mask = 0b0111; }
-      colormask = (1 << bits) - 1;
+      if (     bpp > 18) { bpp = rgb888_3Byte; bits = 24; }
+      else if (bpp > 16) { bpp = rgb666_3Byte; bits = 24; }
+      else if (bpp >  8) { bpp = rgb565_2Byte; bits = 16; }
+      else if (bpp >  4) { bpp = rgb332_1Byte; bits =  8; }
+      else if (bpp == 4) { bpp = palette_4bit; bits =  4; x_mask = 0b0001; }
+      else if (bpp == 2) { bpp = palette_2bit; bits =  2; x_mask = 0b0011; }
+      else               { bpp = palette_1bit; bits =  1; x_mask = 0b0111; }
       depth = bpp;
+      bytes = bits >> 3;
+      colormask = (1 << bits) - 1;
 
       convert_rgb888 = get_fp_convert_src<rgb888_t>(bpp, has_palette);
       convert_rgb565 = get_fp_convert_src<rgb565_t>(bpp, has_palette);
@@ -728,22 +732,22 @@ namespace lgfx
   inline bool operator==(const rgb332_t&   lhs, const rgb332_t&   rhs) { return lhs.raw == rhs.raw; }
   inline bool operator==(const rgb565_t&   lhs, const rgb565_t&   rhs) { return lhs.raw == rhs.raw; }
   inline bool operator==(const swap565_t&  lhs, const swap565_t&  rhs) { return lhs.raw == rhs.raw; }
-  inline bool operator==(const bgr666_t&   lhs, const bgr666_t&   rhs) { return (*(std::uint32_t*)&lhs << 8) == (*(std::uint32_t*)&rhs << 8); }
-  inline bool operator==(const rgb888_t&   lhs, const rgb888_t&   rhs) { return (*(std::uint32_t*)&lhs << 8) == (*(std::uint32_t*)&rhs << 8); }
-  inline bool operator==(const bgr888_t&   lhs, const bgr888_t&   rhs) { return (*(std::uint32_t*)&lhs << 8) == (*(std::uint32_t*)&rhs << 8); }
+  inline bool operator==(const bgr666_t&   lhs, const bgr666_t&   rhs) { return (*reinterpret_cast<const std::uint32_t*>(&lhs) << 8) == (*reinterpret_cast<const std::uint32_t*>(&rhs) << 8); }
+  inline bool operator==(const rgb888_t&   lhs, const rgb888_t&   rhs) { return (*reinterpret_cast<const std::uint32_t*>(&lhs) << 8) == (*reinterpret_cast<const std::uint32_t*>(&rhs) << 8); }
+  inline bool operator==(const bgr888_t&   lhs, const bgr888_t&   rhs) { return (*reinterpret_cast<const std::uint32_t*>(&lhs) << 8) == (*reinterpret_cast<const std::uint32_t*>(&rhs) << 8); }
   inline bool operator==(const argb8888_t& lhs, const argb8888_t& rhs) { return lhs.raw == rhs.raw; }
 
   // for compare transparent color.
-  inline bool operator==(const rgb332_t&   lhs, const std::uint32_t& rhs) { return lhs.raw == rhs; }
-  inline bool operator==(const rgb565_t&   lhs, const std::uint32_t& rhs) { return lhs.raw == rhs; }
-  inline bool operator==(const swap565_t&  lhs, const std::uint32_t& rhs) { return lhs.raw == rhs; }
-  inline bool operator==(const bgr666_t&   lhs, const std::uint32_t& rhs) { return ((*(std::uint32_t*)&lhs) << 8) >> 8 == rhs; }
-  inline bool operator==(const rgb888_t&   lhs, const std::uint32_t& rhs) { return ((*(std::uint32_t*)&lhs) << 8) >> 8 == rhs; }
-  inline bool operator==(const bgr888_t&   lhs, const std::uint32_t& rhs) { return ((*(std::uint32_t*)&lhs) << 8) >> 8 == rhs; }
-  inline bool operator==(const argb8888_t& lhs, const std::uint32_t& rhs) { return lhs.raw == rhs; }
+  inline bool operator==(const rgb332_t&   lhs, std::uint32_t rhs) { return  *reinterpret_cast<const std::uint8_t* >(&lhs) == rhs; }
+  inline bool operator==(const rgb565_t&   lhs, std::uint32_t rhs) { return  *reinterpret_cast<const std::uint16_t*>(&lhs) == rhs; }
+  inline bool operator==(const swap565_t&  lhs, std::uint32_t rhs) { return  *reinterpret_cast<const std::uint16_t*>(&lhs) == rhs; }
+  inline bool operator==(const bgr666_t&   lhs, std::uint32_t rhs) { return (*reinterpret_cast<const std::uint32_t*>(&lhs) << 8) >> 8 == rhs; }
+  inline bool operator==(const rgb888_t&   lhs, std::uint32_t rhs) { return (*reinterpret_cast<const std::uint32_t*>(&lhs) << 8) >> 8 == rhs; }
+  inline bool operator==(const bgr888_t&   lhs, std::uint32_t rhs) { return (*reinterpret_cast<const std::uint32_t*>(&lhs) << 8) >> 8 == rhs; }
+  inline bool operator==(const argb8888_t& lhs, std::uint32_t rhs) { return  *reinterpret_cast<const std::uint32_t*>(&lhs) == rhs; }
 //*/
-  inline bool operator==(const raw_color_t& lhs, const raw_color_t& rhs) { return lhs.raw == rhs.raw; }
-  inline bool operator!=(const raw_color_t& lhs, const raw_color_t& rhs) { return lhs.raw != rhs.raw; }
+  inline bool operator==(const raw_color_t& lhs, const raw_color_t& rhs) { return *reinterpret_cast<const std::uint32_t*>(&lhs) == *reinterpret_cast<const std::uint32_t*>(&rhs); }
+  inline bool operator!=(const raw_color_t& lhs, const raw_color_t& rhs) { return *reinterpret_cast<const std::uint32_t*>(&lhs) != *reinterpret_cast<const std::uint32_t*>(&rhs); }
 
 
 
@@ -969,25 +973,24 @@ namespace lgfx
         {
           std::uint32_t x = param->src_x;
           std::uint32_t y = param->src_y;
-          if (x < src_width && y < src_height)
+          std::uint32_t i = (x + y * src_bitwidth) * src_bits;
+          std::uint32_t raw = (s[i >> 3] >> (-(i + src_bits) & 7)) & src_mask;
+          if (!(raw == transp))
           {
-            std::uint32_t i = (x + y * src_bitwidth) * src_bits;
-            std::uint32_t raw = (s[i >> 3] >> (-(i + src_bits) & 7)) & src_mask;
-            if (!(raw == transp))
-            {
-              d[index] = pal[raw];
-              continue;
-            }
+            d[index].set(pal[raw].R8(), pal[raw].G8(), pal[raw].B8());
           }
-          *reinterpret_cast<std::uint32_t*>(&d[index]) = 0;
+          else
+          {
+            d[index] = 0u;
+          }
         }
         else
         {
           std::uint32_t rgbt[4] = {0};
           std::uint32_t a = 0;
           {
-            std::uint32_t rate_x = (param->src_x == param->src_xe) ? 65535u : static_cast<std::uint16_t>(~param->src_x_lo);
-            std::uint32_t rate_y = (param->src_y == param->src_ye) ? 65535u : static_cast<std::uint16_t>(~param->src_y_lo);
+            std::uint32_t rate_x = (param->src_x == param->src_xe) ? 65535u : (65535u & ~param->src_x_lo);
+            std::uint32_t rate_y = (param->src_y == param->src_ye) ? 65535u : (65535u & ~param->src_y_lo);
             std::uint32_t shift = 24;
             if (rate_x * rate_y < (1u << 24))
             {
@@ -1031,19 +1034,19 @@ namespace lgfx
           }
           if (a)
           {
-            d[index].b = rgbt[0] / a;
-            d[index].g = rgbt[1] / a;
-            d[index].r = rgbt[2] / a;
-            if (!std::is_same<TPalette, argb8888_t>::value) { a *= 255; }
-            d[index].a = a / rgbt[3];
+            d[index].set( (std::is_same<TPalette, argb8888_t>::value ? a : (a * 255)) / rgbt[3]
+                        , rgbt[2] / a
+                        , rgbt[1] / a
+                        , rgbt[0] / a
+                        );
           }
           else
           {
-            *reinterpret_cast<std::uint32_t*>(&d[index]) = 0;
+            d[index] = 0u;
           }
         }
       } while (++index != last);
-      return index;
+      return last;
     }
 
     template <typename TSrc>
@@ -1070,24 +1073,23 @@ namespace lgfx
         {
           std::uint32_t x = param->src_x;
           std::uint32_t y = param->src_y;
-          if (x < src_width && y < src_height)
+          std::uint32_t i = x + y * src_width;
+          if (!(s[i] == transp))
           {
-            std::uint32_t i = x + y * src_width;
-            if (!(s[i] == transp))
-            {
-              d[index] = s[i];
-              continue;
-            }
+            d[index].set(s[i].R8(), s[i].G8(), s[i].B8());
           }
-          *reinterpret_cast<std::uint32_t*>(&d[index]) = 0;
+          else
+          {
+            d[index] = 0u;
+          }
         }
         else
         {
           std::uint32_t rgbt[4] = {0};
           std::uint32_t a = 0;
           {
-            std::uint32_t rate_x = (param->src_x == param->src_xe) ? 65535u : static_cast<std::uint16_t>(~param->src_x_lo);
-            std::uint32_t rate_y = (param->src_y == param->src_ye) ? 65535u : static_cast<std::uint16_t>(~param->src_y_lo);
+            std::uint32_t rate_x = (param->src_x == param->src_xe) ? 65535u : (65535u & ~param->src_x_lo);
+            std::uint32_t rate_y = (param->src_y == param->src_ye) ? 65535u : (65535u & ~param->src_y_lo);
             std::uint32_t shift = 24;
             if (rate_x * rate_y < (1u << 24))
             {
@@ -1130,21 +1132,21 @@ namespace lgfx
           }
           if (a)
           {
-            d[index].b = rgbt[0] / a;
-            d[index].g = rgbt[1] / a;
-            d[index].r = rgbt[2] / a;
-            if (!std::is_same<TSrc, argb8888_t>::value) { a *= 255; }
-            d[index].a = a / rgbt[3];
+            d[index].set( (std::is_same<TSrc, argb8888_t>::value ? a : (a * 255)) / rgbt[3]
+                        , rgbt[2] / a
+                        , rgbt[1] / a
+                        , rgbt[0] / a
+                        );
           }
           else
           {
-            *reinterpret_cast<std::uint32_t*>(&d[index]) = 0;
+            d[index] = 0u;
           }
         }
 //d[index].a = 255;
 //d[index].b = 255;
       } while (++index != last);
-      return index;
+      return last;
     }
 
 
@@ -1175,7 +1177,7 @@ namespace lgfx
           *tmp = (*tmp & ~(dst_mask << shift)) | ((dst_mask & (raw >> (8 - dst_bits)))) << shift;
         }
       } while (++index != last);
-      return index;
+      return last;
     }
 
     template <typename TDst>
@@ -1183,26 +1185,26 @@ namespace lgfx
     {
       auto s = &((const argb8888_t*)param->src_data)[param->src_x + param->src_y * param->src_bitwidth - index];
       auto d = (TDst*)dst;
-      do {
+      for (;;) {
         std::uint_fast16_t a = s[index].a;
         if (a)
         {
           if (a == 255)
           {
-            d[index] = s[index];
+            d[index].set(s[index].r, s[index].g, s[index].b);
+            if (++index == last) return last;
+            continue;
           }
-          else
-          {
-            std::uint_fast16_t inv = 256 - a;
-            ++a;
-            d[index].set( (d[index].R8() * inv + s[index].R8() * a) >> 8
-                        , (d[index].G8() * inv + s[index].G8() * a) >> 8
-                        , (d[index].B8() * inv + s[index].B8() * a) >> 8
-                        );
-          }
+
+          std::uint_fast16_t inv = 256 - a;
+          ++a;
+          d[index].set( (d[index].R8() * inv + s[index].R8() * a) >> 8
+                      , (d[index].G8() * inv + s[index].G8() * a) >> 8
+                      , (d[index].B8() * inv + s[index].B8() * a) >> 8
+                      );
         }
-      } while (++index != last);
-      return index;
+        if (++index == last) return last;
+      }
     }
 
     static std::int32_t skip_bit_affine(std::int32_t index, std::int32_t last, pixelcopy_t* param)

--- a/src/lgfx/lgfx_filesystem_support.hpp
+++ b/src/lgfx/lgfx_filesystem_support.hpp
@@ -94,7 +94,7 @@ namespace lgfx
       return this->drawJpgFile(&file, path, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 
-    inline bool drawPngFile(fs::FS &fs, const char *path, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, double scale = 1.0)
+    inline bool drawPngFile(fs::FS &fs, const char *path, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f)
     {
       FileWrapper file(fs);
       return this->drawPngFile(&file, path, x, y, maxWidth, maxHeight, offX, offY, scale);
@@ -113,7 +113,7 @@ namespace lgfx
       return this->draw_jpg(&data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 
-    inline bool drawPngFile(fs::FS &fs, fs::File *file, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, double scale = 1.0)
+    inline bool drawPngFile(fs::FS &fs, fs::File *file, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f)
     {
       FileWrapper data(fs, file);
       this->prepareTmpTransaction(&data);
@@ -137,7 +137,7 @@ namespace lgfx
       return this->draw_jpg(&data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 
-    inline void drawPng(fs::File *dataSource, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, double scale = 1.0) {
+    inline bool drawPng(fs::File *dataSource, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f) {
       StreamWrapper data;
       data.set(dataSource);
       data.need_transaction = true;
@@ -160,7 +160,7 @@ namespace lgfx
       return this->draw_jpg(&data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 
-    inline void drawPng(Stream *dataSource, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, double scale = 1.0) {
+    inline bool drawPng(Stream *dataSource, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f) {
       StreamWrapper data;
       data.set(dataSource);
       return this->draw_png(&data, x, y, maxWidth, maxHeight, offX, offY, scale);
@@ -178,7 +178,7 @@ namespace lgfx
       FileWrapper file;
       return drawJpgFile(&file, path, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
-    inline bool drawPngFile(const char *path, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, double scale = 1.0)
+    inline bool drawPngFile(const char *path, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f)
     {
       FileWrapper file;
       return drawPngFile(&file, path, x, y, maxWidth, maxHeight, offX, offY, scale);
@@ -210,7 +210,7 @@ namespace lgfx
       return res;
     }
 
-    bool drawPngFile(FileWrapper* file, const char *path, std::int32_t x, std::int32_t y, std::int32_t maxWidth, std::int32_t maxHeight, std::int32_t offX, std::int32_t offY, double scale)
+    bool drawPngFile(FileWrapper* file, const char *path, std::int32_t x, std::int32_t y, std::int32_t maxWidth, std::int32_t maxHeight, std::int32_t offX, std::int32_t offY, float scale)
     {
       bool res = false;
       this->prepareTmpTransaction(file);


### PR DESCRIPTION
hotfix: Sprite using PSRAM tries to use DMA transfer and fails.
add fillAffine function.
add examples/Standard/SaveBMP
add examples/Sprite/RotateDial