### PR TITLE
M5StickCPlus auto-detection support with "ARDUINO_M5Stick_C_Plus" macro.

### DIFF
--- a/src/lgfx/v0/init.hpp
+++ b/src/lgfx/v0/init.hpp
@@ -76,7 +76,7 @@ Contributors:
   #define LGFX_M5STACK_CORE2
  #elif defined( ARDUINO_M5STACK_Core2 ) // M5Stack Core2
   #define LGFX_M5STACK_CORE2
- #elif defined( ARDUINO_M5Stick_C ) // M5Stick C / CPlus
+ #elif defined( ARDUINO_M5Stick_C ) || defined( ARDUINO_M5Stick_C_Plus ) // M5Stick C / CPlus
   #define LGFX_M5STICK_C
  #elif defined( ARDUINO_M5Stack_CoreInk ) // M5Stack CoreInk
   #define LGFX_M5STACK_COREINK


### PR DESCRIPTION
Current boards.txt for "M5Stack Arduino" has a macro definition "ARDUINO_M5Stick_C_Plus".
So we can use this macro for auto-detection M5StickCPlus.