### PR TITLE
SdFat のバージョンを判定し、～2.1.1 にも対応

### DIFF
--- a/src/lgfx/v1/LGFX_Sprite.hpp
+++ b/src/lgfx/v1/LGFX_Sprite.hpp
@@ -196,13 +196,21 @@ namespace lgfx
     }
 
 #if defined (SdFat_h)
-
+  #if SD_FAT_VERSION >= 20102
     inline void createFromBmp(SdBase<FsVolume, FsFormatter> &fs, const char *path) { createFromBmpFile(fs, path); }
     void createFromBmpFile(SdBase<FsVolume, FsFormatter> &fs, const char *path) {
       SdFatWrapper file;
       file.setFS(fs);
       createFromBmpFile(&file, path);
     }
+  #else
+    inline void createFromBmp(SdBase<FsVolume> &fs, const char *path) { createFromBmpFile(fs, path); }
+    void createFromBmpFile(SdBase<FsVolume> &fs, const char *path) {
+      SdFatWrapper file;
+      file.setFS(fs);
+      createFromBmpFile(&file, path);
+    }
+  #endif
 
 #endif
 

--- a/src/lgfx/v1/lgfx_filesystem_support.hpp
+++ b/src/lgfx/v1/lgfx_filesystem_support.hpp
@@ -176,7 +176,7 @@ namespace lgfx
  #endif
 
  #if defined (SdFat_h)
-
+  #if SD_FAT_VERSION >= 20102
     void loadFont(const char *path, SdBase<FsVolume, FsFormatter> &fs)
     {
       init_font_file<SdFatWrapper>(fs);
@@ -251,7 +251,82 @@ namespace lgfx
       SdFatWrapper data(fs, file);
       return this->draw_png(&data, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
     }
+  #else
+    void loadFont(const char *path, SdBase<FsVolume> &fs)
+    {
+      init_font_file<SdFatWrapper>(fs);
+      load_font_with_path(path);
+    }
 
+    void loadFont(SdBase<FsVolume> &fs, const char *path)
+    {
+      init_font_file<SdFatWrapper>(fs);
+      load_font_with_path(path);
+    }
+
+    inline bool drawBmp(SdBase<FsVolume> &fs, const char *path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      return drawBmpFile(fs, path, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+    inline bool drawBmpFile(SdBase<FsVolume> &fs, const char *path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      SdFatWrapper file(fs);
+      return this->drawBmpFile(&file, path, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+    inline bool drawBmpFile(SdBase<FsVolume> &fs, const String& path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      return drawBmpFile(fs, path.c_str(), x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+
+    inline bool drawJpgFile(SdBase<FsVolume> &fs, const char *path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      SdFatWrapper file(fs);
+      return this->drawJpgFile(&file, path, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+    inline bool drawJpgFile(SdBase<FsVolume> &fs, const String& path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      return drawJpgFile(fs, path.c_str(), x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+    [[deprecated("use float scale")]]
+    inline bool drawJpgFile(SdBase<FsVolume> &fs, const char *path, int32_t x, int32_t y, int32_t maxWidth, int32_t maxHeight, int32_t offX, int32_t offY, jpeg_div::jpeg_div_t scale)
+    {
+      return drawJpgFile(fs, path, x, y, maxWidth, maxHeight, offX, offY, 1.0f / (1 << scale));
+    }
+
+    inline bool drawPngFile(SdBase<FsVolume> &fs, const char *path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      SdFatWrapper file(fs);
+      return this->drawPngFile(&file, path, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+    inline bool drawPngFile(SdBase<FsVolume> &fs, const String& path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      return drawPngFile(fs, path.c_str(), x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+
+
+    inline bool drawBmpFile(SdBase<FsVolume> &fs, FsFile *file, int32_t x=0, int32_t y=0, int32_t maxWidth=0, int32_t maxHeight=0, int32_t offX=0, int32_t offY=0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      SdFatWrapper data(fs, file);
+      return this->draw_bmp(&data, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+
+    inline bool drawJpgFile(SdBase<FsVolume> &fs, FsFile *file, int32_t x=0, int32_t y=0, int32_t maxWidth=0, int32_t maxHeight=0, int32_t offX=0, int32_t offY=0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      SdFatWrapper data(fs, file);
+      return this->draw_jpg(&data, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+    [[deprecated("use float scale")]]
+    inline bool drawJpgFile(SdBase<FsVolume> &fs, FsFile *file, int32_t x, int32_t y, int32_t maxWidth, int32_t maxHeight, int32_t offX, int32_t offY, jpeg_div::jpeg_div_t scale)
+    {
+      return drawJpgFile(fs, file, x, y, maxWidth, maxHeight, offX, offY, 1.0f / (1 << scale));
+    }
+
+    inline bool drawPngFile(SdBase<FsVolume> &fs, FsFile *file, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left)
+    {
+      SdFatWrapper data(fs, file);
+      return this->draw_png(&data, x, y, maxWidth, maxHeight, offX, offY, scale_x, scale_y, datum);
+    }
+  #endif
  #endif
 
  #if defined (Stream_h)


### PR DESCRIPTION
https://github.com/lovyan03/LovyanGFX/pull/182　をマージして頂いたため、
今度は SdFat v.2.1.1 までを利用時にコンパイルエラーが出るようになってしまいました。

SdFat のバージョンを判定し、～v2.1.1／v2.1.2～ を切り替え、どちらの場合でもコンパイルできるようにしました。
