### PR TITLE
feat: Add support for I2C LM27965 LED driver and 4DLCD-35480320-IPS LCD 

### DIFF
--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -62,6 +62,7 @@ jobs:
 
           - arduino-boards-fqbn: esp32:esp32:m5stack-core2
             fancy-name: M5Core2
+            arduino-platform: esp32:esp32:m5stack-core2@2.0.2
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
 
           - arduino-boards-fqbn: esp32:esp32:esp32s3box
@@ -88,6 +89,7 @@ jobs:
         uses: ArminJo/arduino-test-compile@v3
         with:
           arduino-board-fqbn: ${{ matrix.arduino-boards-fqbn }}
+          arduino-platform: ${{ matrix.arduino-platform }}
           platform-url: ${{ matrix.platform-url }}
           required-libraries: ${{ matrix.required-libraries }}
           build-properties: ${{ toJson(matrix.build-properties) }}

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -31,6 +31,7 @@ jobs:
           - esp32:esp32:m5stick-c
           - esp32:esp32:m5stack-core-esp32
           - esp32:esp32:m5stack-core2
+          - esp32:esp32:esp32s3box
           #- esp32:esp32:m5stack-fire
           #- esp32:esp32:odroid_esp32
 
@@ -61,6 +62,10 @@ jobs:
 
           - arduino-boards-fqbn: esp32:esp32:m5stack-core2
             fancy-name: M5Core2
+            platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
+
+          - arduino-boards-fqbn: esp32:esp32:esp32s3box
+            fancy-name: ESP32-S3-Box
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
 
           #- arduino-boards-fqbn: esp32:esp32:m5stack-fire

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -46,6 +46,7 @@ jobs:
 
           - arduino-boards-fqbn: esp32:esp32:esp32
             fancy-name: ESP32 Generic
+            arduino-platform: esp32:esp32@1.0.6
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
 
           - arduino-boards-fqbn: esp32:esp32:esp32s2
@@ -54,10 +55,12 @@ jobs:
 
           - arduino-boards-fqbn: esp32:esp32:m5stick-c
             fancy-name: M5StickC
+            arduino-platform: esp32:esp32@2.0.0
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
 
           - arduino-boards-fqbn: esp32:esp32:m5stack-core-esp32
             fancy-name: M5Stack
+            arduino-platform: esp32:esp32@2.0.1
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
 
           - arduino-boards-fqbn: esp32:esp32:m5stack-core2

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -62,7 +62,7 @@ jobs:
 
           - arduino-boards-fqbn: esp32:esp32:m5stack-core2
             fancy-name: M5Core2
-            arduino-platform: esp32@2.0.2
+            arduino-platform: esp32:esp32@2.0.2
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
 
           - arduino-boards-fqbn: esp32:esp32:esp32s3box

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -62,7 +62,7 @@ jobs:
 
           - arduino-boards-fqbn: esp32:esp32:m5stack-core2
             fancy-name: M5Core2
-            arduino-platform: esp32:esp32:m5stack-core2@2.0.2
+            arduino-platform: esp32@2.0.2
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
 
           - arduino-boards-fqbn: esp32:esp32:esp32s3box

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -44,7 +44,7 @@ jobs:
           - esp-idf-fqbn: esp32s2@v4.3.1
             idf-board: esp32s2
             idf-version: v4.3.1
-          - esp-idf-fqbn: esp32s2@v4.4-rc1
+          - esp-idf-fqbn: esp32s3@v4.4-rc1
             idf-board: esp32s3
             idf-version: v4.4-rc1
 

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -29,6 +29,7 @@ jobs:
           - esp32@v4.2
           - esp32@v4.3.1
           - esp32s2@v4.3.1
+          - esp32s2@v4.4-rc1
 
         include:
           - esp-idf-fqbn: esp32@v4.1
@@ -43,6 +44,9 @@ jobs:
           - esp-idf-fqbn: esp32s2@v4.3.1
             idf-board: esp32s2
             idf-version: v4.3.1
+          - esp-idf-fqbn: esp32s2@v4.4-rc1
+            idf-board: esp32s3
+            idf-version: v4.4-rc1
 
       fail-fast: false
 

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -29,7 +29,7 @@ jobs:
           - esp32@v4.2
           - esp32@v4.3.1
           - esp32s2@v4.3.1
-          - esp32s2@v4.4-rc1
+          - esp32s3@v4.4-rc1
 
         include:
           - esp-idf-fqbn: esp32@v4.1

--- a/.github/workflows/PlatformioBuild.yml
+++ b/.github/workflows/PlatformioBuild.yml
@@ -28,6 +28,7 @@ jobs:
           - esp8266
           - esp32
           - esp32-s2
+          - esp32-s3
           - m5stick-c
           - m5stack-core-esp32
           - m5stack-core2
@@ -40,6 +41,7 @@ jobs:
           - pio-env: esp8266
           - pio-env: esp32
           - pio-env: esp32-s2
+          - pio-env: esp32-s3
           - pio-env: m5stick-c
           - pio-env: m5stack-core2
           - pio-env: m5stack-core-esp32

--- a/.github/workflows/pioPkgPublish.yml
+++ b/.github/workflows/pioPkgPublish.yml
@@ -2,6 +2,7 @@ name: pioPkgPublish
 
 on:
   release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![arduino-library-badge](https://www.ardu-badge.com/badge/LovyanGFX.svg?)](https://www.ardu-badge.com/LovyanGFX)
 [![PlatformIO Registry](https://badges.registry.platformio.org/packages/lovyan03/library/LovyanGFX.svg)](https://registry.platformio.org/packages/libraries/lovyan03/LovyanGFX)
 
+![Arduino](https://github.com/lovyan03/LovyanGFX/actions/workflows/ArduinoBuild.yml/badge.svg)
+![Platformio](https://github.com/lovyan03/LovyanGFX/actions/workflows/PlatformioBuild.yml/badge.svg)
+![esp-idf](https://github.com/lovyan03/LovyanGFX/actions/workflows/IDFBuild.yml/badge.svg)
 
 
 Display (LCD / OLED / EPD) graphics library (for ESP32 SPI, I2C, 8bitParallel / ESP8266 SPI, I2C / ATSAMD51 SPI).  

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 [![arduino-library-badge](https://www.ardu-badge.com/badge/LovyanGFX.svg?)](https://www.ardu-badge.com/LovyanGFX)
 [![PlatformIO Registry](https://badges.registry.platformio.org/packages/lovyan03/library/LovyanGFX.svg)](https://registry.platformio.org/packages/libraries/lovyan03/LovyanGFX)
 
-![Arduino](https://github.com/lovyan03/LovyanGFX/actions/workflows/ArduinoBuild.yml/badge.svg)
-![Platformio](https://github.com/lovyan03/LovyanGFX/actions/workflows/PlatformioBuild.yml/badge.svg)
-![esp-idf](https://github.com/lovyan03/LovyanGFX/actions/workflows/IDFBuild.yml/badge.svg)
+[![Arduino](https://github.com/lovyan03/LovyanGFX/actions/workflows/ArduinoBuild.yml/badge.svg?branch=master)](https://github.com/lovyan03/LovyanGFX/actions/workflows/ArduinoBuild.yml)
+[![Platformio](https://github.com/lovyan03/LovyanGFX/actions/workflows/PlatformioBuild.yml/badge.svg?branch=master)](https://github.com/lovyan03/LovyanGFX/actions/workflows/PlatformioBuild.yml)
+[![esp-idf](https://github.com/lovyan03/LovyanGFX/actions/workflows/IDFBuild.yml/badge.svg?branch=master)](https://github.com/lovyan03/LovyanGFX/actions/workflows/IDFBuild.yml)
+
 
 
 Display (LCD / OLED / EPD) graphics library (for ESP32 SPI, I2C, 8bitParallel / ESP8266 SPI, I2C / ATSAMD51 SPI).  

--- a/examples/Test/build_test/platformio.ini
+++ b/examples/Test/build_test/platformio.ini
@@ -8,6 +8,10 @@ framework = arduino
 platform_esp32 = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
 platform_packages_esp32 = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.1
 
+; Tasmota is edgy with arduinoespressif versions, let's pick their platform repo
+platform_esp32_s3 = https://github.com/tasmota/platform-espressif32
+platform_packages_esp32_s3 = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.3-RC1
+
 [env:esp8266]
 platform = espressif8266
 board = d1_mini
@@ -18,6 +22,13 @@ platform = ${env.platform_esp32}
 platform_packages = ${env.platform_packages_esp32}
 board = esp32dev
 board_build.mcu = esp32s2
+
+[env:esp32-s3]
+platform = ${env.platform_esp32_s3}
+platform_packages = ${env.platform_packages_esp32_s3}
+board = esp32dev
+board_build.mcu = esp32s3
+
 
 [env:esp32-c3]
 platform = ${env.platform_esp32}

--- a/src/lgfx/v1/panel/Panel_ILI948x.hpp
+++ b/src/lgfx/v1/panel/Panel_ILI948x.hpp
@@ -231,6 +231,84 @@ namespace lgfx
 
 //----------------------------------------------------------------------------
 
+  struct Panel_ILI9488_4DLCD_35480320_IPS : public Panel_ILI948x
+  {
+    void setColorDepth_impl(color_depth_t depth) override 
+    {
+      _write_depth = (((int)depth & color_depth_t::bit_mask) > 16
+                    || (_bus && _bus->busType() == bus_spi))
+                    ? rgb888_3Byte
+                    : rgb565_2Byte;
+
+      _read_depth = rgb888_3Byte;
+    }
+
+  protected:
+
+    static constexpr uint8_t CMD_FRMCTR1 = 0xB1;
+    static constexpr uint8_t CMD_FRMCTR2 = 0xB2;
+    static constexpr uint8_t CMD_FRMCTR3 = 0xB3;
+    static constexpr uint8_t CMD_INVCTR  = 0xB4;
+    static constexpr uint8_t CMD_DFUNCTR = 0xB6;
+    static constexpr uint8_t CMD_ETMOD   = 0xB7;
+    static constexpr uint8_t CMD_PWCTR1  = 0xC0;
+    static constexpr uint8_t CMD_PWCTR2  = 0xC1;
+    static constexpr uint8_t CMD_PWCTR3  = 0xC2;
+    static constexpr uint8_t CMD_PWCTR4  = 0xC3;
+    static constexpr uint8_t CMD_PWCTR5  = 0xC4;
+    static constexpr uint8_t CMD_VMCTR   = 0xC5;
+    static constexpr uint8_t CMD_GMCTRP1 = 0xE0; // Positive Gamma Correction
+    static constexpr uint8_t CMD_GMCTRN1 = 0xE1; // Negative Gamma Correction
+    static constexpr uint8_t CMD_ADJCTL3 = 0xF7;
+    static constexpr uint8_t CMD_MADCTL  = 0x36;
+    static constexpr uint8_t CMD_COLMOD  = 0x3A;
+    static constexpr uint8_t CMD_IFMODE  = 0xB0;
+    static constexpr uint8_t CMD_SETIMG  = 0xE9;
+
+    const uint8_t* getInitCommands(uint8_t listno) const override
+    {
+      static constexpr uint8_t list0[] =
+      {
+          CMD_PWCTR1,  2, 0x18,  // VRH1
+                          0x16,  // VRH2
+          CMD_PWCTR2,  1, 0x45,  // VGH, VGL
+          CMD_VMCTR ,  3, 0x00,  // nVM
+                          0x63,  // VCM_REG
+                          0x01,  // VCM_REG_EN
+          CMD_FRMCTR1, 1, 0xB0,  // Frame rate = 70 Hz
+          CMD_INVCTR,  1, 0x02,  // Display Inversion Control = 2dot
+          CMD_DFUNCTR, 1, 0x02,  // Nomal scan
+          CMD_ETMOD,   1, 0xC6,  // Entry Mode Set
+          CMD_ADJCTL3, 4, 0xA9,  // Adjust Control 3 
+                          0x51,
+                          0x2C,
+                          0x82,
+          CMD_MADCTL,  1, 0x48,  // Memory Access Control 
+          CMD_COLMOD,  1, 0x55,  // Interface Pixel Format
+          CMD_IFMODE,  1, 0x00,  // Interface Mode Control
+          CMD_SETIMG,  1, 0x00,  // Set Image Function
+          
+          CMD_GMCTRP1,15, 0x00, 0x13, 0x18, 0x04, 0x0F, 0x06, 0x3A, 0x56,
+                          0x4D, 0x03, 0x0A, 0x06, 0x30, 0x3E, 0x0F,
+
+          CMD_GMCTRN1,15, 0x00, 0x13, 0x18, 0x01, 0x11, 0x06, 0x38, 0x34,
+                          0x4D, 0x06, 0x0D, 0x0B, 0x31, 0x37, 0x0F,
+
+          CMD_SLPOUT , 0+CMD_INIT_DELAY, 10,    // Exit sleep mode
+          0x21       , 0,
+          CMD_DISPON , 0+CMD_INIT_DELAY, 2,
+          0xFF,0xFF, // end
+      };
+      switch (listno)
+      {
+      case 0: return list0;
+      default: return nullptr;
+      }
+    }
+  };
+
+//----------------------------------------------------------------------------
+
   struct Panel_HX8357B : public Panel_ILI948x
   {
   protected:

--- a/src/lgfx/v1/platforms/esp32/Light_I2C.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_I2C.cpp
@@ -1,0 +1,76 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#if defined (ESP_PLATFORM)
+#include <sdkconfig.h>
+#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32) || defined (CONFIG_IDF_TARGET_ESP32S2) || defined (CONFIG_IDF_TARGET_ESP32C3)
+
+#include "Light_I2C.hpp"
+
+#if defined ( ARDUINO )
+ #include <esp32-hal-ledc.h>
+#else
+ #include <driver/ledc.h>
+#endif
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+
+  //----------------------------------------------------------------------------
+
+  bool Light_I2C::init ( uint8_t brightness )
+  {
+	
+	  buf = 0x01 ;
+    i2c_manager_write ( I2C_NUM_0, LCD_BL_ADDR, BL_GP_REG, &buf, 1 ) ;
+    setBrightness (brightness) ;
+    
+    return true;
+  }
+
+  //----------------------------------------------------------------------------
+
+  void Light_I2C::setBrightness ( uint8_t brightness )
+  {
+    if (_cfg.invert) brightness = ~brightness ;
+	  
+    buf = 0x01 ;
+    i2c_manager_write ( I2C_NUM_0, LCD_BL_ADDR, BL_GP_REG, &buf, 1 ) ;
+    
+    buf = calculateBrightness (brightness) ;
+    i2c_manager_write ( I2C_NUM_0, LCD_BL_ADDR, BANK_A_BL_CTRL, &buf, 1 ) ;
+  }
+
+  //----------------------------------------------------------------------------
+  
+  uint8_t Light_I2C::calculateBrightness ( uint8_t input )
+  {
+    // on invalid input or steps config set to ~50 % brightness:
+    if ( input <= 0 || DRIVER_STEPS <= 0 || INPUT_STEPS <= 0 ) return 0x18 ;
+
+	  return ( ( input * DRIVER_STEPS ) / INPUT_STEPS ) ;
+  }
+
+  //----------------------------------------------------------------------------
+
+ }
+}
+
+#endif
+#endif

--- a/src/lgfx/v1/platforms/esp32/Light_I2C.hpp
+++ b/src/lgfx/v1/platforms/esp32/Light_I2C.hpp
@@ -1,0 +1,68 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../../Light.hpp"
+#include <i2c_manager.h>
+
+//----------------------------------------------------------------------------
+
+/* LM27965 LED driver */
+#define LCD_BL_ADDR     0x36    // LM27965 LED driver I2C chip address
+
+#define BL_GP_REG       0x10    // LM27965 General Purpose Register
+#define BANK_A_BL_CTRL  0xA0    // Bank A brightness control register
+#define BANK_B_BL_CTRL  0xB0    // Bank B brightness control register
+#define BANK_C_BL_CTRL  0xC0    // Bank C brightness control register
+
+#define DRIVER_STEPS    32      // LM27965 LED driver brightness level steps
+#define INPUT_STEPS     256     // resolution of the brightness regulation input (adjust according to your LVGL object configured range)
+
+//----------------------------------------------------------------------------
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+
+//----------------------------------------------------------------------------
+
+  class Light_I2C : public ILight
+  {
+  public:
+    struct config_t
+    {
+        bool invert = false;
+    };
+    
+    const config_t& config (void) const { return _cfg; }
+
+    void config ( const config_t &cfg ) { _cfg = cfg; }
+
+    bool    init                ( uint8_t brightness ) override ;
+    void    setBrightness       ( uint8_t brightness ) override ;
+    uint8_t calculateBrightness ( uint8_t input ) ;    // translate any backlight input range to LED driver's 32-step range
+
+  private:
+    config_t _cfg ;
+    uint8_t   buf ; // R/W buffer for I2C manager
+  };
+
+//----------------------------------------------------------------------------
+ }
+}

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -734,9 +734,9 @@ namespace lgfx
     {
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
 
-#if defined ( ARDUINO )
- #if defined (ESP_IDF_VERSION_VAL)
-  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#if defined ( ARDUINO ) && defined ( ESP_IDF_VERSION_VAL )
+ #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+  #if ARDUINO_ESP32_GIT_VER != 0x44c11981
       auto twowire = ((i2c_port == 1) ? &Wire1 : &Wire);
       twowire->end();
   #endif

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -736,8 +736,8 @@ namespace lgfx
 
 #if defined ( ARDUINO ) && defined ( ESP_IDF_VERSION_VAL )
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
-  #if __has_include( "core_version.h" )
-    #include "core_version.h"
+  #if __has_include( <core_version.h> )
+    #include <core_version.h>
   #endif
   #if ARDUINO_ESP32_GIT_VER != 0x44c11981
       auto twowire = ((i2c_port == 1) ? &Wire1 : &Wire);

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -736,6 +736,7 @@ namespace lgfx
 
 #if defined ( ARDUINO ) && defined ( ESP_IDF_VERSION_VAL )
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+  #include "core_version.h"
   #if ARDUINO_ESP32_GIT_VER != 0x44c11981
       auto twowire = ((i2c_port == 1) ? &Wire1 : &Wire);
       twowire->end();

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -18,7 +18,7 @@ Contributors:
 #if defined (ESP_PLATFORM)
 #include <sdkconfig.h>
 
-/// ESP32-S3をターゲットにした際にREG_SPI_BASEが定義されていなかったので応急処置 ; 
+/// ESP32-S3をターゲットにした際にREG_SPI_BASEが定義されていなかったので応急処置 ;
 #if defined ( CONFIG_IDF_TARGET_ESP32S3 )
  #define REG_SPI_BASE(i)   (DR_REG_SPI1_BASE + (((i)>1) ? (((i)* 0x1000) + 0x20000) : (((~(i)) & 1)* 0x1000 )))
 #endif
@@ -65,7 +65,7 @@ Contributors:
   #endif
 
   #if defined ( LGFX_EFUSE_WORKAROUND )
-// include <esp_efuse.h> でエラーが出るバージョンが存在するため、エラー回避用の記述を行ってからincludeする。; 
+// include <esp_efuse.h> でエラーが出るバージョンが存在するため、エラー回避用の記述を行ってからincludeする。;
    #define _ROM_SECURE_BOOT_H_
    #define MAX_KEY_DIGESTS 3
    struct ets_secure_boot_key_digests
@@ -702,7 +702,7 @@ namespace lgfx
     cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl)
     {
       if ((i2c_port >= I2C_NUM_MAX)
-       || ((uint32_t)pin_scl >= GPIO_NUM_MAX) 
+       || ((uint32_t)pin_scl >= GPIO_NUM_MAX)
        || ((uint32_t)pin_sda >= GPIO_NUM_MAX))
       {
         return cpp::fail(error_t::invalid_arg);
@@ -736,7 +736,9 @@ namespace lgfx
 
 #if defined ( ARDUINO ) && defined ( ESP_IDF_VERSION_VAL )
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
-  #include "core_version.h"
+  #if __has_include( "core_version.h" )
+    #include "core_version.h"
+  #endif
   #if ARDUINO_ESP32_GIT_VER != 0x44c11981
       auto twowire = ((i2c_port == 1) ? &Wire1 : &Wire);
       twowire->end();

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S3.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S3.hpp
@@ -221,7 +221,7 @@ namespace lgfx
             p->setRotation(1);
           }
           _panel_last = p;
-          _set_pwm_backlight(GPIO_NUM_45, 7, 12000);
+          _set_pwm_backlight(GPIO_NUM_45, 0, 12000);
 
           {
             auto t = new lgfx::Touch_TT21xxx();


### PR DESCRIPTION
The 'Light_I2C' class main features:

* implements LCD backlight control via the LM27965 I2C LED driver
* allows for custom brightness input range translation to the drivers' 32-step range
* requires the external i2c_manager component
* currently implemented for the ESP-IDF platform only (no Arduino support yet)

The 4DLCD-35480320-IPS LCD display utilizes ILITEK ILI9488 driver.
However, the default setup in the 'Panel_ILI9488' struct is not sufficient - this particular LCD model needs a specific registry setup for its proper function.
This is done in the 'Panel_ILI948x.hpp' header file by introducing a 'Panel_ILI9488_4DLCD_35480320_IPS' struct, where all of the important registry are setup according to the LCD's datasheet.