### PR TITLE
Add support for Adafruit HalloWing M0 and M4 boards

### DIFF
--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -44,6 +44,8 @@ namespace lgfx
     , board_SDL
     , board_M5StackCoreS3
     , board_M5AtomS3LCD
+    , board_HalloWingM4
+    , board_HalloWingM0
     };
   }
   using namespace boards;

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
@@ -68,11 +68,8 @@ namespace lgfx
       default: return false;
       }
 
-      // Enable Peripheral Clocks
-      GCLK->GENCTRL.reg = 0 | (1u << 16); // Enable generic clock 0
-      while (GCLK->STATUS.bit.SYNCBUSY);
-
-      GCLK->CLKCTRL.reg = (0x01 < 14) | (0x00 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
+      // Enable Peripheral Clock (Arduino startup set gen clock 0 to 48 MHz)
+      GCLK->CLKCTRL.reg = (1 << 14) | (0 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
       while (GCLK->STATUS.bit.SYNCBUSY);
 
       // Configure _tc
@@ -89,7 +86,7 @@ namespace lgfx
 
       // Configure PORT
       lgfx::pinMode( _cfg.pin, pin_mode_t::output );
-      if (_cfg.timer_alt) lgfx::pinAssignPeriph( _cfg.pin, _cfg.timer_alt ? 5 : 45 ); // 4, 5 = periph E, F (PIO_TIMER, PIO_TIMER_ALT)
+      lgfx::pinAssignPeriph( _cfg.pin, _cfg.timer_alt ? 5 : 4 ); // 4, 5 = periph E, F (PIO_TIMER, PIO_TIMER_ALT)
 
       return true;
     }
@@ -131,12 +128,8 @@ namespace lgfx
       default: return false;
       }
 
-      // Enable Peripheral Clocks
-      GCLK->GENCTRL.reg = 0 | (1u << 16); // Enable generic clock 0
-      while (GCLK->STATUS.bit.SYNCBUSY);
-//CLK_TCC0_APB must be enabled in power manager?
-
-      GCLK->CLKCTRL.reg = (0x01 < 14) | (0x00 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
+      // Enable Peripheral Clock (Arduino startup set gen clock 0 to 48 MHz)
+      GCLK->CLKCTRL.reg = (1 << 14) | (0 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
       while (GCLK->STATUS.bit.SYNCBUSY);
 
       // Configure _tcc
@@ -156,7 +149,7 @@ namespace lgfx
 
       // Configure PORT
       lgfx::pinMode( _cfg.pin, pin_mode_t::output );
-      if (_cfg.timer_alt) lgfx::pinAssignPeriph( _cfg.pin, _cfg.timer_alt ? 5 : 45 ); // 4, 5 = periph E, F (PIO_TIMER, PIO_TIMER_ALT)
+      lgfx::pinAssignPeriph( _cfg.pin, _cfg.timer_alt ? 5 : 4 ); // 4, 5 = periph E, F (PIO_TIMER, PIO_TIMER_ALT)
 
       return true;
     }
@@ -285,7 +278,7 @@ namespace lgfx
 // HalloWing M0 screen is write-only, no LGFX_AUTODETECT
 #if defined ( LGFX_HALLOWING_M0 )
 
-      if (board == 0) // || board == board_t::board_HalloWingM0)
+      if (board == 0 || board == board_t::board_HalloWingM0)
       {
         _pin_reset(samd21::PORT_A | 27, use_reset);
         bus_cfg.sercom_index = 5;
@@ -296,7 +289,7 @@ namespace lgfx
         bus_cfg.freq_write = 24000000;
         _bus_spi.config(bus_cfg);
         board = board_t::board_HalloWingM0;
-        auto p = new lgfx::Panel_ST7735();
+        auto p = new lgfx::Panel_ST7735S();
         _panel_last = p;
         {
           auto cfg = p->config();
@@ -306,10 +299,11 @@ namespace lgfx
           cfg.panel_height = 128;
           cfg.memory_width = 128;
           cfg.memory_height = 128;
+          cfg.offset_x = 2;
+          cfg.offset_y = 1;
           cfg.readable = false;
-          cfg.rgb_order = true;
+          cfg.rgb_order = false;
           cfg.invert = false;
-          cfg.offset_rotation = 2;
           p->config(cfg);
         }
         p->setBus(&_bus_spi);

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
@@ -68,7 +68,13 @@ namespace lgfx
       default: return false;
       }
 
-      // Enable Peripheral Clock (Arduino startup set gen clock 0 to 48 MHz)
+      // As written, _tc will source from Generic Clock Generator 0, which
+      // is presumed already configured in boot code. For example, Arduino
+      // startup sets this to DFLL48M (48 MHz), and almost certainly true
+      // of any non-Arduino environment as well. That step is NOT repeated
+      // here as GCLK0 is the main system clock and unwise to alter now.
+
+      // Enable TC peripheral clock, sourced from GCLK0 (presumed 48 MHz)
       GCLK->CLKCTRL.reg = (1 << 14) | (0 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
       while (GCLK->STATUS.bit.SYNCBUSY);
 
@@ -128,7 +134,13 @@ namespace lgfx
       default: return false;
       }
 
-      // Enable Peripheral Clock (Arduino startup set gen clock 0 to 48 MHz)
+      // As written, _tc will source from Generic Clock Generator 0, which
+      // is presumed already configured in boot code. For example, Arduino
+      // startup sets this to DFLL48M (48 MHz), and almost certainly true
+      // of any non-Arduino environment as well. That step is NOT repeated
+      // here as GCLK0 is the main system clock and unwise to alter now.
+
+      // Enable TCC peripheral clock, sourced from GCLK0 (presumed 48 MHz)
       GCLK->CLKCTRL.reg = (1 << 14) | (0 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
       while (GCLK->STATUS.bit.SYNCBUSY);
 
@@ -321,7 +333,7 @@ namespace lgfx
         goto init_clear;
       }
 
-#endif
+#endif // end LGFX_HALLOWING_M0
 
       board = board_t::board_unknown;
 

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
@@ -26,6 +26,10 @@ Contributors:
     #define LGFX_SEEED_XIAO_EXPANSION
  #endif
 
+ #if defined ( ARDUINO_SAMD_HALLOWING )
+    #define LGFX_HALLOWING_M0
+ #endif
+
 #endif
 
 namespace lgfx
@@ -33,7 +37,7 @@ namespace lgfx
  inline namespace v1
  {
 //----------------------------------------------------------------------------
-/*
+
   struct Light_TC : public ILight
   {
     struct config_t
@@ -41,6 +45,7 @@ namespace lgfx
       uint8_t pin = 0;
       uint8_t tc_index = 0;
       uint8_t cc_index = 0;
+      bool timer_alt = false;
     };
 
     config_t config(void) const { return _cfg; }
@@ -48,45 +53,43 @@ namespace lgfx
 
     bool init(uint8_t brightness) override
     {
-      uint8_t pchctrl_index = 26;
+      uint8_t gclk_id;
       switch (_cfg.tc_index)
       {
-      case 0: MCLK->APBAMASK.bit.TC0_ = 1; _tc = TC0; pchctrl_index =  9; break;
-      case 1: MCLK->APBAMASK.bit.TC1_ = 1; _tc = TC1; pchctrl_index =  9; break;
-      case 2: MCLK->APBBMASK.bit.TC2_ = 1; _tc = TC2; pchctrl_index = 26; break;
-      case 3: MCLK->APBBMASK.bit.TC3_ = 1; _tc = TC3; pchctrl_index = 26; break;
-      case 4: MCLK->APBCMASK.bit.TC4_ = 1; _tc = TC4; pchctrl_index = 30; break;
-      case 5: MCLK->APBCMASK.bit.TC5_ = 1; _tc = TC5; pchctrl_index = 30; break;
+      case 3: _tc = TC3; gclk_id = 0x1B; break;
+      case 4: _tc = TC4; gclk_id = 0x1C; break;
+      case 5: _tc = TC5; gclk_id = 0x1C; break;
 #if defined ( TC6 )
-      case 6: MCLK->APBDMASK.bit.TC6_ = 1; _tc = TC6; pchctrl_index = 39; break;
+      case 6: _tc = TC6; gclk_id = 0x1D; break;
 #endif
 #if defined ( TC7 )
-      case 7: MCLK->APBDMASK.bit.TC7_ = 1; _tc = TC7; pchctrl_index = 39; break;
+      case 7: _tc = TC7; gclk_id = 0x1D; break;
 #endif
       default: return false;
       }
 
       // Enable Peripheral Clocks
-      GCLK->PCHCTRL[pchctrl_index].reg = 0 | (1u << 6);
-      while (!GCLK->PCHCTRL[pchctrl_index].bit.CHEN);
+      GCLK->GENCTRL.reg = 0 | (1u << 16); // Enable generic clock 0
+      while (GCLK->STATUS.bit.SYNCBUSY);
+
+      GCLK->CLKCTRL.reg = (0x01 < 14) | (0x00 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
+      while (GCLK->STATUS.bit.SYNCBUSY);
 
       // Configure _tc
-      _tc->COUNT8.CTRLA.reg = (1u << 0);   // SWRST;
-      while ( _tc->COUNT8.SYNCBUSY.bit.SWRST );
-      _tc->COUNT8.CTRLA.reg = (0x01 << 2) | (0x01 << 4) | (0x04 << 8);   // MODE=COUNT8, PRESCALER=DIV16, PRESCSYNC=PRESC
-      _tc->COUNT8.WAVE.reg  = 0x02; // WAVEGEN=NPWM;
-      _tc->COUNT8.CTRLBSET.reg = (1u<<1); // LUPD
-      _tc->COUNT8.PER.reg = 255;  // max brightness;
+      _tc->COUNT8.CTRLA.bit.SWRST = 1;
+      while (_tc->COUNT8.CTRLA.bit.SWRST);
+      _tc->COUNT8.CTRLA.reg = (0x01 << 2) | (0x02 << 5) | (0x04 << 8) | (0x01 << 12); // MODE=COUNT8, WAVEGEN=NPWM, PRESCALER=DIV16, PRESCSYNC=PRESC
+      _tc->COUNT8.PER.reg = 255;      // max brightness;
       _tc->COUNT8.CC[_cfg.cc_index].reg = brightness;
       _tc->COUNT8.DBGCTRL.bit.DBGRUN = 1;
-      _tc->COUNT8.INTFLAG.reg = 0x33;    // Clear all flags
-      while ( _tc->COUNT8.SYNCBUSY.reg );
-      _tc->COUNT8.CTRLA.bit.ENABLE = 1;   // ENABLE
-      while ( _tc->COUNT8.SYNCBUSY.bit.ENABLE );
+      _tc->COUNT8.INTFLAG.reg = 0x33; // Clear all flags
+      while ( _tc->COUNT8.STATUS.bit.SYNCBUSY );
+      _tc->COUNT8.CTRLA.bit.ENABLE = 1;
+      while ( _tc->COUNT8.STATUS.bit.SYNCBUSY );
 
       // Configure PORT
       lgfx::pinMode( _cfg.pin, pin_mode_t::output );
-      lgfx::pinAssignPeriph( _cfg.pin, 4 ); // 4 = periph E ( PIO_TIMER )
+      if (_cfg.timer_alt) lgfx::pinAssignPeriph( _cfg.pin, _cfg.timer_alt ? 5 : 45 ); // 4, 5 = periph E, F (PIO_TIMER, PIO_TIMER_ALT)
 
       return true;
     }
@@ -100,7 +103,73 @@ namespace lgfx
     config_t _cfg;
     Tc* _tc = nullptr;
   };
-//*/
+
+  struct Light_TCC : public ILight
+  {
+    struct config_t
+    {
+      uint8_t pin = 0;
+      uint8_t tcc_index = 0;
+      uint8_t cc_index = 0;
+      bool timer_alt = false;
+    };
+
+    config_t config(void) const { return _cfg; }
+    void config(const config_t& config) { _cfg = config; }
+
+    bool init(uint8_t brightness) override
+    {
+      uint8_t gclk_id;
+      switch (_cfg.tcc_index)
+      {
+      case 0: _tcc = TCC0; gclk_id = 0x1A; break;
+      case 1: _tcc = TCC1; gclk_id = 0x1A; break;
+      case 2: _tcc = TCC2; gclk_id = 0x1B; break;
+#if defined ( TCC3 )
+      case 3: _tcc = TCC3; gclk_id = 0x25; break;
+#endif
+      default: return false;
+      }
+
+      // Enable Peripheral Clocks
+      GCLK->GENCTRL.reg = 0 | (1u << 16); // Enable generic clock 0
+      while (GCLK->STATUS.bit.SYNCBUSY);
+//CLK_TCC0_APB must be enabled in power manager?
+
+      GCLK->CLKCTRL.reg = (0x01 < 14) | (0x00 << 8) | gclk_id; // CLKEN + Generic clock gen 0 + ID
+      while (GCLK->STATUS.bit.SYNCBUSY);
+
+      // Configure _tcc
+      _tcc->CTRLA.bit.SWRST = 1;
+      while (_tcc->SYNCBUSY.bit.SWRST);
+      _tcc->CTRLA.reg = (0x04 << 8) | (0x01 << 12); // PRESCALER=DIV16, PRESCSYNC=PRESC
+      _tcc->CTRLBCLR.reg = (1u<<1); // Continuous
+      while (_tcc->SYNCBUSY.bit.CTRLB);
+      _tcc->PER.reg = 255 << 6;     // 8-bit range, no dither
+      while (_tcc->SYNCBUSY.bit.PER);
+      _tcc->CC[_cfg.cc_index].reg = brightness;
+      while (_tcc->SYNCBUSY.reg & 0xF00);
+      _tcc->DBGCTRL.bit.DBGRUN = 1;
+      _tcc->INTFLAG.reg = 0x3FCF;   // Clear all flags
+      _tcc->CTRLA.bit.ENABLE = 1;
+      while (_tcc->SYNCBUSY.bit.ENABLE);
+
+      // Configure PORT
+      lgfx::pinMode( _cfg.pin, pin_mode_t::output );
+      if (_cfg.timer_alt) lgfx::pinAssignPeriph( _cfg.pin, _cfg.timer_alt ? 5 : 45 ); // 4, 5 = periph E, F (PIO_TIMER, PIO_TIMER_ALT)
+
+      return true;
+    }
+
+    void setBrightness(uint8_t brightness) override
+    {
+      if (_tcc) _tcc->CC[_cfg.cc_index].reg = brightness;
+    }
+
+  protected:
+    config_t _cfg;
+    Tcc* _tcc = nullptr;
+  };
 
   class LGFX : public LGFX_Device
   {
@@ -209,6 +278,53 @@ namespace lgfx
       {
         // board = board_t::board_SeeedXIAOExpansion;
 /////
+      }
+
+#endif
+
+// HalloWing M0 screen is write-only, no LGFX_AUTODETECT
+#if defined ( LGFX_HALLOWING_M0 )
+
+      if (board == 0) // || board == board_t::board_HalloWingM0)
+      {
+        _pin_reset(samd21::PORT_A | 27, use_reset);
+        bus_cfg.sercom_index = 5;
+        bus_cfg.pin_mosi  = samd21::PORT_B | 22;
+        bus_cfg.pin_miso  = -1;
+        bus_cfg.pin_sclk  = samd21::PORT_B | 23;
+        bus_cfg.pin_dc    = samd21::PORT_A | 28;
+        bus_cfg.freq_write = 24000000;
+        _bus_spi.config(bus_cfg);
+        board = board_t::board_HalloWingM0;
+        auto p = new lgfx::Panel_ST7735();
+        _panel_last = p;
+        {
+          auto cfg = p->config();
+          cfg.pin_cs  = samd21::PORT_A |  1;
+          cfg.pin_rst = samd21::PORT_A | 27;
+          cfg.panel_width  = 128;
+          cfg.panel_height = 128;
+          cfg.memory_width = 128;
+          cfg.memory_height = 128;
+          cfg.readable = false;
+          cfg.rgb_order = true;
+          cfg.invert = false;
+          cfg.offset_rotation = 2;
+          p->config(cfg);
+        }
+        p->setBus(&_bus_spi);
+        {
+          auto l = new Light_TCC();
+          auto cfg = l->config();
+          cfg.pin = samd21::PORT_A | 0;
+          cfg.tcc_index = 2;
+          cfg.cc_index = 0;
+          l->config(cfg);
+          p->setLight(l);
+          _light_last = l;
+        }
+
+        goto init_clear;
       }
 
 #endif

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
@@ -30,6 +30,10 @@ Contributors:
   #define LGFX_WIO_TERMINAL
  #endif
 
+ #if defined ( ARDUINO_HALLOWING_M4 )
+  #define LGFX_HALLOWING_M4
+ #endif
+
 #endif
 
 namespace lgfx
@@ -418,6 +422,53 @@ namespace lgfx
           }
           _bus_spi.release();
         }
+      }
+
+#endif
+
+// HalloWing M4 screen is write-only, no LGFX_AUTODETECT
+#if defined ( LGFX_HALLOWING_M4 )
+
+      if (board == 0 || board == board_t::board_HalloWingM4)
+      {
+        _pin_reset(samd51::PORT_B | 30, use_reset);
+        bus_cfg.sercom_index = 1;
+        bus_cfg.pin_mosi  = samd51::PORT_A |  0;
+        bus_cfg.pin_miso  = -1;
+        bus_cfg.pin_sclk  = samd51::PORT_A |  1;
+        bus_cfg.pin_dc    = samd51::PORT_B | 31;
+        bus_cfg.freq_write = 50000000;
+        _bus_spi.config(bus_cfg);
+        board = board_t::board_HalloWingM4;
+        auto p = new lgfx::Panel_ST7789();
+        _panel_last = p;
+        {
+          auto cfg = p->config();
+          cfg.pin_cs  = samd51::PORT_A | 27;
+          cfg.pin_rst = samd51::PORT_B | 30;
+          cfg.panel_width  = 240;
+          cfg.panel_height = 240;
+          cfg.memory_width = 240;
+          cfg.memory_height = 320;
+          cfg.readable = false;
+          cfg.rgb_order = true;
+          cfg.invert = true;
+          cfg.offset_rotation = 2;
+          p->config(cfg);
+        }
+        p->setBus(&_bus_spi);
+        {
+          auto l = new Light_TC();
+          auto cfg = l->config();
+          cfg.pin = samd51::PORT_B | 14;
+          cfg.tc_index = 5;
+          cfg.cc_index = 0;
+          l->config(cfg);
+          p->setLight(l);
+          _light_last = l;
+        }
+
+        goto init_clear;
       }
 
 #endif

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
@@ -471,7 +471,7 @@ namespace lgfx
         goto init_clear;
       }
 
-#endif
+#endif // end LGFX_HALLOWING_M4
 
       board = board_t::board_unknown;
 


### PR DESCRIPTION
Goal is to add support for several Adafruit boards, but as this is my first pull request to this repository, I'll start with just these two to verify that I'm following the desired code formatting, etc.

In addition to setting up the panel initialization for these two boards (HalloWing M0 and M4), this enables PWM backlight control on SAMD21 using the TC or TCC peripherals.