### PR TITLE
0.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ This library has the following advantages.
   - ディスプレイ Displays
     - HX8357
     - ILI9163
-    - ILI9341 (ODROID-GO, ESP-WROVER-KIT, LoLin D32 Pro, WioTerminal)
+    - ILI9341 (WioTerminal, ESP-WROVER-KIT, ODROID-GO, LoLin D32 Pro, WiFiBoy Pro)
     - ILI9342 (M5Stack, M5Stack Core2)
     - ILI9486
-    - ILI9488
+    - ILI9488 (Makerfabs Touch with Camera)
     - SSD1351
-    - ST7735 (M5StickC, TTGO T-Wristband, TTGO TS, LoLin D32 Pro)
-    - ST7789 (M5StickCPlus, TTGO T-Watch, DSTIKE D-duino-32 XS, ESP-WROVER-KIT)
+    - ST7735 (M5StickC, TTGO T-Wristband, TTGO TS, LoLin D32 Pro, WiFiBoy mini)
+    - ST7789 (M5StickCPlus, TTGO T-Watch, ESP-WROVER-KIT, Makerfabs MakePython, DSTIKE D-duino-32 XS)
     - ST7796
 
   - タッチパネル TouchScreens (only ESP32)
-    - I2C FT5x06
+    - I2C FT5x06 / FT6x36
     - SPI XPT2046
     - SPI STMPE610
 
@@ -73,17 +73,21 @@ This library is also compatible with the above models and LCD panels with a simi
 // 対応機種がボードマネージャに無い場合 ( TTGO T-Wristband や ESP-WROVER-KIT等 ) は、
 // LovyanGFX.hppのincludeより前に、define LGFX_～ の定義を記述してください。
 
-// #define LGFX_M5STACK          // M5Stack (Basic / Gray / Go / Fire)
-// #define LGFX_M5STACKCORE2     // M5StackCore2
-// #define LGFX_M5STICKC         // M5Stick C / CPlus
-// #define LGFX_ODROID_GO        // ODROID-GO
-// #define LGFX_TTGO_TS          // TTGO TS
-// #define LGFX_TTGO_TWATCH      // TTGO T-Watch
-// #define LGFX_TTGO_TWRISTBAND  // TTGO T-Wristband
-// #define LGFX_DDUINO32_XS      // DSTIKE D-duino-32 XS
-// #define LGFX_LOLIN_D32_PRO    // LoLin D32 Pro
-// #define LGFX_ESP_WROVER_KIT   // ESP-WROVER-KIT
-// #define LGFX_WIO_TERMINAL     // Wio Terminal
+// #define LGFX_M5STACK               // M5Stack (Basic / Gray / Go / Fire)
+// #define LGFX_M5STACKCORE2          // M5StackCore2
+// #define LGFX_M5STICKC              // M5Stick C / CPlus
+// #define LGFX_ODROID_GO             // ODROID-GO
+// #define LGFX_TTGO_TS               // TTGO TS
+// #define LGFX_TTGO_TWATCH           // TTGO T-Watch
+// #define LGFX_TTGO_TWRISTBAND       // TTGO T-Wristband
+// #define LGFX_DDUINO32_XS           // DSTIKE D-duino-32 XS
+// #define LGFX_LOLIN_D32_PRO         // LoLin D32 Pro
+// #define LGFX_ESP_WROVER_KIT        // ESP-WROVER-KIT
+// #define LGFX_WIFIBOY_PRO           // WiFiBoy Pro
+// #define LGFX_WIFIBOY_MINI          // WiFiBoy mini
+// #define LGFX_MAKERFABS_TOUCHCAMERA // Makerfabs Touch with Camera
+// #define LGFX_MAKERFABS_MAKEPYTHON  // Makerfabs MakePython
+// #define LGFX_WIO_TERMINAL          // Wio Terminal
 
 // #define LGFX_AUTODETECT // 自動認識 (M5Stack, M5StickC/CPlus, ODROID-GO, TTGO T-Watch, TTGO T-Wristband, LoLin D32 Pro, ESP-WROVER-KIT)
 

--- a/examples/Advanced/ESP32DeepSleepDisplay/ESP32DeepSleepDisplay.ino
+++ b/examples/Advanced/ESP32DeepSleepDisplay/ESP32DeepSleepDisplay.ino
@@ -1,0 +1,73 @@
+#define LGFX_AUTODETECT
+
+#include <LovyanGFX.hpp>
+
+static LGFX lcd;
+
+RTC_DATA_ATTR int bootCount = 0;  // 起動回数を保持（deepsleepしても値は消えない）
+
+void setup(void)
+{
+}
+
+void loop(void)
+{
+  switch(esp_sleep_get_wakeup_cause())
+  {
+  case ESP_SLEEP_WAKEUP_EXT0 :
+  case ESP_SLEEP_WAKEUP_EXT1 :
+  case ESP_SLEEP_WAKEUP_TIMER :
+  case ESP_SLEEP_WAKEUP_TOUCHPAD :
+  case ESP_SLEEP_WAKEUP_ULP :
+    lcd.autodetect(false); // deep sleep からの復帰時はautodetectを呼び出す。
+                           // 引数をfalseとすることでRSTピンの制御を行わない。
+    lcd.setColorDepth(16); // 初期化手順を踏まない代わりに、色数指定や回転方向は自前で設定しておく。
+    lcd.setRotation(1);
+    break;
+
+  default :
+    lcd.init();            // 通常起動時はinitを呼び出す。
+
+    if (lcd.getPanel()->gpio_rst >= 0)
+    {
+      rtc_gpio_set_level((gpio_num_t)lcd.getPanel()->gpio_rst, 1);
+      rtc_gpio_set_direction((gpio_num_t)lcd.getPanel()->gpio_rst, RTC_GPIO_MODE_OUTPUT_ONLY);
+      rtc_gpio_init((gpio_num_t)lcd.getPanel()->gpio_rst);
+    }
+//*/
+    lcd.startWrite();      // 背景を描画しておく
+    lcd.setColorDepth(24);
+    lcd.setAddrWindow(0, 0, lcd.width(), lcd.height());
+    for (int y = 0; y < lcd.height(); ++y)
+      for (int x = 0; x < lcd.width(); ++x)
+        lcd.writeColor( lcd.color888(x << 1, x + y, y << 1), 1);
+    lcd.endWrite();
+    break;
+  }
+
+  ++bootCount;
+  lcd.setCursor(bootCount*6, bootCount*8);
+  lcd.print("DeepSleep test : " + String(bootCount));
+
+  auto gpio_rst = (gpio_num_t)lcd.getPanel()->gpio_rst;
+  if (gpio_rst >= 0) {
+    // RSTピンをRTC_GPIOで管理しhigh状態を維持する
+    rtc_gpio_set_level(gpio_rst, 1);
+    rtc_gpio_set_direction(gpio_rst, RTC_GPIO_MODE_OUTPUT_ONLY);
+    rtc_gpio_init(gpio_rst);
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+  }
+
+  auto gpio_bl = (gpio_num_t)lcd.getPanel()->gpio_bl;
+  if (gpio_bl >= 0) {
+    // BackLightピンをRTC_GPIOで管理しhigh状態を維持する
+    rtc_gpio_set_level(gpio_bl, 1);
+    rtc_gpio_set_direction(gpio_bl, RTC_GPIO_MODE_OUTPUT_ONLY);
+    rtc_gpio_init(gpio_bl);
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+  }
+
+  esp_sleep_enable_timer_wakeup(1 * 1000 * 1000); // micro sec
+
+  esp_deep_sleep_start();
+}

--- a/examples/Advanced/ESP32DeepSleepDisplay/ESP32DeepSleepDisplay.ino
+++ b/examples/Advanced/ESP32DeepSleepDisplay/ESP32DeepSleepDisplay.ino
@@ -8,10 +8,6 @@ RTC_DATA_ATTR int bootCount = 0;  // 起動回数を保持（deepsleepしても�
 
 void setup(void)
 {
-}
-
-void loop(void)
-{
   switch(esp_sleep_get_wakeup_cause())
   {
   case ESP_SLEEP_WAKEUP_EXT0 :
@@ -34,7 +30,7 @@ void loop(void)
       rtc_gpio_set_direction((gpio_num_t)lcd.getPanel()->gpio_rst, RTC_GPIO_MODE_OUTPUT_ONLY);
       rtc_gpio_init((gpio_num_t)lcd.getPanel()->gpio_rst);
     }
-//*/
+
     lcd.startWrite();      // 背景を描画しておく
     lcd.setColorDepth(24);
     lcd.setAddrWindow(0, 0, lcd.width(), lcd.height());
@@ -70,4 +66,9 @@ void loop(void)
   esp_sleep_enable_timer_wakeup(1 * 1000 * 1000); // micro sec
 
   esp_deep_sleep_start();
+}
+
+void loop(void)
+{
+  delay(10000);
 }

--- a/examples/Advanced/ESP32DeepSleepDisplay/ESP32DeepSleepDisplay.ino
+++ b/examples/Advanced/ESP32DeepSleepDisplay/ESP32DeepSleepDisplay.ino
@@ -24,13 +24,6 @@ void setup(void)
   default :
     lcd.init();            // 通常起動時はinitを呼び出す。
 
-    if (lcd.getPanel()->gpio_rst >= 0)
-    {
-      rtc_gpio_set_level((gpio_num_t)lcd.getPanel()->gpio_rst, 1);
-      rtc_gpio_set_direction((gpio_num_t)lcd.getPanel()->gpio_rst, RTC_GPIO_MODE_OUTPUT_ONLY);
-      rtc_gpio_init((gpio_num_t)lcd.getPanel()->gpio_rst);
-    }
-
     lcd.startWrite();      // 背景を描画しておく
     lcd.setColorDepth(24);
     lcd.setAddrWindow(0, 0, lcd.width(), lcd.height());

--- a/examples/HowToUse/1_simple_use/1_simple_use.ino
+++ b/examples/HowToUse/1_simple_use/1_simple_use.ino
@@ -4,19 +4,23 @@
 // 対応機種がボードマネージャに無い場合 ( TTGO T-Wristband や ESP-WROVER-KIT等 ) は、
 // LovyanGFX.hppのincludeより前に、define LGFX_～ の定義を記述してください。
 
-// #define LGFX_M5STACK          // M5Stack (Basic / Gray / Go / Fire)
-// #define LGFX_M5STACKCORE2     // M5StackCore2
-// #define LGFX_M5STICKC         // M5Stick C / CPlus
-// #define LGFX_ODROID_GO        // ODROID-GO
-// #define LGFX_TTGO_TS          // TTGO TS
-// #define LGFX_TTGO_TWATCH      // TTGO T-Watch
-// #define LGFX_TTGO_TWRISTBAND  // TTGO T-Wristband
-// #define LGFX_DDUINO32_XS      // DSTIKE D-duino-32 XS
-// #define LGFX_LOLIN_D32_PRO    // LoLin D32 Pro
-// #define LGFX_ESP_WROVER_KIT   // ESP-WROVER-KIT
-// #define LGFX_WIO_TERMINAL     // Wio Terminal
+// #define LGFX_M5STACK               // M5Stack (Basic / Gray / Go / Fire)
+// #define LGFX_M5STACKCORE2          // M5StackCore2
+// #define LGFX_M5STICKC              // M5Stick C / CPlus
+// #define LGFX_ODROID_GO             // ODROID-GO
+// #define LGFX_TTGO_TS               // TTGO TS
+// #define LGFX_TTGO_TWATCH           // TTGO T-Watch
+// #define LGFX_TTGO_TWRISTBAND       // TTGO T-Wristband
+// #define LGFX_DDUINO32_XS           // DSTIKE D-duino-32 XS
+// #define LGFX_LOLIN_D32_PRO         // LoLin D32 Pro
+// #define LGFX_ESP_WROVER_KIT        // ESP-WROVER-KIT
+// #define LGFX_WIFIBOY_PRO           // WiFiBoy Pro
+// #define LGFX_WIFIBOY_MINI          // WiFiBoy mini
+// #define LGFX_MAKERFABS_TOUCHCAMERA // Makerfabs Touch with Camera
+// #define LGFX_MAKERFABS_MAKEPYTHON  // Makerfabs MakePython
+// #define LGFX_WIO_TERMINAL          // Wio Terminal
 
-// #define LGFX_AUTODETECT // 自動認識 (M5Stack, M5StickC/CPlus, ODROID-GO, TTGO T-Watch, TTGO T-Wristband, LoLin D32 Pro, ESP-WROVER-KIT)
+ #define LGFX_AUTODETECT // 自動認識 (M5Stack, M5StickC/CPlus, ODROID-GO, TTGO T-Watch, TTGO T-Wristband, LoLin D32 Pro, ESP-WROVER-KIT)
 
 // 複数機種の定義を行うか、LGFX_AUTODETECTを定義することで、実行時にボードを自動認識します。
 

--- a/examples/HowToUse/1_simple_use/1_simple_use.ino
+++ b/examples/HowToUse/1_simple_use/1_simple_use.ino
@@ -20,7 +20,7 @@
 // #define LGFX_MAKERFABS_MAKEPYTHON  // Makerfabs MakePython
 // #define LGFX_WIO_TERMINAL          // Wio Terminal
 
- #define LGFX_AUTODETECT // 自動認識 (M5Stack, M5StickC/CPlus, ODROID-GO, TTGO T-Watch, TTGO T-Wristband, LoLin D32 Pro, ESP-WROVER-KIT)
+// #define LGFX_AUTODETECT // 自動認識 (M5Stack, M5StickC/CPlus, ODROID-GO, TTGO T-Watch, TTGO T-Wristband, LoLin D32 Pro, ESP-WROVER-KIT)
 
 // 複数機種の定義を行うか、LGFX_AUTODETECTを定義することで、実行時にボードを自動認識します。
 

--- a/examples/Standard/SaveBMP/SaveBMP.ino
+++ b/examples/Standard/SaveBMP/SaveBMP.ino
@@ -21,7 +21,7 @@ static constexpr char filename[] = "/lovyangfx_test.bmp";
 #endif
 
 
-bool saveToSD_16bit()
+bool saveToSD_16bit(void)
 {
   std::size_t dlen;
 
@@ -65,7 +65,7 @@ bool saveToSD_16bit()
   return result;
 }
 
-bool saveToSD_24bit()
+bool saveToSD_24bit(void)
 {
   std::size_t dlen;
 
@@ -109,7 +109,7 @@ bool saveToSD_24bit()
   return result;
 }
 
-void setup()
+void setup(void)
 {
   lcd.init();
 

--- a/examples/Standard/SavePNG/SavePNG.ino
+++ b/examples/Standard/SavePNG/SavePNG.ino
@@ -21,7 +21,7 @@ static constexpr char filename[] = "/lovyangfx_test.png";
 #endif
 
 
-bool saveToSD()
+bool saveToSD(void)
 {
   // createPng関数で指定範囲の画像からPNG形式のデータを生成します。
   // SAMD51の場合 172x172程度が上限です。
@@ -55,7 +55,7 @@ bool saveToSD()
   return result;
 }
 
-void setup()
+void setup(void)
 {
   lcd.init();
 

--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/lovyan03/LovyanGFX"
   },
-  "version": "0.2.6",
+  "version": "0.2.7",
   "framework": "arduino, espidf",
   "platforms": "espressif32, atmelsam",
   "build": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LovyanGFX
-version=0.2.6
+version=0.2.7
 author=lovyan03
 maintainer=Lovyan <42724151+lovyan03@users.noreply.github.com>
 sentence=LCD Graphics driver with touch for ESP32 and SAMD51

--- a/src/Fonts/lgfx_fonts.hpp
+++ b/src/Fonts/lgfx_fonts.hpp
@@ -37,6 +37,9 @@ namespace lgfx
     virtual bool updateFontMetric(FontMetrics *metrics, std::uint16_t uniCode) const = 0;
     virtual bool unloadFont(void) { return false; }
     virtual std::size_t drawChar(LGFXBase* gfx, std::int32_t x, std::int32_t y, std::uint16_t c, const TextStyle* style) const = 0;
+
+  protected:
+    std::size_t drawCharDummy(LGFXBase* gfx, std::int32_t x, std::int32_t y, std::int32_t w, std::int32_t h, const TextStyle* style) const;
   };
 
   struct BaseFont : public IFont {

--- a/src/config/LGFX_Config_AutoDetectESP32.hpp
+++ b/src/config/LGFX_Config_AutoDetectESP32.hpp
@@ -165,9 +165,9 @@ namespace lgfx
     void resetPanel(void)
     {
       // AXP192 reg 0x96 = GPIO3&4 control
-      lgfx::i2c::writeRegister8(axp_i2c_port, axp_i2c_addr, 0x96, 0, ~0x02);
+      lgfx::i2c::writeRegister8(axp_i2c_port, axp_i2c_addr, 0x96, 0, ~0x02); // GPIO4 LOW (LCD RST)
       delay(10);
-      lgfx::i2c::writeRegister8(axp_i2c_port, axp_i2c_addr, 0x96, 2, ~0);
+      lgfx::i2c::writeRegister8(axp_i2c_port, axp_i2c_addr, 0x96, 2, ~0); // GPIO4 HIGH (LCD RST)
     }
 
     void init(void) override
@@ -199,11 +199,9 @@ public:
   {
   }
 
-private:
-  void init_impl(void) override
+  void autodetect(bool use_reset = true)
   {
     if (_spi_mosi != -1 && _spi_sclk != -1) {
-      lgfx::LGFX_SPI<lgfx::LGFX_Config>::init_impl();
       return;
     }
 
@@ -299,7 +297,7 @@ private:
       p_tmp.spi_dc   = 23;
       p_tmp.gpio_rst = 26;
       setPanel(&p_tmp);
-      _reset();
+      _reset(use_reset);
 
       auto id = readPanelID();
       ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
@@ -359,7 +357,7 @@ private:
 
         p_tmp.spi_3wire = false;
         setPanel(&p_tmp);
-        _reset();
+        _reset(use_reset);
 
         id = readPanelID();
 
@@ -401,7 +399,7 @@ private:
  #endif
 
       setPanel(&p_tmp);
-      _reset();
+      _reset(use_reset);
 
       id = readPanelID();
 
@@ -513,7 +511,7 @@ private:
       p_tmp.spi_dc   = 23;
       p_tmp.gpio_rst = 18;
       setPanel(&p_tmp);
-      _reset();
+      _reset(use_reset);
 
       id = readPanelID();
       ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
@@ -552,7 +550,7 @@ private:
       p_tmp.spi_dc   = 21;
       p_tmp.gpio_rst = 18;
       setPanel(&p_tmp);
-      _reset();
+      _reset(use_reset);
 
       id = readPanelID();
       ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
@@ -616,7 +614,7 @@ private:
       p_tmp.spi_dc   = 17;
       p_tmp.gpio_rst =  9;
       setPanel(&p_tmp);
-      _reset();
+      _reset(use_reset);
 
       id = readPanelID();
       ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
@@ -650,11 +648,11 @@ private:
 #if defined ( LGFX_AUTODETECT ) || defined ( LGFX_M5STACKCORE2 )
     if (nvs_board == 0 || nvs_board == lgfx::board_t::board_M5StackCore2) {
       lgfx::i2c::init(I2C_NUM_1, 21, 22, 400000);
-      if (lgfx::i2c::writeRegister8(I2C_NUM_1, 0x34, 0x96, 0, ~0x02)) { // GPIO4 LOW (LCD RST)
+      if (lgfx::i2c::writeRegister8(I2C_NUM_1, 0x34, 0x95, 0x84, 0x72)) { // GPIO4 enable
         // AXP192_LDO2 = LCD PWR
         // AXP192_DC3  = LCD BL
         // AXP192_IO4  = LCD RST
-        lgfx::i2c::writeRegister8(I2C_NUM_1, 0x34, 0x95, 0x84, 0x72); // GPIO4 enable
+        if (use_reset) lgfx::i2c::writeRegister8(I2C_NUM_1, 0x34, 0x96, 0, ~0x02); // GPIO4 LOW (LCD RST)
         lgfx::i2c::writeRegister8(I2C_NUM_1, 0x34, 0x28, 0xF0, ~0);   // set LDO2 3300mv // LCD PWR
         lgfx::i2c::writeRegister8(I2C_NUM_1, 0x34, 0x12, 0x06, ~0);   // LDO2 and DC3 enable (DC3 = LCD BL)
         lgfx::i2c::writeRegister8(I2C_NUM_1, 0x34, 0x96, 2, ~0);      // GPIO4 HIGH (LCD RST)
@@ -759,7 +757,6 @@ private:
     goto init_clear;
 init_clear:
     panel_last = getPanel();
-    lgfx::LGFX_SPI<lgfx::LGFX_Config>::init_impl();
 
     if (nvs_board != board) {
       if (0 == nvs_open(NVS_NAME, NVS_READWRITE, &nvs_handle)) {
@@ -770,9 +767,18 @@ init_clear:
     }
   }
 
-  void _reset(void) {
+private:
+  void init_impl(void) override
+  {
+    autodetect();
+    lgfx::LGFX_SPI<lgfx::LGFX_Config>::init_impl();
+  }
+
+  void _reset(bool use_reset) {
     auto pin = _panel->gpio_rst;
+    lgfx::gpio_hi(pin);
     lgfx::lgfxPinMode(pin, lgfx::pin_mode_t::output);
+    if (!use_reset) return;
     lgfx::gpio_lo(pin);
     delay(1);
     lgfx::gpio_hi(pin);

--- a/src/config/LGFX_Config_AutoDetectESP32.hpp
+++ b/src/config/LGFX_Config_AutoDetectESP32.hpp
@@ -664,7 +664,6 @@ public:
       auto id = readPanelID();
       ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
       if ((id & 0xFF) == 0x7C) {  //  check panel (ST7735)
-      {
         ESP_LOGW("LovyanGFX", "[Autodetect] WiFiBoy mini");
         board = lgfx::board_t::board_WiFiBoy_Mini;
         releaseBus();
@@ -797,9 +796,7 @@ public:
 
 // Makerfabs MakePython
 #if defined ( LGFX_AUTODETECT ) || defined ( LGFX_MAKERFABS_MAKEPYTHON )
-    if (nvs_board == 0
-     || nvs_board == lgfx::board_t::board_Makerfabs_MakePython
-    ) {
+    if (nvs_board == 0 || nvs_board == lgfx::board_t::board_Makerfabs_MakePython) {
       releaseBus();
       _spi_mosi = 13;
       _spi_miso = 12;

--- a/src/config/LGFX_Config_AutoDetectESP32.hpp
+++ b/src/config/LGFX_Config_AutoDetectESP32.hpp
@@ -644,6 +644,204 @@ public:
     }
 #endif
 
+// WiFiBoy mini
+#if defined ( LGFX_AUTODETECT ) || defined ( LGFX_WIFIBOY_MINI )
+    if (nvs_board == 0
+     || nvs_board == lgfx::board_t::board_WiFiBoy_Mini
+    ) {
+      releaseBus();
+      _spi_mosi = 13;
+      _spi_miso = 12;
+      _spi_sclk = 14;
+      initBus();
+
+      p_tmp.spi_3wire = true;
+      p_tmp.spi_cs   = 15;
+      p_tmp.spi_dc   = 4;
+      p_tmp.gpio_rst = -1;
+      setPanel(&p_tmp);
+
+      auto id = readPanelID();
+      ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
+      if ((id & 0xFF) == 0x7C) {  //  check panel (ST7735)
+      {
+        ESP_LOGW("LovyanGFX", "[Autodetect] WiFiBoy mini");
+        board = lgfx::board_t::board_WiFiBoy_Mini;
+        releaseBus();
+        _spi_host = HSPI_HOST;
+        initBus();
+        auto p = new lgfx::Panel_ST7735S();
+        p->freq_read  = 8000000;
+        p->panel_width  = 128;
+        p->panel_height = 128;
+        p->memory_width  = 132;
+        p->memory_height = 132;
+        p->spi_3wire = true;
+        p->offset_x     = 2;
+        p->offset_y     = 1;
+        p->spi_cs    = 15;
+        p->spi_dc    = 4;
+        p->gpio_bl   = 27;
+        p->pwm_ch_bl = 7;
+        p->offset_rotation = 2;
+        setPanel(p);
+
+        goto init_clear;
+      }
+      lgfx::gpio_lo(p_tmp.spi_cs);
+      lgfx::gpio_lo(p_tmp.spi_dc);
+    }
+#endif
+
+// WiFiBoy Pro
+#if defined ( LGFX_AUTODETECT ) || defined ( LGFX_WIFIBOY_PRO )
+    if (nvs_board == 0 || nvs_board == lgfx::board_t::board_WiFiBoy_Pro) {
+      releaseBus();
+      _spi_mosi = 13;
+      _spi_miso = 12;
+      _spi_sclk = 14;
+      initBus();
+
+      p_tmp.spi_3wire = false;
+      p_tmp.spi_cs   = 15;
+      p_tmp.spi_dc   =  4;
+      p_tmp.gpio_rst = -1;
+      setPanel(&p_tmp);
+
+      auto id = readPanelID();
+      ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
+      if (id == 0 && readCommand32(0x09) != 0) {   // check panel (ILI9341) panelIDが0なのでステータスリードを併用する
+        ESP_LOGW("LovyanGFX", "[Autodetect] WiFiBoy Pro");
+        board = lgfx::board_t::board_WiFiBoy_Pro;
+        releaseBus();
+        _spi_host = HSPI_HOST;
+        initBus();
+        auto p = new lgfx::Panel_ILI9341();
+        p->freq_write = 40000000;
+        p->freq_read  = 16000000;
+        p->freq_fill  = 40000000;
+        p->spi_3wire = false;
+        p->spi_cs    = 15;
+        p->spi_dc    =  4;
+        p->gpio_bl   = 27;
+        p->offset_rotation = 2;
+        setPanel(p);
+
+        goto init_clear;
+      }
+      lgfx::gpio_lo(p_tmp.spi_cs);
+      lgfx::gpio_lo(p_tmp.spi_dc);
+      p_tmp.spi_3wire = true;
+    }
+#endif
+
+// Makerfabs TouchScreen_Camera
+#if defined ( LGFX_AUTODETECT ) || defined ( LGFX_MAKERFABS_TOUCHCAMERA )
+    if (nvs_board == 0 || nvs_board == lgfx::board_t::board_Makerfabs_TouchCamera) {
+      releaseBus();
+      _spi_mosi = 13;
+      _spi_miso = 12;
+      _spi_sclk = 14;
+      initBus();
+
+      lgfx::lgfxPinMode(4, lgfx::pin_mode_t::output); // Makerfabs TouchCamera TF card CS
+      lgfx::gpio_hi(4);
+
+      p_tmp.spi_3wire = false;
+      p_tmp.spi_cs   = 15;
+      p_tmp.spi_dc   = 33;
+      p_tmp.gpio_rst = -1;
+      setPanel(&p_tmp);
+
+      auto id = readPanelID();
+      ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
+      if ((id & 0xFF) == 0x54) {   // check panel (ILI9488)
+        ESP_LOGW("LovyanGFX", "[Autodetect] Makerfabs_TouchCamera");
+        board = lgfx::board_t::board_Makerfabs_TouchCamera;
+        auto p = new lgfx::Panel_ILI9488();
+        p->freq_write = 40000000;
+        p->freq_read  = 16000000;
+        p->freq_fill  = 40000000;
+        p->spi_3wire = false;
+        p->spi_cs    = 15;
+        p->spi_dc    = 33;
+        p->gpio_bl   = -1;
+        setPanel(p);
+
+        lgfx::i2c::init(I2C_NUM_1, 26, 27, 400000);
+        std::uint8_t tmp[2];
+        if (lgfx::i2c::readRegister(I2C_NUM_1, 0x38, 0xA8, tmp, 1))
+        {
+          ESP_LOGW("LovyanGFX", "[Autodetect] touch id:%08x", tmp[1]);
+          auto t = new lgfx::Touch_FT5x06();
+          t->gpio_int = 38;   // INT pin number
+          t->i2c_sda  = 26;   // I2C SDA pin number
+          t->i2c_scl  = 27;   // I2C SCL pin number
+          t->i2c_addr = 0x38; // I2C device addr
+          t->i2c_port = I2C_NUM_1;// I2C port number
+          t->freq = 400000;   // I2C freq
+          t->x_min = 0;
+          t->x_max = 319;
+          t->y_min = 0;
+          t->y_max = 479;
+          touch(t);
+        }
+        goto init_clear;
+      }
+      lgfx::gpio_lo(p_tmp.spi_cs);
+      lgfx::gpio_lo(p_tmp.spi_dc);
+      lgfx::gpio_lo(4);
+      p_tmp.spi_3wire = true;
+    }
+#endif
+
+// Makerfabs MakePython
+#if defined ( LGFX_AUTODETECT ) || defined ( LGFX_MAKERFABS_MAKEPYTHON )
+    if (nvs_board == 0
+     || nvs_board == lgfx::board_t::board_Makerfabs_MakePython
+    ) {
+      releaseBus();
+      _spi_mosi = 13;
+      _spi_miso = 12;
+      _spi_sclk = 14;
+      initBus();
+
+      p_tmp.spi_cs   = 15;
+      p_tmp.spi_dc   = 22;
+      p_tmp.gpio_rst = 21;
+      setPanel(&p_tmp);
+      _reset(use_reset);
+
+      auto id = readPanelID();
+      ESP_LOGW("LovyanGFX", "[Autodetect] panel id:%08x", id);
+      if ((id & 0xFF) == 0x85) {  //  check panel (ST7789)
+        ESP_LOGW("LovyanGFX", "[Autodetect] Makerfabs_Makepython");
+        board = lgfx::board_t::board_Makerfabs_MakePython;
+        releaseBus();
+        _spi_host = HSPI_HOST;
+        initBus();
+        auto p = new lgfx::Panel_ST7789();
+        p->reverse_invert = true;
+        p->freq_write = 80000000;
+        p->freq_read  = 16000000;
+        p->freq_fill  = 80000000;
+        p->spi_3wire = true;
+        p->panel_height = 240;
+        p->spi_cs    = 15;
+        p->spi_dc    = 22;
+        p->gpio_bl   = 5;
+        p->gpio_rst  = 21;
+        p->pwm_ch_bl = 7;
+        setPanel(p);
+
+        goto init_clear;
+      }
+      lgfx::gpio_lo(p_tmp.spi_cs);
+      lgfx::gpio_lo(p_tmp.spi_dc);
+      lgfx::gpio_lo(p_tmp.gpio_rst);
+    }
+#endif
+
 // M5StackCore2 判定
 #if defined ( LGFX_AUTODETECT ) || defined ( LGFX_M5STACKCORE2 )
     if (nvs_board == 0 || nvs_board == lgfx::board_t::board_M5StackCore2) {

--- a/src/gitTagVersion.h
+++ b/src/gitTagVersion.h
@@ -1,1 +1,1 @@
-#define LOVYANGFX_VERSION F("0.2.6")
+#define LOVYANGFX_VERSION F("0.2.7")

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -1807,15 +1807,13 @@ namespace lgfx
         std::int32_t w  = std::max(xo + _font_metrics.width * _text_style.size_x, _font_metrics.x_advance * _text_style.size_x);
         if (_textscroll || _textwrap_x) {
           std::int32_t llimit = _textscroll ? this->_sx : this->_clip_l;
-          if (_cursor_x < llimit - xo) _cursor_x = llimit - xo;
-          else {
-            std::int32_t rlimit = _textscroll ? this->_sx + this->_sw : (this->_clip_r + 1);
-            if (_cursor_x + w > rlimit) {
-              _filled_x = llimit;
-              _cursor_x = llimit - xo;
-              _cursor_y += _font_metrics.y_advance * _text_style.size_y;
-            }
+          std::int32_t rlimit = _textscroll ? this->_sx + this->_sw : (this->_clip_r + 1);
+          if (_cursor_x + w > rlimit) {
+            _filled_x = llimit;
+            _cursor_x = llimit - std::min(0, xo);
+            _cursor_y += _font_metrics.y_advance * _text_style.size_y;
           }
+          if (_cursor_x < llimit - xo) _cursor_x = llimit - xo;
         }
 
         std::int32_t h  = _font_metrics.height * _text_style.size_y;
@@ -1841,9 +1839,7 @@ namespace lgfx
           }
         } else if (_textwrap_y) {
           if (y + h > (this->_clip_b + 1)) {
-            _filled_x = 0;
-            _cursor_x = - xo;
-            y = 0;
+            y = this->_clip_t;
           } else
           if (y < this->_clip_t) y = this->_clip_t;
         }

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -1810,7 +1810,7 @@ namespace lgfx
           std::int32_t rlimit = _textscroll ? this->_sx + this->_sw : (this->_clip_r + 1);
           if (_cursor_x + w > rlimit) {
             _filled_x = llimit;
-            _cursor_x = llimit - std::min(0, xo);
+            _cursor_x = llimit - std::min<std::int32_t>(0, xo);
             _cursor_y += _font_metrics.y_advance * _text_style.size_y;
           }
           if (_cursor_x < llimit - xo) _cursor_x = llimit - xo;

--- a/src/lgfx/LGFXBase.cpp
+++ b/src/lgfx/LGFXBase.cpp
@@ -1654,7 +1654,8 @@ namespace lgfx
           if (uniCode < 0x20) break;
         }
 
-        if (!_font->updateFontMetric(&_font_metrics, uniCode)) continue;
+        //if (!_font->updateFontMetric(&_font_metrics, uniCode)) continue;
+        _font->updateFontMetric(&_font_metrics, uniCode);
         if (left == 0 && right == 0 && _font_metrics.x_offset < 0) left = right = - (int)(_font_metrics.x_offset * sx);
         right = left + std::max<int>(_font_metrics.x_advance * sx, int(_font_metrics.width * sx) + int(_font_metrics.x_offset * sx));
         //right = left + (int)(std::max<int>(_font_metrics.x_advance, _font_metrics.width + _font_metrics.x_offset) * sx);
@@ -1681,7 +1682,8 @@ namespace lgfx
           if (uniCode < 0x20) break;
         }
 
-        if (!_font->updateFontMetric(&_font_metrics, uniCode)) continue;
+        //if (!_font->updateFontMetric(&_font_metrics, uniCode)) continue;
+        _font->updateFontMetric(&_font_metrics, uniCode);
         if (left == 0 && right == 0 && _font_metrics.x_offset < 0) left = right = - (int)(_font_metrics.x_offset * sx);
         right = left + std::max<int>(_font_metrics.x_advance*sx, int(_font_metrics.width*sx) + int(_font_metrics.x_offset * sx));
         //right = left + (int)(std::max<int>(_font_metrics.x_advance, _font_metrics.width + _font_metrics.x_offset) * sx);
@@ -1728,7 +1730,9 @@ namespace lgfx
             } while (uniCode < 0x20 && *++tmp);
             if (uniCode < 0x20) break;
           }
-          if (_font->updateFontMetric(&_font_metrics, uniCode)) {
+          //if (_font->updateFontMetric(&_font_metrics, uniCode))
+          {
+            _font->updateFontMetric(&_font_metrics, uniCode);
             if (_font_metrics.x_offset < 0) sumX = - _font_metrics.x_offset * _text_style.size_x;
             break;
           }
@@ -1801,7 +1805,8 @@ namespace lgfx
           if (uniCode < 0x20) return 1;
         }
         //if (!(fpUpdateFontSize)(this, uniCode)) return 1;
-        if (!_font->updateFontMetric(&_font_metrics, uniCode)) return 1;
+        //if (!_font->updateFontMetric(&_font_metrics, uniCode)) return 1;
+        _font->updateFontMetric(&_font_metrics, uniCode);
 
         std::int32_t xo = _font_metrics.x_offset  * _text_style.size_x;
         std::int32_t w  = std::max(xo + _font_metrics.width * _text_style.size_x, _font_metrics.x_advance * _text_style.size_x);

--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -191,9 +191,9 @@ namespace lgfx
     __attribute__ ((always_inline)) inline void pushPixels(const void*          data, std::int32_t len, bool swap) { startWrite(); writePixels(data, len, swap); endWrite(); }
 
     template<typename T>
-    void writePixels(const T *data, std::int32_t len)                        { auto pc = create_pc(data      ); writePixels_impl(len, &pc); }
-    void writePixels(const std::uint16_t* data, std::int32_t len, bool swap) { auto pc = create_pc(data, swap); writePixels_impl(len, &pc); }
-    void writePixels(const void*          data, std::int32_t len, bool swap) { auto pc = create_pc(data, swap); writePixels_impl(len, &pc); }
+    void writePixels(const T *data, std::int32_t len)                        { auto pc = create_pc_fast(data      ); writePixels_impl(len, &pc); }
+    void writePixels(const std::uint16_t* data, std::int32_t len, bool swap) { auto pc = create_pc_fast(data, swap); writePixels_impl(len, &pc); }
+    void writePixels(const void*          data, std::int32_t len, bool swap) { auto pc = create_pc_fast(data, swap); writePixels_impl(len, &pc); }
 
     template<typename T>
     void writeIndexedPixels(const uint8_t *data, T* palette, std::int32_t len, lgfx::color_depth_t colordepth = lgfx::rgb332_1Byte)
@@ -727,6 +727,69 @@ namespace lgfx
     }
 
 //----------------------------------------------------------------------------
+
+    template<typename T>
+    pixelcopy_t create_pc_fast(const T *data)
+    {
+      auto dst_depth = _write_conv.depth;
+      pixelcopy_t pc(data, dst_depth, get_depth<T>::value, hasPalette());
+      if (hasPalette() || dst_depth < rgb332_1Byte)
+      {
+        pc.fp_copy = pixelcopy_t::copy_bit_fast;
+      }
+      else
+      if (dst_depth > rgb565_2Byte)
+      {
+        if (     dst_depth == rgb888_3Byte) { pc.fp_copy = pixelcopy_t::copy_rgb_fast<bgr888_t, T>; }
+        else if (dst_depth == rgb666_3Byte) { pc.fp_copy = pixelcopy_t::copy_rgb_fast<bgr666_t, T>; }
+        else                                { pc.fp_copy = pixelcopy_t::copy_rgb_fast<argb8888_t, T>; }
+      }
+      else
+      {
+        if (dst_depth == rgb565_2Byte) { pc.fp_copy = pixelcopy_t::copy_rgb_fast<swap565_t, T>; }
+        else                           { pc.fp_copy = pixelcopy_t::copy_rgb_fast<rgb332_t, T>; }
+      }
+      return pc;
+    }
+    __attribute__ ((always_inline)) inline pixelcopy_t create_pc_fast(const std::uint8_t  *data) { return create_pc_fast(reinterpret_cast<const rgb332_t*>(data)); }
+    __attribute__ ((always_inline)) inline pixelcopy_t create_pc_fast(const std::uint16_t *data) { return create_pc_fast(data, _swapBytes); }
+    __attribute__ ((always_inline)) inline pixelcopy_t create_pc_fast(const void          *data) { return create_pc_fast(data, _swapBytes); }
+    __attribute__ ((always_inline)) inline pixelcopy_t create_pc_fast(const std::uint16_t *data, bool swap)
+    {
+      return swap && !hasPalette() && _write_conv.depth >= 8
+           ? create_pc_fast(reinterpret_cast<const rgb565_t* >(data))
+           : create_pc_fast(reinterpret_cast<const swap565_t*>(data));
+    }
+    __attribute__ ((always_inline)) inline pixelcopy_t create_pc_fast(const void *data, bool swap)
+    {
+      return swap && !hasPalette() && _write_conv.depth >= 8
+           ? create_pc_fast(reinterpret_cast<const rgb888_t*>(data))
+           : create_pc_fast(reinterpret_cast<const bgr888_t*>(data));
+    }
+
+    template<typename T>
+    pixelcopy_t create_pc_fast(const void *data, const T *palette, lgfx::color_depth_t depth)
+    {
+      pixelcopy_t pc(data, _write_conv.depth, get_depth<T>::value, hasPalette());
+      if (hasPalette() || _write_conv.depth < rgb332_1Byte)
+      {
+        if (palette && (_write_conv.depth == rgb332_1Byte) && (depth == rgb332_1Byte))
+        {
+          pc.fp_copy = pixelcopy_t::copy_rgb_fast<rgb332_t, rgb332_t>;
+        }
+        else
+        {
+          pc.fp_copy = pixelcopy_t::copy_bit_fast;
+        }
+      }
+      else
+      if (palette)
+      {
+        pc.fp_copy = pixelcopy_t::copy_palette_fast<T>;
+      }
+      return pc;
+    }
+
 
     template<typename T>
     pixelcopy_t create_pc(const T *data)

--- a/src/lgfx/LGFXBase.hpp
+++ b/src/lgfx/LGFXBase.hpp
@@ -622,10 +622,10 @@ namespace lgfx
     void qrcode(const char *string, std::int32_t x = -1, std::int32_t y = -1, std::int32_t width = -1, std::uint8_t version = 1);
 
 
-    void drawBmp(const std::uint8_t *bmp_data, std::uint32_t bmp_len, std::int32_t x=0, std::int32_t y=0) {
+    bool drawBmp(const std::uint8_t *bmp_data, std::uint32_t bmp_len, std::int32_t x=0, std::int32_t y=0) {
       PointerWrapper data;
       data.set(bmp_data, bmp_len);
-      this->draw_bmp(&data, x, y);
+      return this->draw_bmp(&data, x, y);
     }
     bool drawJpg(const std::uint8_t *jpg_data, std::uint32_t jpg_len, std::int32_t x=0, std::int32_t y=0, std::int32_t maxWidth=0, std::int32_t maxHeight=0, std::int32_t offX=0, std::int32_t offY=0, jpeg_div::jpeg_div_t scale=jpeg_div::jpeg_div_t::JPEG_DIV_NONE) {
       PointerWrapper data;
@@ -639,8 +639,8 @@ namespace lgfx
       return this->draw_png(&data, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 
-    inline void drawBmp(DataWrapper *data, std::int32_t x=0, std::int32_t y=0) {
-      this->draw_bmp(data, x, y);
+    inline bool drawBmp(DataWrapper *data, std::int32_t x=0, std::int32_t y=0) {
+      return this->draw_bmp(data, x, y);
     }
     inline bool drawJpg(DataWrapper *data, std::int32_t x=0, std::int32_t y=0, std::int32_t maxWidth=0, std::int32_t maxHeight=0, std::int32_t offX=0, std::int32_t offY=0, jpeg_div::jpeg_div_t scale=jpeg_div::jpeg_div_t::JPEG_DIV_NONE) {
       return this->draw_jpg(data, x, y, maxWidth, maxHeight, offX, offY, scale);

--- a/src/lgfx/LGFX_Device.hpp
+++ b/src/lgfx/LGFX_Device.hpp
@@ -150,7 +150,7 @@ namespace lgfx
     template <typename T>
     std::uint_fast8_t getTouch(T *x, T *y, std::uint_fast8_t number = 0)
     {
-      std::int32_t tx, ty;
+      std::int32_t tx = -1, ty = -1;
       auto res = getTouch(&tx, &ty, number);
       if (x) *x = tx;
       if (y) *y = ty;

--- a/src/lgfx/LGFX_Device.hpp
+++ b/src/lgfx/LGFX_Device.hpp
@@ -159,7 +159,7 @@ namespace lgfx
 
     std::uint_fast8_t getTouch(std::int32_t *x, std::int32_t *y, std::uint_fast8_t number = 0)
     {
-      std::int32_t tx, ty;
+      std::int32_t tx = -1, ty = -1;
       auto res = getTouchRaw(&tx, &ty, number);
       if (0 == res) return 0;
       convertRawXY(&tx, &ty);

--- a/src/lgfx/LGFX_Sprite.hpp
+++ b/src/lgfx/LGFX_Sprite.hpp
@@ -50,7 +50,7 @@ namespace lgfx
       _transaction_count = 0xFFFF;
     }
 
-    __attribute__ ((always_inline)) inline void* getBuffer(void) const { return _img; }
+    __attribute__ ((always_inline)) inline void* getBuffer(void) const { return _img.get(); }
     std::uint32_t bufferLength(void) const { return (_bitwidth * _write_conv.bits >> 3) * _height; }
 
     LGFX_Sprite()

--- a/src/lgfx/lgfx_common.hpp
+++ b/src/lgfx/lgfx_common.hpp
@@ -1332,7 +1332,7 @@ namespace lgfx
       return ( (bfType == 0x4D42)   // bmp header "BM"
             && (biPlanes == 1)  // bcPlanes always 1
             && (biWidth > 0)
-            && (biHeight > 0)
+            && (biHeight != 0)
             && (biBitCount <= 32)
             && (biBitCount != 0));
     }

--- a/src/lgfx/lgfx_common.hpp
+++ b/src/lgfx/lgfx_common.hpp
@@ -903,15 +903,13 @@ namespace lgfx
       auto d = static_cast<TDst*>(dst);
       auto pal = static_cast<const TPalette*>(param->palette);
       auto transp     = param->transp;
-      param->src_x32 -= param->src_x32_add;
-      param->src_y32 -= param->src_y32_add;
       do {
-        param->src_x32 += param->src_x32_add;
-        param->src_y32 += param->src_y32_add;
         std::uint32_t i = (param->src_x + param->src_y * param->src_bitwidth) * param->src_bits;
         std::uint32_t raw = (s[i >> 3] >> (-(i + param->src_bits) & 7)) & param->src_mask;
         if (raw == transp) break;
         d[index] = pal[raw];
+        param->src_x32 += param->src_x32_add;
+        param->src_y32 += param->src_y32_add;
       } while (++index != last);
       return index;
     }
@@ -923,14 +921,12 @@ namespace lgfx
       auto d = static_cast<TDst*>(dst);
       auto src_x32_add = param->src_x32_add;
       auto src_y32_add = param->src_y32_add;
-      param->src_x32 -= src_x32_add;
-      param->src_y32 -= src_y32_add;
       do {
-        param->src_x32 += src_x32_add;
-        param->src_y32 += src_y32_add;
         std::uint32_t i = param->src_x + param->src_y * param->src_bitwidth;
         if (s[i] == param->transp) break;
         d[index] = s[i];
+        param->src_x32 += src_x32_add;
+        param->src_y32 += src_y32_add;
       } while (++index != last);
       return index;
     }

--- a/src/lgfx/lgfx_filesystem_support.hpp
+++ b/src/lgfx/lgfx_filesystem_support.hpp
@@ -195,25 +195,19 @@ namespace lgfx
     inline bool drawBmpUrl(const char* url, std::int32_t x=0, std::int32_t y=0)
     {
       HttpWrapper http;
-      if (!http.open(url)) return false;
-
-      return drawBmp(&http, x, y);
+      return http.open(url) && drawBmp(&http, x, y);
     }
 
     inline bool drawJpgUrl(const char* url, std::int32_t x=0, std::int32_t y=0, std::int32_t maxWidth=0, std::int32_t maxHeight=0, std::int32_t offX=0, std::int32_t offY=0, jpeg_div::jpeg_div_t scale=jpeg_div::jpeg_div_t::JPEG_DIV_NONE)
     {
       HttpWrapper http;
-      if (!http.open(url)) return false;
-
-      return drawJpg(&http, x, y, maxWidth, maxHeight, offX, offY, scale);
+      return http.open(url) && drawJpg(&http, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
 
     inline bool drawPngUrl(const char* url, std::int32_t x = 0, std::int32_t y = 0, std::int32_t maxWidth = 0, std::int32_t maxHeight = 0, std::int32_t offX = 0, std::int32_t offY = 0, float scale = 1.0f)
     {
       HttpWrapper http;
-      if (!http.open(url)) return false;
-
-      return drawPng(&http, x, y, maxWidth, maxHeight, offX, offY, scale);
+      return http.open(url) && drawPng(&http, x, y, maxWidth, maxHeight, offX, offY, scale);
     }
     
   #endif

--- a/src/lgfx/platforms/LGFX_SPI_SAMD51.hpp
+++ b/src/lgfx/platforms/LGFX_SPI_SAMD51.hpp
@@ -889,7 +889,6 @@ void enableSPI()
     void write_pixels(std::int32_t length, pixelcopy_t* param)
     {
       const std::uint8_t dst_bytes = _write_conv.bytes;
-      const std::uint8_t src_bits = param->src_bits;
       std::uint32_t limit = (dst_bytes == 2) ? 16 : 12;
       std::uint32_t len;
       do {
@@ -899,9 +898,6 @@ void enableSPI()
         auto dmabuf = get_dmabuffer(len * dst_bytes);
         param->fp_copy(dmabuf, 0, len, param);
         write_bytes(dmabuf, len * dst_bytes, true);
-        auto src_move = ((len * src_bits) & ~7);
-        param->src_data = &reinterpret_cast<const uint8_t*>(param->src_data)[src_move >> 3];
-        param->src_x -= src_move / src_bits;
       } while (length -= len);
     }
 

--- a/src/lgfx/platforms/esp32_common.hpp
+++ b/src/lgfx/platforms/esp32_common.hpp
@@ -107,6 +107,7 @@ namespace lgfx
     void set(Stream* src, std::uint32_t length = ~0) { _stream = src; _length = length; _index = 0; }
 
     int read(std::uint8_t *buf, std::uint32_t len) override {
+      len = std::min<std::uint32_t>(len, _stream->available());
       if (len > _length - _index) { len = _length - _index; }
       _index += len;
       return _stream->readBytes((char*)buf, len);

--- a/src/lgfx/platforms/esp32_common.hpp
+++ b/src/lgfx/platforms/esp32_common.hpp
@@ -116,7 +116,7 @@ namespace lgfx
     bool seek(std::uint32_t offset) override { if (offset < _index) { return false; } skip(offset - _index); return true; }
     void close() override { }
 
-  private:
+  protected:
     Stream* _stream;
     std::uint32_t _index;
     std::uint32_t _length = 0;


### PR DESCRIPTION
hotfix: breakage of writePixels/pushPixels in v0.2.6.
fix: an issue vertical inverted BMPs could not be drawn.
fix: an issue of print shifting to the left just after wordwrap.
update: draw a square instead of characters that are not in the font set.
add drawBmpUrl / drawJpgUrl / drawPngUrl functions. ( for ArduinoESP32 )
add DeepSleep example. ( for ESP32 )
add support WiFiBoy Pro / mini .
add support Makerfabs MakePython / Touch with Camera .
