### PR TITLE
Bus_Stream の新設

### DIFF
--- a/src/lgfx/v1/Bus.hpp
+++ b/src/lgfx/v1/Bus.hpp
@@ -34,6 +34,7 @@ namespace lgfx
     bus_i2c,
     bus_parallel8,
     bus_parallel16,
+    bus_stream,
   };
 
   struct IBus

--- a/src/lgfx/v1/platforms/arduino_default/Bus_Stream.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_Stream.cpp
@@ -1,0 +1,130 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#if defined (ESP_PLATFORM)
+#include <sdkconfig.h>
+#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32) || defined (CONFIG_IDF_TARGET_ESP32S2) || defined (CONFIG_IDF_TARGET_ESP32C3)
+
+#include "Bus_Stream.hpp"
+#include "../../misc/pixelcopy.hpp"
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  void Bus_Stream::config(const config_t& config)
+  {
+    _cfg = config;
+  }
+
+  void Bus_Stream::writeData(uint32_t data, uint_fast8_t bit_length)
+  {
+    const uint8_t dst_bytes = bit_length >> 3;
+    writeBytes((uint8_t*)&data, dst_bytes);
+  }
+
+  void Bus_Stream::writeDataRepeat(uint32_t data, uint_fast8_t bit_length, uint32_t length)
+  {
+    const uint8_t dst_bytes = bit_length >> 3;
+    uint32_t buf0 = data | data << bit_length;
+    uint32_t buf1;
+    uint32_t buf2;
+    // make 12Bytes data.
+    if (dst_bytes != 3)
+    {
+      if (dst_bytes == 1)
+      {
+        buf0 |= buf0 << 16;
+      }
+      buf1 = buf0;
+      buf2 = buf0;
+    }
+    else
+    {
+      buf1 = buf0 >>  8 | buf0 << 16;
+      buf2 = buf0 >> 16 | buf0 <<  8;
+    }
+    uint32_t src[8] = { buf0, buf1, buf2, buf0, buf1, buf2, buf0, buf1 };
+    auto buf = reinterpret_cast<uint8_t*>(src);
+    uint32_t limit = 32 / dst_bytes;
+    uint32_t len;
+    do
+    {
+      len = ((length - 1) % limit) + 1;
+      writeBytes(buf, len * dst_bytes);
+    } while (length -= len);
+  }
+
+  void Bus_Stream::writePixels(pixelcopy_t* param, uint32_t length)
+  {
+    const uint8_t dst_bytes = param->dst_bits >> 3;
+    uint32_t limit = 32 / dst_bytes;
+    uint32_t len;
+    uint8_t buf[32];
+    do
+    {
+      len = ((length - 1) % limit) + 1;
+      param->fp_copy(buf, 0, len, param);
+      writeBytes(buf, len * dst_bytes);
+    } while (length -= len);
+  }
+
+  void Bus_Stream::writeBytes(const uint8_t* data, uint32_t length)
+  {
+    _cfg.stream->write(data, length);
+  }
+
+  uint32_t Bus_Stream::readData(uint_fast8_t bit_length)
+  {
+    const uint8_t dst_bytes = bit_length >> 3;
+    uint32_t res;
+    _cfg.stream->readBytes(reinterpret_cast<uint8_t*>(&res), dst_bytes);
+    return res;
+  }
+
+  bool Bus_Stream::readBytes(uint8_t* dst, uint32_t length, bool use_dma)
+  {
+    _cfg.stream->readBytes(dst, length);
+    return true;
+  }
+
+  void Bus_Stream::readPixels(void* dst, pixelcopy_t* param, uint32_t length)
+  {
+    beginRead();
+    const auto bytes = param->src_bits >> 3;
+    uint32_t regbuf[8];
+    uint32_t limit = 32 / bytes;
+
+    param->src_data = regbuf;
+    int32_t dstindex = 0;
+    do {
+      uint32_t len = (limit > length) ? length : limit;
+      length -= len;
+      _cfg.stream->readBytes((uint8_t*)regbuf, len * bytes);
+      param->src_x = 0;
+      dstindex = param->fp_copy(dst, dstindex, dstindex + len, param);
+    } while (length);
+  }
+
+//----------------------------------------------------------------------------
+ }
+}
+
+#endif
+#endif

--- a/src/lgfx/v1/platforms/arduino_default/Bus_Stream.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_Stream.cpp
@@ -15,9 +15,7 @@ Contributors:
  [mongonta0716](https://github.com/mongonta0716)
  [tobozo](https://github.com/tobozo)
 /----------------------------------------------------------------------------*/
-#if defined (ESP_PLATFORM)
-#include <sdkconfig.h>
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32) || defined (CONFIG_IDF_TARGET_ESP32S2) || defined (CONFIG_IDF_TARGET_ESP32C3)
+#if defined (ARDUINO)
 
 #include "Bus_Stream.hpp"
 #include "../../misc/pixelcopy.hpp"
@@ -126,5 +124,4 @@ namespace lgfx
  }
 }
 
-#endif
 #endif

--- a/src/lgfx/v1/platforms/arduino_default/Bus_Stream.hpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_Stream.hpp
@@ -1,0 +1,81 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include <stdint.h>
+#include <Stream.h>
+
+#include "../../Bus.hpp"
+#include "../common.hpp"
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  class Bus_Stream : public IBus
+  {
+  public:
+    struct config_t
+    {
+      Stream* stream = nullptr;
+    };
+
+    const config_t& config(void) const { return _cfg; }
+
+    void config(const config_t& config);
+
+    bus_type_t busType(void) const override { return bus_type_t::bus_stream; }
+
+    bool init(void) override {return true;}
+    void release(void) override {}
+
+    void beginTransaction(void) override {}
+    void endTransaction(void) override {}
+    void wait(void) override {}
+    bool busy(void) const override {return false;}
+
+    void flush(void) override {}
+    bool writeCommand(uint32_t data, uint_fast8_t bit_length) override {return false;}
+    void writeData(uint32_t data, uint_fast8_t bit_length) override;
+    void writeDataRepeat(uint32_t data, uint_fast8_t bit_length, uint32_t count) override;
+    void writePixels(pixelcopy_t* param, uint32_t length) override;
+    void writeBytes(const uint8_t* data, uint32_t length, bool dc, bool use_dma) override { writeBytes(data, length); }
+
+    void initDMA(void) override {}
+    void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length); }
+    void execDMAQueue(void) {}
+    uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+
+    void beginRead(void) override {}
+    void endRead(void) override {}
+    uint32_t readData(uint_fast8_t bit_length) override;
+    bool readBytes(uint8_t* dst, uint32_t length, bool use_dma) override;
+    void readPixels(void* dst, pixelcopy_t* param, uint32_t length) override;
+
+  private:
+    void writeBytes(const uint8_t* data, uint32_t length);
+    config_t _cfg;
+    SimpleBuffer _flip_buffer;
+
+  };
+
+//----------------------------------------------------------------------------
+ }
+}


### PR DESCRIPTION
　ATOM Printer 等のプリンターを液晶デバイスに見立てて、LovyanGFX から印刷できるようにするにあたり、Serial や TCP-Socket で接続できるよう bus_type_t に bus_stream を追加し、対応する派生クラスも Bus_Stream として備わっていると都合がいいと思って PR いたします。

　今回はプリンターですが、（あるかどうか分からないですが）シリアル接続の液晶デバイスに対応する場合にも広く使って頂けるのではないかと。

 理論的には TCP-Socket でも大丈夫なはずなので、場所の離れたデバイスを描画させる場合にも使えるのではないかと思ってます。

　Bus_I2C を見本に作りましたが、至らぬところが多々あると思いますが、たたき台として宜しくお願いいたします。