### PR TITLE
Remove forced in linking of some methods

### DIFF
--- a/src/lgfx/v0/lgfx_common.hpp
+++ b/src/lgfx/v0/lgfx_common.hpp
@@ -259,30 +259,24 @@ namespace lgfx
   __attribute__ ((always_inline)) inline static constexpr uint16_t getSwap16(uint16_t c) { return __builtin_bswap16(c); }
   __attribute__ ((always_inline)) inline static constexpr uint32_t getSwap24(uint32_t c) { return ((uint8_t)c)<<16 | ((uint8_t)(c>>8))<<8 | (uint8_t)(c>>16); }
 
-  __attribute__((used))
   static constexpr uint32_t convert_bgr888_to_rgb888( uint32_t c) { return getSwap24(c);  }
-  __attribute__((used))
   static constexpr uint32_t convert_bgr888_to_rgb565( uint32_t c) { return  (((uint8_t)c) >> 3) << 11 | (((uint16_t)c)>>10)<<5 | c>>19; }
   static constexpr uint32_t convert_bgr888_to_swap565(uint32_t c) { return  (((uint8_t)c) >> 3) << 3 |  ((uint16_t)c) >> 13 | (c & 0x1C00) << 3 | (c>>19) << 8; }
   static constexpr uint32_t convert_bgr888_to_bgr666 (uint32_t c) { return (c>>2) & 0x3F3F3F;  }
   static constexpr uint32_t convert_bgr888_to_rgb332 (uint32_t c) { return ((uint8_t)c >> 5) << 5 | (((uint16_t)c)>>13) << 2 | c>>22; }
 
-  __attribute__((used))
   static constexpr uint32_t convert_rgb888_to_bgr666 (uint32_t c) { return ((c>>2) & 0x3F) << 16 | ((c >> 10) & 0x3F) << 8 | ((c>>18)&0x3F);  }
-  __attribute__((used))
   static constexpr uint32_t convert_rgb888_to_rgb565 (uint32_t c) { return  (c>>19) << 11 | (((uint16_t)c)>>10)<<5 | ((uint8_t)c) >> 3;   }
   static constexpr uint32_t convert_rgb888_to_bgr888 (uint32_t c) { return getSwap24(c);  }
   static constexpr uint32_t convert_rgb888_to_swap565(uint32_t c) { return  (c>>19) << 3 |  ((uint16_t)c) >> 13 | (c & 0x1C00) << 3 | (((uint8_t)c) >> 3) << 8; }
   static constexpr uint32_t convert_rgb888_to_rgb332 (uint32_t c) { return ((c>>21) << 5) | ((((uint16_t)c)>>13) << 2) | ((c>>6) & 3); }
 
-  __attribute__((used))
   static constexpr uint32_t convert_rgb565_to_rgb888( uint32_t c) { return ((((c>>11)*0x21)>>2)<<8 | ((((c>>5)&0x3F)*0x41)>>4))<<8 | (((c&0x1F)*0x21)>>2); }
   static constexpr uint32_t convert_rgb565_to_bgr888 (uint32_t c) { return ((((c&0x1F)*0x21)>>2)<<8 | ((((c>>5)&0x3F)*0x41)>>4))<<8 | (((c>>11)*0x21)>>2); }
   static constexpr uint32_t convert_rgb565_to_bgr666 (uint32_t c) { return ((c&0x1F)<<17) | ((c&0x10)<<12) | ((c&0x7E0)<<3) | ((c>>10)&0xF8) | (c>>15); }
   static constexpr uint32_t convert_rgb565_to_swap565(uint32_t c) { return (0xFF & c)<<8|c>>8; }
   static constexpr uint32_t convert_rgb565_to_rgb332 (uint32_t c) { return ((c>>13) <<5) | ((c>>6) & 0x1C) | ((c>>3) & 3); }
 
-  __attribute__((used))
   static constexpr uint32_t convert_rgb332_to_rgb888 (uint32_t c) { return ((((c>>5)*0x49) >> 1)<<8 | ((c&0x1C)*0x49)>>3)<<8 | ((c&3)*0x55); }
   static constexpr uint32_t convert_rgb332_to_bgr888 (uint32_t c) { return (((c&3)*0x55)<<8 | ((c&0x1C)*0x49)>>3)<<8 | (((c>>5)*0x49) >> 1); }
   static constexpr uint32_t convert_rgb332_to_bgr666 (uint32_t c) { return (((c&0xE0)*9)>>5) | ((c&0x1C)*0x240) | ((c&3)*0x15)<<16; }

--- a/src/lgfx/v1/misc/DataWrapper.hpp
+++ b/src/lgfx/v1/misc/DataWrapper.hpp
@@ -32,7 +32,7 @@ namespace lgfx
 #if defined ( _MSVC_LANG )
  #define LGFX_INLINE inline
 #else
- #define LGFX_INLINE __attribute__((used)) __attribute__ ((always_inline)) inline
+ #define LGFX_INLINE __attribute__ ((always_inline)) inline
 #endif
 
 //----------------------------------------------------------------------------

--- a/src/lgfx/v1/misc/colortype.hpp
+++ b/src/lgfx/v1/misc/colortype.hpp
@@ -34,7 +34,7 @@ namespace lgfx
 #if defined ( _MSVC_LANG )
  #define LGFX_INLINE inline static
 #else
- #define LGFX_INLINE __attribute__((used)) __attribute__ ((always_inline)) inline static
+ #define LGFX_INLINE __attribute__ ((always_inline)) inline static
 #endif
 
   LGFX_INLINE constexpr uint8_t  color332(uint8_t r, uint8_t g, uint8_t b) { return ((((r >> 5) << 3) + (g >> 5)) << 2) + (b >> 6); }
@@ -516,7 +516,7 @@ namespace lgfx
 #if defined ( _MSVC_LANG )
 #define LGFX_INLINE inline
 #else
-#define LGFX_INLINE __attribute__((used)) __attribute__ ((always_inline)) inline
+#define LGFX_INLINE __attribute__ ((always_inline)) inline
 #endif
 
   template<class TDst, class TSrc> LGFX_INLINE uint32_t color_convert(uint32_t c) { return c; }

--- a/src/lgfx/v1/misc/range.hpp
+++ b/src/lgfx/v1/misc/range.hpp
@@ -66,7 +66,7 @@ namespace lgfx
 #if defined ( _MSVC_LANG )
 #define LGFX_INLINE inline
 #else
-#define LGFX_INLINE __attribute__((used)) __attribute__ ((always_inline)) inline
+#define LGFX_INLINE __attribute__ ((always_inline)) inline
 #endif
 
     LGFX_INLINE int_fast16_t width(void) const { return right - left + 1; }


### PR DESCRIPTION
This removes the usage of `__attribute__((used))`
This saves some space in the firmware. Almost 5.5kb in my case. 

I do not know if methods/attribute is needed for some strange after linkagre magic or something else I didn't know about. I just tested to remove it on my setup.