### PR TITLE
feat: Add support for I2C LM27965 LED driver and 4DLCD-35480320-IPS LCD

### DIFF
--- a/src/lgfx/v1/panel/Panel_ILI948x.hpp
+++ b/src/lgfx/v1/panel/Panel_ILI948x.hpp
@@ -231,6 +231,84 @@ namespace lgfx
 
 //----------------------------------------------------------------------------
 
+  struct Panel_ILI9488_4DLCD_35480320_IPS : public Panel_ILI948x
+  {
+    void setColorDepth_impl(color_depth_t depth) override 
+    {
+      _write_depth = (((int)depth & color_depth_t::bit_mask) > 16
+                    || (_bus && _bus->busType() == bus_spi))
+                    ? rgb888_3Byte
+                    : rgb565_2Byte;
+
+      _read_depth = rgb888_3Byte;
+    }
+
+  protected:
+
+    static constexpr uint8_t CMD_FRMCTR1 = 0xB1;
+    static constexpr uint8_t CMD_FRMCTR2 = 0xB2;
+    static constexpr uint8_t CMD_FRMCTR3 = 0xB3;
+    static constexpr uint8_t CMD_INVCTR  = 0xB4;
+    static constexpr uint8_t CMD_DFUNCTR = 0xB6;
+    static constexpr uint8_t CMD_ETMOD   = 0xB7;
+    static constexpr uint8_t CMD_PWCTR1  = 0xC0;
+    static constexpr uint8_t CMD_PWCTR2  = 0xC1;
+    static constexpr uint8_t CMD_PWCTR3  = 0xC2;
+    static constexpr uint8_t CMD_PWCTR4  = 0xC3;
+    static constexpr uint8_t CMD_PWCTR5  = 0xC4;
+    static constexpr uint8_t CMD_VMCTR   = 0xC5;
+    static constexpr uint8_t CMD_GMCTRP1 = 0xE0; // Positive Gamma Correction
+    static constexpr uint8_t CMD_GMCTRN1 = 0xE1; // Negative Gamma Correction
+    static constexpr uint8_t CMD_ADJCTL3 = 0xF7;
+    static constexpr uint8_t CMD_MADCTL  = 0x36;
+    static constexpr uint8_t CMD_COLMOD  = 0x3A;
+    static constexpr uint8_t CMD_IFMODE  = 0xB0;
+    static constexpr uint8_t CMD_SETIMG  = 0xE9;
+
+    const uint8_t* getInitCommands(uint8_t listno) const override
+    {
+      static constexpr uint8_t list0[] =
+      {
+          CMD_PWCTR1,  2, 0x18,  // VRH1
+                          0x16,  // VRH2
+          CMD_PWCTR2,  1, 0x45,  // VGH, VGL
+          CMD_VMCTR ,  3, 0x00,  // nVM
+                          0x63,  // VCM_REG
+                          0x01,  // VCM_REG_EN
+          CMD_FRMCTR1, 1, 0xB0,  // Frame rate = 70 Hz
+          CMD_INVCTR,  1, 0x02,  // Display Inversion Control = 2dot
+          CMD_DFUNCTR, 1, 0x02,  // Nomal scan
+          CMD_ETMOD,   1, 0xC6,  // Entry Mode Set
+          CMD_ADJCTL3, 4, 0xA9,  // Adjust Control 3 
+                          0x51,
+                          0x2C,
+                          0x82,
+          CMD_MADCTL,  1, 0x48,  // Memory Access Control 
+          CMD_COLMOD,  1, 0x55,  // Interface Pixel Format
+          CMD_IFMODE,  1, 0x00,  // Interface Mode Control
+          CMD_SETIMG,  1, 0x00,  // Set Image Function
+          
+          CMD_GMCTRP1,15, 0x00, 0x13, 0x18, 0x04, 0x0F, 0x06, 0x3A, 0x56,
+                          0x4D, 0x03, 0x0A, 0x06, 0x30, 0x3E, 0x0F,
+
+          CMD_GMCTRN1,15, 0x00, 0x13, 0x18, 0x01, 0x11, 0x06, 0x38, 0x34,
+                          0x4D, 0x06, 0x0D, 0x0B, 0x31, 0x37, 0x0F,
+
+          CMD_SLPOUT , 0+CMD_INIT_DELAY, 10,    // Exit sleep mode
+          0x21       , 0,
+          CMD_DISPON , 0+CMD_INIT_DELAY, 2,
+          0xFF,0xFF, // end
+      };
+      switch (listno)
+      {
+      case 0: return list0;
+      default: return nullptr;
+      }
+    }
+  };
+
+//----------------------------------------------------------------------------
+
   struct Panel_HX8357B : public Panel_ILI948x
   {
   protected:

--- a/src/lgfx/v1/platforms/esp32/Light_I2C.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_I2C.cpp
@@ -1,0 +1,76 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#if defined (ESP_PLATFORM)
+#include <sdkconfig.h>
+#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32) || defined (CONFIG_IDF_TARGET_ESP32S2) || defined (CONFIG_IDF_TARGET_ESP32C3)
+
+#include "Light_I2C.hpp"
+
+#if defined ( ARDUINO )
+ #include <esp32-hal-ledc.h>
+#else
+ #include <driver/ledc.h>
+#endif
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+
+  //----------------------------------------------------------------------------
+
+  bool Light_I2C::init ( uint8_t brightness )
+  {
+	
+	  buf = 0x01 ;
+    i2c_manager_write ( I2C_NUM_0, LCD_BL_ADDR, BL_GP_REG, &buf, 1 ) ;
+    setBrightness (brightness) ;
+    
+    return true;
+  }
+
+  //----------------------------------------------------------------------------
+
+  void Light_I2C::setBrightness ( uint8_t brightness )
+  {
+    if (_cfg.invert) brightness = ~brightness ;
+	  
+    buf = 0x01 ;
+    i2c_manager_write ( I2C_NUM_0, LCD_BL_ADDR, BL_GP_REG, &buf, 1 ) ;
+    
+    buf = calculateBrightness (brightness) ;
+    i2c_manager_write ( I2C_NUM_0, LCD_BL_ADDR, BANK_A_BL_CTRL, &buf, 1 ) ;
+  }
+
+  //----------------------------------------------------------------------------
+  
+  uint8_t Light_I2C::calculateBrightness ( uint8_t input )
+  {
+    // on invalid input or steps config set to ~50 % brightness:
+    if ( input <= 0 || DRIVER_STEPS <= 0 || INPUT_STEPS <= 0 ) return 0x18 ;
+
+	  return ( ( input * DRIVER_STEPS ) / INPUT_STEPS ) ;
+  }
+
+  //----------------------------------------------------------------------------
+
+ }
+}
+
+#endif
+#endif

--- a/src/lgfx/v1/platforms/esp32/Light_I2C.hpp
+++ b/src/lgfx/v1/platforms/esp32/Light_I2C.hpp
@@ -1,0 +1,68 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../../Light.hpp"
+#include <i2c_manager.h>
+
+//----------------------------------------------------------------------------
+
+/* LM27965 LED driver */
+#define LCD_BL_ADDR     0x36    // LM27965 LED driver I2C chip address
+
+#define BL_GP_REG       0x10    // LM27965 General Purpose Register
+#define BANK_A_BL_CTRL  0xA0    // Bank A brightness control register
+#define BANK_B_BL_CTRL  0xB0    // Bank B brightness control register
+#define BANK_C_BL_CTRL  0xC0    // Bank C brightness control register
+
+#define DRIVER_STEPS    32      // LM27965 LED driver brightness level steps
+#define INPUT_STEPS     256     // resolution of the brightness regulation input (adjust according to your LVGL object configured range)
+
+//----------------------------------------------------------------------------
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+
+//----------------------------------------------------------------------------
+
+  class Light_I2C : public ILight
+  {
+  public:
+    struct config_t
+    {
+        bool invert = false;
+    };
+    
+    const config_t& config (void) const { return _cfg; }
+
+    void config ( const config_t &cfg ) { _cfg = cfg; }
+
+    bool    init                ( uint8_t brightness ) override ;
+    void    setBrightness       ( uint8_t brightness ) override ;
+    uint8_t calculateBrightness ( uint8_t input ) ;    // translate any backlight input range to LED driver's 32-step range
+
+  private:
+    config_t _cfg ;
+    uint8_t   buf ; // R/W buffer for I2C manager
+  };
+
+//----------------------------------------------------------------------------
+ }
+}


### PR DESCRIPTION
The 'Light_I2C' class main features:

* implements LCD backlight control via the LM27965 I2C LED driver
* allows for custom brightness input range translation to the drivers' 32-step range

The 'Light_I2C' class requirements and limitations:

* requires the external i2c_manager component
* currently implemented for the ESP-IDF platform only (no Arduino support yet)

The 4DLCD-35480320-IPS LCD display utilizes ILITEK ILI9488 driver.
However, the default setup in the 'Panel_ILI9488' struct is not sufficient for this particular LCD model - it needs a specific registry setup for proper function.
This is done in the 'Panel_ILI948x.hpp' header file by introducing a 'Panel_ILI9488_4DLCD_35480320_IPS' struct, where all of the important registry are set up according to the LCD's datasheet.