### PR TITLE
円弧塗潰描画 （fillArc）をベースに楕円弧塗潰描画 （fillEllipseArc）を追加

### DIFF
--- a/src/lgfx/v0/LGFXBase.cpp
+++ b/src/lgfx/v0/LGFXBase.cpp
@@ -917,16 +917,16 @@ namespace lgfx
       else if (end < 180 && start < 180) y = 0;
     }
 
-    std::int32_t iradius_x2 = trueCircle ? iradius_x2 * iradius_x2 + iradius_x2 : iradius_x * iradius_x;
-    std::int32_t oradius_x2 = trueCircle ? oradius_x2 * oradius_x2 + oradius_x2 : oradius_x * oradius_x;
-    std::int32_t iradius_y2 = trueCircle ? iradius_x2                           : iradius_y * iradius_y;
-    std::int32_t oradius_y2 = trueCircle ? oradius_x2                           : oradius_y * oradius_y;
-    float irad_rate = trueCircle ? 1 : iradius_y2 ? (float)iradius_x2 / iradius_y2 : INT32_MAX;
-    float orad_rate = trueCircle ? 1 : oradius_y2 ? (float)oradius_x2 / oradius_y2 : INT32_MAX;
+    std::int32_t iradius_x2 = iradius_x * iradius_x + (trueCircle ? iradius_x : 0);
+    std::int32_t oradius_x2 = oradius_x * oradius_x + (trueCircle ? oradius_x : 0);
+    std::int32_t iradius_y2 = trueCircle ? iradius_x2 : iradius_y * iradius_y;
+    std::int32_t oradius_y2 = trueCircle ? oradius_x2 : oradius_y * oradius_y;
+    float irad_rate = trueCircle ? 1 : iradius_y2 ? (float)iradius_x2 / iradius_y2 : 0;
+    float orad_rate = trueCircle ? 1 : oradius_y2 ? (float)oradius_x2 / oradius_y2 : 0;
     do {
       std::int32_t y2 = y * y;
-      std::int32_t compare_i = trueCircle ? iradius_x2 - y2 : iradius_y2 ? iradius_x2 - irad_rate * y2 : -INT32_MAX;
-      std::int32_t compare_o = trueCircle ? oradius_x2 - y2 : oradius_y2 ? oradius_x2 - orad_rate * y2 : -INT32_MAX;
+      std::int32_t compare_i = trueCircle ? iradius_x2 - y2 : iradius_y2 ? iradius_x2 - irad_rate * y2 : 0;
+      std::int32_t compare_o = trueCircle ? oradius_x2 - y2 : oradius_y2 ? oradius_x2 - orad_rate * y2 : 0;
       int x = xs;
       if (x < 0) {
         while (x * x >= compare_o) ++x;

--- a/src/lgfx/v0/LGFXBase.cpp
+++ b/src/lgfx/v0/LGFXBase.cpp
@@ -919,8 +919,8 @@ namespace lgfx
 
     std::int32_t iradius_x2 = trueCircle ? iradius_x2 * iradius_x2 + iradius_x2 : iradius_x * iradius_x;
     std::int32_t oradius_x2 = trueCircle ? oradius_x2 * oradius_x2 + oradius_x2 : oradius_x * oradius_x;
-    std::int32_t iradius_y2 = trueCircle ? iradius_x2                             : iradius_y * iradius_y;
-    std::int32_t oradius_y2 = trueCircle ? oradius_x2                             : oradius_y * oradius_y;
+    std::int32_t iradius_y2 = trueCircle ? iradius_x2                           : iradius_y * iradius_y;
+    std::int32_t oradius_y2 = trueCircle ? oradius_x2                           : oradius_y * oradius_y;
     float irad_rate = trueCircle ? 1 : iradius_y2 ? (float)iradius_x2 / iradius_y2 : INT32_MAX;
     float orad_rate = trueCircle ? 1 : oradius_y2 ? (float)oradius_x2 / oradius_y2 : INT32_MAX;
     do {

--- a/src/lgfx/v0/LGFXBase.cpp
+++ b/src/lgfx/v0/LGFXBase.cpp
@@ -904,6 +904,7 @@ namespace lgfx
     bool start180 = !(start < 180);
     bool end180 = end < 180;
     bool reversed = start + 180 < end || (end < start && start < end + 180);
+    bool trueCircle = oradius_x == oradius_y && iradius_x == iradius_y;
 
     std::int32_t xs = -oradius_x;
     std::int32_t y = -oradius_y;
@@ -916,16 +917,16 @@ namespace lgfx
       else if (end < 180 && start < 180) y = 0;
     }
 
-    std::int32_t iradius_x2 = iradius_x * iradius_x;
-    std::int32_t oradius_x2 = oradius_x * oradius_x;
-    std::int32_t iradius_y2 = iradius_y * iradius_y;
-    std::int32_t oradius_y2 = oradius_y * oradius_y;
-    float irad_rate = iradius_y2 ? iradius_x2 / iradius_y2 : INT32_MAX;
-    float orad_rate = oradius_y2 ? oradius_x2 / oradius_y2 : INT32_MAX;
+    std::int32_t iradius_x2 = trueCircle ? iradius_x2 * iradius_x2 + iradius_x2 : iradius_x * iradius_x;
+    std::int32_t oradius_x2 = trueCircle ? oradius_x2 * oradius_x2 + oradius_x2 : oradius_x * oradius_x;
+    std::int32_t iradius_y2 = trueCircle ? iradius_x2 : iradius_y * iradius_y;
+    std::int32_t oradius_y2 = trueCircle ? oradius_x2 : oradius_y * oradius_y;
+    float irad_rate = trueCircle ? 1 : iradius_y2 ? iradius_x2 / iradius_y2 : INT32_MAX;
+    float orad_rate = trueCircle ? 1 : oradius_y2 ? oradius_x2 / oradius_y2 : INT32_MAX;
     do {
       std::int32_t y2 = y * y;
-      std::int32_t compare_i = iradius_x2 - irad_rate * y2;
-      std::int32_t compare_o = oradius_x2 - irad_rate * y2;
+      std::int32_t compare_i = trueCircle ? iradius_x2 - y2 : iradius_x2 - irad_rate * y2;
+      std::int32_t compare_o = trueCircle ? oradius_x2 - y2 : oradius_x2 - irad_rate * y2;
       int x = xs;
       if (x < 0) {
         while (x * x >= compare_o) ++x;

--- a/src/lgfx/v0/LGFXBase.cpp
+++ b/src/lgfx/v0/LGFXBase.cpp
@@ -919,14 +919,14 @@ namespace lgfx
 
     std::int32_t iradius_x2 = trueCircle ? iradius_x2 * iradius_x2 + iradius_x2 : iradius_x * iradius_x;
     std::int32_t oradius_x2 = trueCircle ? oradius_x2 * oradius_x2 + oradius_x2 : oradius_x * oradius_x;
-    std::int32_t iradius_y2 = trueCircle ? iradius_x2 : iradius_y * iradius_y;
-    std::int32_t oradius_y2 = trueCircle ? oradius_x2 : oradius_y * oradius_y;
-    float irad_rate = trueCircle ? 1 : iradius_y2 ? iradius_x2 / iradius_y2 : INT32_MAX;
-    float orad_rate = trueCircle ? 1 : oradius_y2 ? oradius_x2 / oradius_y2 : INT32_MAX;
+    std::int32_t iradius_y2 = trueCircle ? iradius_x2                             : iradius_y * iradius_y;
+    std::int32_t oradius_y2 = trueCircle ? oradius_x2                             : oradius_y * oradius_y;
+    float irad_rate = trueCircle ? 1 : iradius_y2 ? (float)iradius_x2 / iradius_y2 : INT32_MAX;
+    float orad_rate = trueCircle ? 1 : oradius_y2 ? (float)oradius_x2 / oradius_y2 : INT32_MAX;
     do {
       std::int32_t y2 = y * y;
-      std::int32_t compare_i = trueCircle ? iradius_x2 - y2 : iradius_x2 - irad_rate * y2;
-      std::int32_t compare_o = trueCircle ? oradius_x2 - y2 : oradius_x2 - irad_rate * y2;
+      std::int32_t compare_i = trueCircle ? iradius_x2 - y2 : iradius_y2 ? iradius_x2 - irad_rate * y2 : -INT32_MAX;
+      std::int32_t compare_o = trueCircle ? oradius_x2 - y2 : oradius_y2 ? oradius_x2 - orad_rate * y2 : -INT32_MAX;
       int x = xs;
       if (x < 0) {
         while (x * x >= compare_o) ++x;

--- a/src/lgfx/v0/LGFXBase.hpp
+++ b/src/lgfx/v0/LGFXBase.hpp
@@ -118,6 +118,8 @@ namespace lgfx
                                 void drawArc         ( std::int32_t x, std::int32_t y, std::int32_t r0, std::int32_t r1, float angle0, float angle1);
     template<typename T> inline void fillArc         ( std::int32_t x, std::int32_t y, std::int32_t r0, std::int32_t r1, float angle0, float angle1, const T& color) { setColor(color); fillArc( x, y, r0, r1, angle0, angle1); }
                                 void fillArc         ( std::int32_t x, std::int32_t y, std::int32_t r0, std::int32_t r1, float angle0, float angle1);
+    template<typename T> inline void fillEllipseArc  ( std::int32_t x, std::int32_t y, std::int32_t r0x, std::int32_t r1x, std::int32_t r0y, std::int32_t r1y, float angle0, float angle1, const T& color) { setColor(color); fillEllipseArc( x, y, r0x, r1x, r0y, r1y, angle0, angle1); }
+                                void fillEllipseArc  ( std::int32_t x, std::int32_t y, std::int32_t r0x, std::int32_t r1x, std::int32_t r0y, std::int32_t r1y, float angle0, float angle1);
     template<typename T> inline void drawCircleHelper( std::int32_t x, std::int32_t y, std::int32_t r, std::uint_fast8_t cornername                 , const T& color)  { setColor(color); drawCircleHelper(x, y, r, cornername    ); }
                                 void drawCircleHelper( std::int32_t x, std::int32_t y, std::int32_t r, std::uint_fast8_t cornername);
     template<typename T> inline void fillCircleHelper( std::int32_t x, std::int32_t y, std::int32_t r, std::uint_fast8_t corners, std::int32_t delta, const T& color)  { setColor(color); fillCircleHelper(x, y, r, corners, delta); }
@@ -999,7 +1001,7 @@ namespace lgfx
     void writeRawColor( std::uint32_t color, std::int32_t length) { if (0 >= length) return; setRawColor(color); pushBlock_impl(length); }
     void read_rect(std::int32_t x, std::int32_t y, std::int32_t w, std::int32_t h, void* dst, pixelcopy_t* param);
     void draw_gradient_line( std::int32_t x0, std::int32_t y0, std::int32_t x1, std::int32_t y1, uint32_t colorstart, uint32_t colorend );
-    void fill_arc_helper(std::int32_t cx, std::int32_t cy, std::int32_t oradius, std::int32_t iradius, float start, float end);
+    void fill_arc_helper(std::int32_t cx, std::int32_t cy, std::int32_t oradius_x, std::int32_t iradius_x, std::int32_t oradius_y, std::int32_t iradius_y, float start, float end);
     void draw_bezier_helper(std::int32_t x0, std::int32_t y0, std::int32_t x1, std::int32_t y1, std::int32_t x2, std::int32_t y2);
     void draw_bitmap(std::int32_t x, std::int32_t y, const std::uint8_t *bitmap, std::int32_t w, std::int32_t h, std::uint32_t fg_rawcolor, std::uint32_t bg_rawcolor = ~0u);
     void draw_xbitmap(std::int32_t x, std::int32_t y, const std::uint8_t *bitmap, std::int32_t w, std::int32_t h, std::uint32_t fg_rawcolor, std::uint32_t bg_rawcolor = ~0u);


### PR DESCRIPTION
fill_arc_helper() を円弧・楕円弧の両方対応にしました。