### PR TITLE
Fix compile errors on macOS

### DIFF
--- a/src/lgfx/v1/platforms/opencv/Panel_OpenCV.cpp
+++ b/src/lgfx/v1/platforms/opencv/Panel_OpenCV.cpp
@@ -173,10 +173,10 @@ namespace lgfx
 
   void Panel_OpenCV::setWindow(uint_fast16_t xs, uint_fast16_t ys, uint_fast16_t xe, uint_fast16_t ye)
   {
-    xs = std::max(0u, std::min<uint_fast16_t>(_width  - 1, xs));
-    xe = std::max(0u, std::min<uint_fast16_t>(_width  - 1, xe));
-    ys = std::max(0u, std::min<uint_fast16_t>(_height - 1, ys));
-    ye = std::max(0u, std::min<uint_fast16_t>(_height - 1, ye));
+    xs = std::max(static_cast<uint_fast16_t>(0u), std::min<uint_fast16_t>(_width  - 1, xs));
+    xe = std::max(static_cast<uint_fast16_t>(0u), std::min<uint_fast16_t>(_width  - 1, xe));
+    ys = std::max(static_cast<uint_fast16_t>(0u), std::min<uint_fast16_t>(_height - 1, ys));
+    ye = std::max(static_cast<uint_fast16_t>(0u), std::min<uint_fast16_t>(_height - 1, ye));
     _xpos = xs;
     _xs = xs;
     _xe = xe;

--- a/src/lgfx/v1/platforms/opencv/common.hpp
+++ b/src/lgfx/v1/platforms/opencv/common.hpp
@@ -21,7 +21,11 @@ Contributors:
 #include "../../misc/enum.hpp"
 #include "../../../utility/result.hpp"
 
-#include <malloc.h>
+#ifdef __MACH__
+# include <stdlib.h>
+#else
+# include <malloc.h>
+#endif
 #include <stdio.h>
 
 namespace lgfx

--- a/src/lgfx/v1/platforms/sdl/common.hpp
+++ b/src/lgfx/v1/platforms/sdl/common.hpp
@@ -24,7 +24,11 @@ Porting for SDL:
 #include "../../misc/enum.hpp"
 #include "../../../utility/result.hpp"
 
-#include <malloc.h>
+#ifdef __MACH__
+# include <stdlib.h>
+#else
+# include <malloc.h>
+#endif
 #include <stdio.h>
 
 #if __has_include(<SDL2/SDL.h>)


### PR DESCRIPTION
macOSでOpenCVとSDL2でのコンパイルが通らなかったので修正しました。

* examples_for_PC/CMake_OpenCV
* examples_for_PC/CMake_SDL

のサンプルの動作を確認しています。

### 動作確認した環境

macOS BigSur 11.6.4
opencv 4.5.5_2
sdl2 2.0.22
Macbook Air M1 2020
M5CORE2
