### PR TITLE
Fix compilation error / issue #91

### DIFF
--- a/src/lgfx/platforms/LGFX_SPI_ESP32.hpp
+++ b/src/lgfx/platforms/LGFX_SPI_ESP32.hpp
@@ -36,7 +36,6 @@ Contributors:
 
 #if defined (ARDUINO) // Arduino ESP32
  #include <SPI.h>
- #include <driver/periph_ctrl.h>
  #include <soc/periph_defs.h>
  #include <esp32-hal-cpu.h>
 #else

--- a/src/lgfx/platforms/LGFX_SPI_ESP32.hpp
+++ b/src/lgfx/platforms/LGFX_SPI_ESP32.hpp
@@ -42,9 +42,11 @@ Contributors:
 #else
  #include <esp_log.h>
  #include <driver/spi_master.h>
- #if ESP_IDF_VERSION_MAJOR > 3
-  #include <driver/spi_common_internal.h>
- #endif
+#endif
+
+// ESP_IDF_VERSION_MAJOR is defined since ESP-IDF v3.3 
+#if defined(ESP_IDF_VERSION_MAJOR) && ESP_IDF_VERSION_MAJOR > 3
+ #include <driver/spi_common_internal.h>
 #endif
 
 #if defined (CONFIG_IDF_TARGET_ESP32S2)

--- a/src/lgfx/platforms/esp32_common.hpp
+++ b/src/lgfx/platforms/esp32_common.hpp
@@ -9,6 +9,7 @@
 #if defined ARDUINO
   #include <Arduino.h>
   #include <soc/periph_defs.h>
+  #include <soc/dport_reg.h>
 #else
   #include <freertos/FreeRTOS.h>
   #include <freertos/task.h>


### PR DESCRIPTION
This closes #91.

Also, I removed `#include <soc/periph_defs.h>`, because it has already been included in line 28.

https://github.com/lovyan03/LovyanGFX/blob/be4420a658ad3e58395d6a8e939327c58125f7cb/src/lgfx/platforms/LGFX_SPI_ESP32.hpp#L28
