### PR TITLE
Linux panel framebuffer simple support

### DIFF
--- a/examples/Advanced/CMake_FrameBuffer/CMakeLists.txt
+++ b/examples/Advanced/CMake_FrameBuffer/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required (VERSION 3.8)
+project(LGFXFB)
+
+file(GLOB Target_Files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS 
+    *.cpp
+    LovyanGFX/src/lgfx/Fonts/efont/*.c
+    LovyanGFX/src/lgfx/Fonts/IPA/*.c
+    LovyanGFX/src/lgfx/utility/*.c
+    LovyanGFX/src/lgfx/v1/*.cpp
+    LovyanGFX/src/lgfx/v1/misc/*.cpp
+    LovyanGFX/src/lgfx/v1/panel/*.cpp
+    LovyanGFX/src/lgfx/v1/platforms/framebuffer/*.cpp
+    )
+
+add_executable (LGFXFB ${Target_Files})
+target_include_directories(LGFXFB PUBLIC "LovyanGFX/src/")
+target_compile_features(LGFXFB PUBLIC cxx_std_17)
+target_link_libraries(LGFXFB -lpthread)

--- a/examples/Advanced/CMake_FrameBuffer/LGFXFrameBuffer.cpp
+++ b/examples/Advanced/CMake_FrameBuffer/LGFXFrameBuffer.cpp
@@ -1,0 +1,34 @@
+﻿#include <stdio.h>  // for drawBmpFile / drawJpgFile / drawPngFile
+
+#define LGFX_USE_V1
+#include <LovyanGFX.hpp>
+#include <LGFX_AUTODETECT.hpp>
+
+#define SCREEN_X 320
+#define SCREEN_Y 240
+
+LGFX lcd ( SCREEN_X, SCREEN_Y );
+
+int32_t target_x = (SCREEN_X / 2) * 256;
+int32_t target_y = (SCREEN_Y / 2) * 256;
+int32_t current_x = 0;
+int32_t current_y = 0;
+int32_t add_x = 0;
+int32_t add_y = 0;
+
+void setup()
+{
+  lcd.init();
+}
+
+void loop()
+{
+  static int i;
+  ++i;
+  lcd.fillCircle(current_x >> 8, current_y >> 8, 5, i);
+  current_x += add_x;
+  current_y += add_y;
+  add_x += (current_x < target_x) ? 1 : -1;
+  add_y += (current_y < target_y) ? 1 : -1;
+  lgfx::delay(1);
+}

--- a/examples/Advanced/CMake_FrameBuffer/main.cpp
+++ b/examples/Advanced/CMake_FrameBuffer/main.cpp
@@ -1,0 +1,28 @@
+#include <linux/fb.h>
+#include <thread>
+
+#define LGFX_USE_V1
+#include <LovyanGFX.hpp>
+#include <LGFX_AUTODETECT.hpp>
+
+void setup(void);
+void loop(void);
+
+void loopThread(void)
+{
+  setup();
+  for (;;)
+  {
+    loop();
+    std::this_thread::yield();
+  }
+}
+
+int main(int, char**)
+{
+  std::thread sub_thread(loopThread);
+  for (;;)
+  {
+    std::this_thread::yield();
+  }
+}

--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -33,6 +33,7 @@ namespace lgfx
     , board_PyBadge
     , board_M5Tough
     , board_OpenCV
+    , board_FrameBuffer
     , board_M5Station
     , board_ESPboy
     , board_M5UnitLCD

--- a/src/lgfx/v1/LGFX_Sprite.cpp
+++ b/src/lgfx/v1/LGFX_Sprite.cpp
@@ -152,10 +152,10 @@ namespace lgfx
 
   void Panel_Sprite::setWindow(uint_fast16_t xs, uint_fast16_t ys, uint_fast16_t xe, uint_fast16_t ye)
   {
-    xs = std::max(0u, std::min<uint_fast16_t>(_width  - 1, xs));
-    xe = std::max(0u, std::min<uint_fast16_t>(_width  - 1, xe));
-    ys = std::max(0u, std::min<uint_fast16_t>(_height - 1, ys));
-    ye = std::max(0u, std::min<uint_fast16_t>(_height - 1, ye));
+    xs = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_width  - 1, xs));
+    xe = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_width  - 1, xe));
+    ys = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_height - 1, ys));
+    ye = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_height - 1, ye));
     _xpos = xs;
     _xs = xs;
     _xe = xe;

--- a/src/lgfx/v1/LGFX_Sprite.cpp
+++ b/src/lgfx/v1/LGFX_Sprite.cpp
@@ -152,10 +152,10 @@ namespace lgfx
 
   void Panel_Sprite::setWindow(uint_fast16_t xs, uint_fast16_t ys, uint_fast16_t xe, uint_fast16_t ye)
   {
-    xs = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_width  - 1, xs));
-    xe = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_width  - 1, xe));
-    ys = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_height - 1, ys));
-    ye = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_height - 1, ye));
+    xs = std::max<uint_fast16_t>(0u, std::min<uint_fast16_t>(_width  - 1, xs));
+    xe = std::max<uint_fast16_t>(0u, std::min<uint_fast16_t>(_width  - 1, xe));
+    ys = std::max<uint_fast16_t>(0u, std::min<uint_fast16_t>(_height - 1, ys));
+    ye = std::max<uint_fast16_t>(0u, std::min<uint_fast16_t>(_height - 1, ye));
     _xpos = xs;
     _xs = xs;
     _xe = xe;

--- a/src/lgfx/v1/platforms/common.hpp
+++ b/src/lgfx/v1/platforms/common.hpp
@@ -14,6 +14,7 @@ Contributors:
  [ciniml](https://github.com/ciniml)
  [mongonta0716](https://github.com/mongonta0716)
  [tobozo](https://github.com/tobozo)
+ [imliubo](https://github.com/imliubo)
 /----------------------------------------------------------------------------*/
 #pragma once
 
@@ -52,6 +53,10 @@ Contributors:
 #elif defined (_WIN32) || __has_include(<opencv2/opencv.hpp>)
 
 #include "opencv/common.hpp"
+
+#elif defined (__linux__)
+
+#include "framebuffer/common.hpp"
 
 #endif
 

--- a/src/lgfx/v1/platforms/framebuffer/Panel_fb.cpp
+++ b/src/lgfx/v1/platforms/framebuffer/Panel_fb.cpp
@@ -29,23 +29,12 @@ namespace lgfx
 {
  inline namespace v1
  {
-  struct fb_info_t
-  {
-    Panel_fb* panel;
-    // TODO
-    const char* window_name;
-    //bool init;
-  };
-  static std::list<fb_info_t> _list_mat;
-  static int _window_no;
-
 //----------------------------------------------------------------------------
   void Panel_fb::fb_draw_rgb_pixel(int x, int y, uint32_t rawcolor)
   {
     unsigned int pix_offset = 0;
     uint8_t r = 0, g = 0, b = 0;
 
-    // TODO
     // GGGBBBBB RRRRRGGG
     if (_write_depth = color_depth_t::rgb565_2Byte)
     {
@@ -154,7 +143,7 @@ namespace lgfx
 
   void Panel_fb::display(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h)
   {
-    // TODO
+    // Nothings to do
   }
 
   color_depth_t Panel_fb::setColorDepth(color_depth_t depth)
@@ -278,6 +267,7 @@ namespace lgfx
 
   void Panel_fb::_rotate_pixelcopy(uint_fast16_t& x, uint_fast16_t& y, uint_fast16_t& w, uint_fast16_t& h, pixelcopy_t* param, uint32_t& nextx, uint32_t& nexty)
   {
+    // NOT TEST
     uint32_t addx = param->src_x32_add;
     uint32_t addy = param->src_y32_add;
     uint_fast8_t r = _internal_rotation;
@@ -309,6 +299,7 @@ namespace lgfx
 
   void Panel_fb::writePixels(pixelcopy_t* param, uint32_t length, bool use_dma)
   {
+    // NOT TEST
     uint_fast16_t xs = _xs;
     uint_fast16_t xe = _xe;
     uint_fast16_t ys = _ys;
@@ -412,6 +403,7 @@ namespace lgfx
 
   void Panel_fb::writeImage(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param, bool)
   {
+    // NOT TEST
     uint_fast8_t r = _internal_rotation;
     if (r == 0 && param->transp == pixelcopy_t::NON_TRANSP && param->no_convert)
     {
@@ -462,6 +454,7 @@ namespace lgfx
 
   void Panel_fb::writeImageARGB(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param)
   {
+    // NOT TEST
     uint32_t nextx = 0;
     uint32_t nexty = 1 << pixelcopy_t::FP_SCALE;
     if (_internal_rotation)
@@ -491,12 +484,34 @@ namespace lgfx
 
   void Panel_fb::copyRect(uint_fast16_t dst_x, uint_fast16_t dst_y, uint_fast16_t w, uint_fast16_t h, uint_fast16_t src_x, uint_fast16_t src_y)
   {
-    // TODO
+
+    uint_fast8_t r = _internal_rotation;
+    if (r)
+    {
+      if ((1u << r) & 0b10010110) { src_y = _height - (src_y + h); dst_y = _height - (dst_y + h); }
+      if (r & 2)                  { src_x = _width  - (src_x + w); dst_x = _width  - (dst_x + w); }
+      if (r & 1) { std::swap(src_x, src_y);  std::swap(dst_x, dst_y);  std::swap(w, h); }
+    }
+
+    if ((dst_x + w) > _var_info.xres) w = _var_info.xres - dst_x;
+    if ((dst_y + h) > _var_info.yres) h = _var_info.yres - dst_y;
+    size_t bytes = _write_bits >> 3;
+    size_t len = w * bytes;
+    int32_t add = _var_info.xres * bytes;  // _cfg.panel_width may not was the screen width, use _var_info.xres instead.
+    char *src = (_fbp + (src_x * bytes + src_y * _fix_info.line_length));
+    char *dst = (_fbp + (dst_x * bytes + dst_y * _fix_info.line_length));
+
+    do
+    {
+      memmove(dst, src, len);
+      src += add;
+      dst += add;
+    } while (--h);
   }
 
   uint_fast8_t Panel_fb::getTouchRaw(touch_point_t* tp, uint_fast8_t count)
   {
-     memcpy(tp, &_touch_point, sizeof(touch_point_t));
+    memcpy(tp, &_touch_point, sizeof(touch_point_t));
     return _touch_point.size ? 1 : 0;
   }
 

--- a/src/lgfx/v1/platforms/framebuffer/Panel_fb.cpp
+++ b/src/lgfx/v1/platforms/framebuffer/Panel_fb.cpp
@@ -1,0 +1,507 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+ [imliubo](https://github.com/imliubo)
+/----------------------------------------------------------------------------*/
+#if defined (__linux__)
+
+#include "Panel_fb.hpp"
+
+#include "../common.hpp"
+#include "../../Bus.hpp"
+
+#include <list>
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+  struct fb_info_t
+  {
+    Panel_fb* panel;
+    // TODO
+    const char* window_name;
+    //bool init;
+  };
+  static std::list<fb_info_t> _list_mat;
+  static int _window_no;
+
+//----------------------------------------------------------------------------
+  void Panel_fb::fb_draw_rgb_pixel(int x, int y, uint32_t rawcolor)
+  {
+    unsigned int pix_offset = 0;
+    uint8_t r = 0, g = 0, b = 0;
+
+    // TODO
+    // GGGBBBBB RRRRRGGG
+    if (_write_depth = color_depth_t::rgb565_2Byte)
+    {
+      b = (uint8_t)((rawcolor >> 8) & 0b11111);
+      g = (uint8_t)((((rawcolor >> 10) & 0b111000)) | (rawcolor & 0b111));
+      r = (uint8_t)((rawcolor >> 3) & 0b11111);
+
+      pix_offset = x * 2 + y * _fix_info.line_length;
+      unsigned short c = (r << 11) | (g << 5) | b;
+      // write 'two bytes at once'
+      *((unsigned short*)(_fbp + pix_offset)) = c;
+    }
+    // BBBBBBBB GGGGGGGG RRRRRRRR
+    else if (_write_depth = color_depth_t::rgb888_3Byte)
+    {
+      b = (uint8_t)((rawcolor >> 16) & 0xff);
+      g = (uint8_t)((rawcolor >> 8) & 0xff);
+      r = (uint8_t)((rawcolor >> 0) & 0xff);
+
+      pix_offset = x * 3 + y * _fix_info.line_length;
+      *((char*)(_fbp + pix_offset)) = b;
+      *((char*)(_fbp + pix_offset + 1)) = g;
+      *((char*)(_fbp + pix_offset + 2)) = r;
+    }
+  }
+
+  void Panel_fb::fb_draw_argb_pixel(int x, int y, uint32_t rawcolor)
+  {
+    unsigned int pix_offset = x * 4 + y * _fix_info.line_length;
+
+    uint8_t r = 0, g = 0, b = 0, a = 0;
+
+    // BBBBBBBB GGGGGGGG RRRRRRRR AAAAAAAA
+    b = (uint8_t)((rawcolor >> 24) & 0xff);
+    g = (uint8_t)((rawcolor >> 16) & 0xff);
+    r = (uint8_t)((rawcolor >> 8) & 0xff);
+    a = (uint8_t)((rawcolor >> 0) & 0xff);
+    
+    *((char*)(_fbp + pix_offset)) = b;
+    *((char*)(_fbp + pix_offset + 1)) = g;
+    *((char*)(_fbp + pix_offset + 2)) = r;
+    *((char*)(_fbp + pix_offset + 3)) = a;
+  }
+
+  Panel_fb::~Panel_fb(void)
+  {
+    // unmap fb file from memory
+    munmap(_fbp, _screensize);
+    // reset the display mode
+    if (ioctl(_fbfd, FBIOPUT_VSCREENINFO, &_fix_info)) {
+        printf("Error re-setting variable information.\n");
+    }
+    // close fb file    
+    close(_fbfd);
+
+    memset(&_fix_info, 0, sizeof(_fix_info));
+    memset(&_var_info, 0, sizeof(_fix_info));
+  }
+
+  Panel_fb::Panel_fb(void) : Panel_Device(), _fbp(nullptr)
+  {
+    _fbp = 0;
+  }
+
+  bool Panel_fb::init(bool use_reset)
+  {
+    // TODO
+    // default: /dev/fb0
+    // Open the file for reading and writing
+    _fbfd = open("/dev/fb0", O_RDWR);
+    if (_fbfd == -1) {
+        printf("Error: cannot open framebuffer device.\n");
+        return 1;
+    }
+    // printf("The framebuffer device was opened successfully.\n");
+
+    // Get variable screen information
+    if (ioctl(_fbfd, FBIOGET_VSCREENINFO, &_var_info)) {
+        printf("Error reading variable information.\n");
+        return 1;
+    }
+    // printf("%dx%d, %dbpp\n", _var_info.xres, _var_info.yres, _var_info.bits_per_pixel);
+
+    // 16/24/32
+    setColorDepth((color_depth_t)_var_info.bits_per_pixel);
+
+    // Get fixed screen information
+    if (ioctl(_fbfd, FBIOGET_FSCREENINFO, &_fix_info)) {
+        printf("Error reading fixed information.\n");
+        return 1;
+    }
+
+    // Figure out the size of the screen in bytes
+    _screensize = _fix_info.smem_len;  //finfo.line_length * vinfo.yres;    
+
+    // Map the device to memory
+    _fbp = (char *)mmap(0, _screensize, PROT_READ | PROT_WRITE, MAP_SHARED, _fbfd, 0);
+    if((intptr_t)_fbp == -1) {
+        perror("Error: failed to map framebuffer device to memory");
+        return 1;
+    }
+    memset(_fbp, 0, _screensize);
+
+    return Panel_Device::init(use_reset);
+  }
+
+  void Panel_fb::display(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h)
+  {
+    // TODO
+  }
+
+  color_depth_t Panel_fb::setColorDepth(color_depth_t depth)
+  {
+    // TODO
+    _write_bits = depth;
+    _read_bits = depth;
+    _write_depth = depth;
+    _read_depth = depth;
+    return depth;
+  }
+
+  void Panel_fb::beginTransaction(void) {}
+
+  void Panel_fb::endTransaction(void) {}
+
+  void Panel_fb::setRotation(uint_fast8_t r)
+  {
+    r &= 7;
+    _rotation = r;
+    _internal_rotation = ((r + _cfg.offset_rotation) & 3) | ((r & 4) ^ (_cfg.offset_rotation & 4));
+
+    _width  = _cfg.panel_width;
+    _height = _cfg.panel_height;
+    if (_internal_rotation & 1) std::swap(_width, _height);
+  }
+
+  void Panel_fb::setWindow(uint_fast16_t xs, uint_fast16_t ys, uint_fast16_t xe, uint_fast16_t ye)
+  {
+    xs = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_width  - 1, xs));
+    xe = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_width  - 1, xe));
+    ys = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_height - 1, ys));
+    ye = std::max<unsigned long>(0u, std::min<uint_fast16_t>(_height - 1, ye));
+    _xpos = xs;
+    _xs = xs;
+    _xe = xe;
+    _ypos = ys;
+    _ys = ys;
+    _ye = ye;
+  }
+
+  void Panel_fb::drawPixelPreclipped(uint_fast16_t x, uint_fast16_t y, uint32_t rawcolor)
+  {
+    uint_fast8_t rotation = _internal_rotation;
+    if (rotation)
+    {
+      if ((1u << rotation) & 0b10010110) { y = _height - (y + 1); }
+      if (rotation & 2)                  { x = _width  - (x + 1); }
+      if (rotation & 1) { std::swap(x, y); }
+    }
+
+    switch (_write_depth)
+    {
+      case color_depth_t::rgb565_2Byte:
+      case color_depth_t::rgb888_3Byte:
+        fb_draw_rgb_pixel(x, y, rawcolor);
+        break;
+      case color_depth_t::argb8888_4Byte:
+        fb_draw_argb_pixel(x, y, rawcolor);
+        break;
+      default:
+        break;
+    }
+
+    if (!getStartCount())
+    {
+      display(x, y, 1, 1);
+    }
+  }
+
+  void Panel_fb::writeFillRectPreclipped(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, uint32_t rawcolor)
+  {
+    uint_fast8_t rotation = _internal_rotation;
+    if (rotation)
+    {
+      if ((1u << rotation) & 0b10010110) { y = _height - (y + 1); }
+      if (rotation & 2)                  { x = _width  - (x + 1); }
+      if (rotation & 1) { std::swap(x, y); }
+    }
+
+    for (size_t width = 0; width < w; width++)
+    {
+      for (size_t height = 0; height < h; height++)
+      {
+        uint_fast16_t x_pos = x + width;
+        uint_fast16_t y_pos = y + height;
+
+        switch (_write_depth)
+        {
+          case color_depth_t::rgb565_2Byte:
+          case color_depth_t::rgb888_3Byte:
+            fb_draw_rgb_pixel(x_pos, y_pos, rawcolor);
+            break;
+          case color_depth_t::argb8888_4Byte:
+            fb_draw_argb_pixel(x_pos, y_pos, rawcolor);
+            break;
+          default:
+            break;
+        }
+      }
+    }
+  }
+
+  void Panel_fb::writeBlock(uint32_t rawcolor, uint32_t length)
+  {
+    do
+    {
+      uint32_t h = 1;
+      auto w = std::min<uint32_t>(length, _xe + 1 - _xpos);
+      if (length >= (w << 1) && _xpos == _xs)
+      {
+        h = std::min<uint32_t>(length / w, _ye + 1 - _ypos);
+      }
+      writeFillRectPreclipped(_xpos, _ypos, w, h, rawcolor);
+      if ((_xpos += w) <= _xe) return;
+      _xpos = _xs;
+      if (_ye < (_ypos += h)) { _ypos = _ys; }
+      length -= w * h;
+    } while (length);
+  }
+
+  void Panel_fb::_rotate_pixelcopy(uint_fast16_t& x, uint_fast16_t& y, uint_fast16_t& w, uint_fast16_t& h, pixelcopy_t* param, uint32_t& nextx, uint32_t& nexty)
+  {
+    uint32_t addx = param->src_x32_add;
+    uint32_t addy = param->src_y32_add;
+    uint_fast8_t r = _internal_rotation;
+    uint_fast8_t bitr = 1u << r;
+    if (bitr & 0b10010110) // case 1:2:4:7:
+    {
+      param->src_y32 += nexty * (h - 1);
+      nexty = -(int32_t)nexty;
+      y = _height - (y + h);
+    }
+    if (r & 2)
+    {
+      param->src_x32 += addx * (w - 1);
+      param->src_y32 += addy * (w - 1);
+      addx = -(int32_t)addx;
+      addy = -(int32_t)addy;
+      x = _width  - (x + w);
+    }
+    if (r & 1)
+    {
+      std::swap(x, y);
+      std::swap(w, h);
+      std::swap(nextx, addx);
+      std::swap(nexty, addy);
+    }
+    param->src_x32_add = addx;
+    param->src_y32_add = addy;
+  }
+
+  void Panel_fb::writePixels(pixelcopy_t* param, uint32_t length, bool use_dma)
+  {
+    uint_fast16_t xs = _xs;
+    uint_fast16_t xe = _xe;
+    uint_fast16_t ys = _ys;
+    uint_fast16_t ye = _ye;
+    uint_fast16_t x = _xpos;
+    uint_fast16_t y = _ypos;
+    const size_t bits = _write_bits;
+    auto k = _cfg.panel_width * bits >> 3;
+
+    uint_fast8_t r = _internal_rotation;
+    if (!r)
+    {
+      uint_fast16_t linelength;
+      do {
+        linelength = std::min<uint_fast16_t>(xe - x + 1, length);
+        param->fp_copy(&_fbp[y * k], x, x + linelength, param);
+        if ((x += linelength) > xe)
+        {
+          x = xs;
+          y = (y != ye) ? (y + 1) : ys;
+        }
+      } while (length -= linelength);
+      _xpos = x;
+      _ypos = y;
+      return;
+    }
+
+    int_fast16_t ax = 1;
+    int_fast16_t ay = 1;
+    if ((1u << r) & 0b10010110) { y = _height - (y + 1); ys = _height - (ys + 1); ye = _height - (ye + 1); ay = -1; }
+    if (r & 2)                  { x = _width  - (x + 1); xs = _width  - (xs + 1); xe = _width  - (xe + 1); ax = -1; }
+    if (param->no_convert)
+    {
+      size_t bytes = bits >> 3;
+      size_t xw = 1;
+      size_t yw = _cfg.panel_width;
+      if (r & 1) std::swap(xw, yw);
+      size_t idx = y * yw + x * xw;
+      auto data = (uint8_t*)param->src_data;
+      do
+      {
+        auto dst = &_fbp[idx * bytes];
+        size_t b = 0;
+        do
+        {
+          dst[b] = *data++;
+        } while (++b < bytes);
+        if (x != xe)
+        {
+          idx += xw * ax;
+          x += ax;
+        }
+        else
+        {
+          x = xs;
+          y = (y != ye) ? (y + ay) : ys;
+          idx = y * yw + x * xw;
+        }
+      } while (--length);
+    }
+    else
+    {
+      if (r & 1)
+      {
+        do
+        {
+          param->fp_copy(&_fbp[x * k], y, y + 1, param);
+          if (x != xe)
+          {
+            x += ax;
+          }
+          else
+          {
+            x = xs;
+            y = (y != ye) ? (y + ay) : ys;
+          }
+        } while (--length);
+      }
+      else
+      {
+        do
+        {
+          param->fp_copy(&_fbp[y * k], x, x + 1, param);
+          if (x != xe)
+          {
+            x += ax;
+          }
+          else
+          {
+            x = xs;
+            y = (y != ye) ? (y + ay) : ys;
+          }
+        } while (--length);
+      }
+    }
+    if ((1u << r) & 0b10010110) { y = _height - (y + 1); }
+    if (r & 2)                  { x = _width  - (x + 1); }
+    _xpos = x;
+    _ypos = y;
+  }
+
+  void Panel_fb::writeImage(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param, bool)
+  {
+    uint_fast8_t r = _internal_rotation;
+    if (r == 0 && param->transp == pixelcopy_t::NON_TRANSP && param->no_convert)
+    {
+      auto sx = param->src_x;
+      auto bits = param->src_bits;
+
+      auto bw = _cfg.panel_width * bits >> 3;
+      auto dst = &_fbp[bw * y];
+      auto sw = param->src_bitwidth * bits >> 3;
+      auto src = &((uint8_t*)param->src_data)[param->src_y * sw];
+      if (sw == bw && this->_cfg.panel_width == w && sx == 0 && x == 0)
+      {
+        memcpy(dst, src, bw * h);
+        return;
+      }
+      y = 0;
+      dst +=  x * bits >> 3;
+      src += sx * bits >> 3;
+      w    =  w * bits >> 3;
+      do
+      {
+        memcpy(&dst[y * bw], &src[y * sw], w);
+      } while (++y != h);
+      return;
+    }
+
+    uint32_t nextx = 0;
+    uint32_t nexty = 1 << pixelcopy_t::FP_SCALE;
+    if (r)
+    {
+      _rotate_pixelcopy(x, y, w, h, param, nextx, nexty);
+    }
+    uint32_t sx32 = param->src_x32;
+    uint32_t sy32 = param->src_y32;
+
+    y *= _cfg.panel_width;
+    do
+    {
+      int32_t pos = x + y;
+      int32_t end = pos + w;
+      while (end != (pos = param->fp_copy(_fbp, pos, end, param))
+         &&  end != (pos = param->fp_skip(      pos, end, param)));
+      param->src_x32 = (sx32 += nextx);
+      param->src_y32 = (sy32 += nexty);
+      y += _cfg.panel_width;
+    } while (--h);
+  }
+
+  void Panel_fb::writeImageARGB(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param)
+  {
+    uint32_t nextx = 0;
+    uint32_t nexty = 1 << pixelcopy_t::FP_SCALE;
+    if (_internal_rotation)
+    {
+      _rotate_pixelcopy(x, y, w, h, param, nextx, nexty);
+    }
+    uint32_t sx32 = param->src_x32;
+    uint32_t sy32 = param->src_y32;
+
+    uint32_t pos = x + y * _cfg.panel_width;
+    uint32_t end = pos + w;
+    param->fp_copy(_fbp, pos, end, param);
+    while (--h)
+    {
+      pos += _cfg.panel_width;
+      end = pos + w;
+      param->src_x32 = (sx32 += nextx);
+      param->src_y32 = (sy32 += nexty);
+      param->fp_copy(_fbp, pos, end, param);
+    }
+  }
+
+  void Panel_fb::readRect(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, void* dst, pixelcopy_t* param)
+  {
+    // TODO
+  }
+
+  void Panel_fb::copyRect(uint_fast16_t dst_x, uint_fast16_t dst_y, uint_fast16_t w, uint_fast16_t h, uint_fast16_t src_x, uint_fast16_t src_y)
+  {
+    // TODO
+  }
+
+  uint_fast8_t Panel_fb::getTouchRaw(touch_point_t* tp, uint_fast8_t count)
+  {
+     memcpy(tp, &_touch_point, sizeof(touch_point_t));
+    return _touch_point.size ? 1 : 0;
+  }
+
+//----------------------------------------------------------------------------
+ }
+}
+
+#endif

--- a/src/lgfx/v1/platforms/framebuffer/Panel_fb.hpp
+++ b/src/lgfx/v1/platforms/framebuffer/Panel_fb.hpp
@@ -1,0 +1,94 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+ [imliubo](https://github.com/imliubo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../../panel/Panel_Device.hpp"
+#include "../../misc/range.hpp"
+#include "../../Touch.hpp"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <linux/fb.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  struct Panel_fb : public Panel_Device
+  {
+
+  public:
+    Panel_fb(void);
+    virtual ~Panel_fb(void);
+
+    bool init(bool use_reset) override;
+    void beginTransaction(void) override;
+    void endTransaction(void) override;
+
+    color_depth_t setColorDepth(color_depth_t depth);
+    void setRotation(uint_fast8_t r) override;
+    void setInvert(bool invert) override {}
+    void setSleep(bool flg) override {}
+    void setPowerSave(bool) override {}
+
+    void waitDisplay(void) override {}
+    bool displayBusy(void) override { return false; }
+
+    void writePixels(pixelcopy_t* param, uint32_t len, bool use_dma) override;
+    void writeBlock(uint32_t rawcolor, uint32_t length) override;
+    void display(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h) override;
+    void setWindow(uint_fast16_t xs, uint_fast16_t ys, uint_fast16_t xe, uint_fast16_t ye) override;
+    void drawPixelPreclipped(uint_fast16_t x, uint_fast16_t y, uint32_t rawcolor) override;
+    void writeFillRectPreclipped(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, uint32_t rawcolor) override;
+    void writeImage(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param, bool use_dma) override;
+    void writeImageARGB(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param) override;
+
+    uint32_t readCommand(uint_fast8_t cmd, uint_fast8_t index, uint_fast8_t len) override { return 0; }
+    uint32_t readData(uint_fast8_t index, uint_fast8_t len) override { return 0; }
+    void readRect(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, void* dst, pixelcopy_t* param) override;
+    void copyRect(uint_fast16_t dst_x, uint_fast16_t dst_y, uint_fast16_t w, uint_fast16_t h, uint_fast16_t src_x, uint_fast16_t src_y) override;
+
+    uint_fast8_t getTouchRaw(touch_point_t* tp, uint_fast8_t count) override;
+
+  private:
+    void fb_draw_rgb_pixel(int x, int y, uint32_t rawcolor);
+    void fb_draw_argb_pixel(int x, int y, uint32_t rawcolor);
+
+  protected:
+    touch_point_t _touch_point;
+    // framebuffer
+    int _fbfd = 0;
+    char* _fbp = 0;
+    long int _screensize = 0;
+    struct fb_var_screeninfo _var_info;
+    struct fb_fix_screeninfo _fix_info;
+
+    int32_t _xpos = 0;
+    int32_t _ypos = 0;
+
+    void _rotate_pixelcopy(uint_fast16_t& x, uint_fast16_t& y, uint_fast16_t& w, uint_fast16_t& h, pixelcopy_t* param, uint32_t& nextx, uint32_t& nexty);
+  };
+
+//----------------------------------------------------------------------------
+ }
+}

--- a/src/lgfx/v1/platforms/framebuffer/common.cpp
+++ b/src/lgfx/v1/platforms/framebuffer/common.cpp
@@ -1,0 +1,119 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+ [imliubo](https://github.com/imliubo)
+/----------------------------------------------------------------------------*/
+#if defined (__linux__)
+
+#include "common.hpp"
+
+#include <linux/fb.h>
+
+#include <chrono>
+#include <thread>
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  unsigned long millis(void)
+  {
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    return (ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+  }
+
+  unsigned long micros(void)
+  {
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    return (ts.tv_sec * 1000000 + ts.tv_nsec / 1000);
+  }
+
+  void delay(unsigned long milliseconds)
+  {
+    if (milliseconds < 20)
+    {
+      delayMicroseconds(milliseconds * 1000);
+    }
+    else
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+    }
+  }
+
+  void delayMicroseconds(unsigned int us)
+  {
+/*
+    std::this_thread::sleep_for(std::chrono::microseconds(us));
+/*/
+    auto start = micros();
+    do
+    {
+      std::this_thread::yield();
+      // for (int i = 0; i < 256; ++i)
+      // {
+      //   __nop();
+      // }
+    } while (micros() - start < us);
+//*/
+  }
+
+//----------------------------------------------------------------------------
+
+  namespace spi
+  {
+    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)  { return cpp::fail(error_t::unknown_err); }
+    void release(int spi_host) {}
+    void beginTransaction(int spi_host, uint32_t freq, int spi_mode) {}
+    void endTransaction(int spi_host) {}
+    void writeBytes(int spi_host, const uint8_t* data, size_t length) {}
+    void readBytes(int spi_host, uint8_t* data, size_t length) {}
+  }
+
+//----------------------------------------------------------------------------
+
+  namespace i2c
+  {
+    cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl) { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> release(int i2c_port) { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read) { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read) { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> endTransaction(int i2c_port) { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length) { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length) { return cpp::fail(error_t::unknown_err); }
+
+//--------
+
+    cpp::result<void, error_t> transactionWrite(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> transactionRead(int i2c_port, int addr, uint8_t *readdata, uint8_t readlen, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> transactionWriteRead(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint8_t *readdata, size_t readlen, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+
+    cpp::result<uint8_t, error_t> readRegister8(int i2c_port, int addr, uint8_t reg, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> writeRegister8(int i2c_port, int addr, uint8_t reg, uint8_t data, uint8_t mask, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+  }
+
+//----------------------------------------------------------------------------
+ }
+}
+
+#endif

--- a/src/lgfx/v1/platforms/framebuffer/common.hpp
+++ b/src/lgfx/v1/platforms/framebuffer/common.hpp
@@ -1,0 +1,81 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+ [imliubo](https://github.com/imliubo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../../misc/DataWrapper.hpp"
+#include "../../misc/enum.hpp"
+#include "../../../utility/result.hpp"
+
+#include <malloc.h>
+#include <stdio.h>
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  unsigned long millis(void);
+
+  unsigned long micros(void);
+
+  void delay(unsigned long milliseconds);
+
+  void delayMicroseconds(unsigned int us);
+
+  static inline void* heap_alloc(      size_t length) { return malloc(length); }
+  static inline void* heap_alloc_psram(size_t length) { return malloc(length); }
+  static inline void* heap_alloc_dma(  size_t length) { return malloc(length); } // aligned_alloc(16, length);
+  static inline void heap_free(void* buf) { free(buf); }
+
+  static inline void gpio_hi(uint32_t pin) { }
+  static inline void gpio_lo(uint32_t pin) { }
+  static inline bool gpio_in(uint32_t pin) { return false; }
+
+  enum pin_mode_t
+  { output
+  , input
+  , input_pullup
+  , input_pulldown
+  };
+
+  static void pinMode(int_fast16_t pin, pin_mode_t mode) {}
+  static void lgfxPinMode(int_fast16_t pin, pin_mode_t mode) {}
+
+//----------------------------------------------------------------------------
+
+  struct FileWrapper : public DataWrapper
+  {
+    FileWrapper() : DataWrapper()
+    {
+      need_transaction = false;
+    }
+    FILE* _fp;
+    bool open(const char* path) override { return (_fp = fopen(path, "rb")); }
+    int read(uint8_t *buf, uint32_t len) override { return fread((char*)buf, 1, len, _fp); }
+    void skip(int32_t offset) override { seek(offset, SEEK_CUR); }
+    bool seek(uint32_t offset) override { return seek(offset, SEEK_SET); }
+    bool seek(uint32_t offset, int origin) { return fseek(_fp, offset, origin); }
+    void close() override { if (_fp) fclose(_fp); }
+    int32_t tell(void) override { return ftell(_fp); }
+  };
+
+//----------------------------------------------------------------------------
+ }
+}

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_FrameBuffer.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_FrameBuffer.hpp
@@ -14,6 +14,7 @@ Contributors:
  [ciniml](https://github.com/ciniml)
  [mongonta0716](https://github.com/mongonta0716)
  [tobozo](https://github.com/tobozo)
+ [imliubo](https://github.com/imliubo)
 /----------------------------------------------------------------------------*/
 #pragma once
 

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_FrameBuffer.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_FrameBuffer.hpp
@@ -1,0 +1,58 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../v1_init.hpp"
+#include "common.hpp"
+#include "../v1/platforms/framebuffer/Panel_fb.hpp"
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  class LGFX : public LGFX_Device
+  {
+    lgfx::Panel_fb _panel_instance;
+
+    bool init_impl(bool use_reset, bool use_clear)
+    {
+      return LGFX_Device::init_impl(false, use_clear);
+    }
+
+  public:
+
+    LGFX(int width = 320, int height = 240)
+    {
+      auto cfg = _panel_instance.config();
+      cfg.memory_width = width;
+      cfg.panel_width = width;
+      cfg.memory_height = height;
+      cfg.panel_height = height;
+      _panel_instance.config(cfg);
+      setPanel(&_panel_instance);
+      _board = board_t::board_FrameBuffer;
+    }
+  };
+
+//----------------------------------------------------------------------------
+ }
+}
+
+using LGFX = lgfx::LGFX;

--- a/src/lgfx/v1_autodetect/common.hpp
+++ b/src/lgfx/v1_autodetect/common.hpp
@@ -59,4 +59,8 @@ Contributors:
 
   #include "LGFX_AutoDetect_OpenCV.hpp"
 
+#elif defined (__linux__)
+
+  #include "LGFX_AutoDetect_FrameBuffer.hpp"
+
 #endif


### PR DESCRIPTION
Not fully completed, only a part of the function is supported.Simple support for Linux, the framebuffer used can run on some embedded Linux development boards, and this method is not recommended for desktop Linux().

1. display is OK.
2. copyRect is OK.
3. writePixels not working.
4. writeImage not working.
5. writeImageARGB not working.
6. touch or mouse not support.

Tested Platforms:

1. PC
2. ARM
3. RISC-V

demo video(running on my PC):
https://user-images.githubusercontent.com/26544331/151314097-96b4cc04-1fb4-41a5-bf4e-d747f60864d7.mp4
