### PR TITLE
Add Adafruit Feather TFT ESP32 S2&S3, FunHouse, fix HalloWings

### DIFF
--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -49,6 +49,8 @@ jobs:
           - { board: 'd1_mini:eesz=4M3M,xtal=80', platform: esp8266, archi: esp8266, platform-url: 'https://arduino.esp8266.com/stable/package_esp8266com_index.json', platform-version: 3.0.2, ... }
           - { board: adafruit_hallowing, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
           - { board: adafruit_hallowing_m4, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
+          - { board: adafruit_pybadge_m4, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
+          - { board: adafruit_pygamer_m4, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
           - { board: adafruit_feather_esp32s2_tft, platform: esp32, archi: esp32, platform-url: 'https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json', platform-version: 2.0.4, ... }
           - { board: adafruit_feather_esp32s3_tft, platform: esp32, archi: esp32, platform-url: 'https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json', platform-version: 2.0.4, ... }
           - { board: adafruit_funhouse_esp32s2, platform: esp32, archi: esp32, platform-url: 'https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json', platform-version: 2.0.4, ... }

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -49,6 +49,9 @@ jobs:
           - { board: 'd1_mini:eesz=4M3M,xtal=80', platform: esp8266, archi: esp8266, platform-url: 'https://arduino.esp8266.com/stable/package_esp8266com_index.json', platform-version: 3.0.2, ... }
           - { board: adafruit_hallowing, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
           - { board: adafruit_hallowing_m4, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
+          - { board: adafruit_feather_esp32s2_tft, platform: esp32, archi: esp32, ... }
+          - { board: adafruit_feather_esp32s3_tft, platform: esp32, archi: esp32, ... }
+          - { board: adafruit_funhouse_esp32s2, platform: esp32, archi: esp32, ... }
           # 3D matrix applies to these:
           - { board: esp32,              platform: esp32, archi: esp32, ... }
           - { board: esp32s2,            platform: esp32, archi: esp32, ... }

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -49,9 +49,10 @@ jobs:
           - { board: 'd1_mini:eesz=4M3M,xtal=80', platform: esp8266, archi: esp8266, platform-url: 'https://arduino.esp8266.com/stable/package_esp8266com_index.json', platform-version: 3.0.2, ... }
           - { board: adafruit_hallowing, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
           - { board: adafruit_hallowing_m4, platform: adafruit, archi: samd, platform-url: 'https://adafruit.github.io/arduino-board-index/package_adafruit_index.json', platform-version: 1.7.10, ... }
-          - { board: adafruit_feather_esp32s2_tft, platform: esp32, archi: esp32, ... }
-          - { board: adafruit_feather_esp32s3_tft, platform: esp32, archi: esp32, ... }
-          - { board: adafruit_funhouse_esp32s2, platform: esp32, archi: esp32, ... }
+          - { board: adafruit_feather_esp32s2_tft, platform: esp32, archi: esp32, platform-url: 'https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json', platform-version: 2.0.4, ... }
+          - { board: adafruit_feather_esp32s3_tft, platform: esp32, archi: esp32, platform-url: 'https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json', platform-version: 2.0.4, ... }
+          - { board: adafruit_funhouse_esp32s2, platform: esp32, archi: esp32, platform-url: 'https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json', platform-version: 2.0.4, ... }
+
           # 3D matrix applies to these:
           - { board: esp32,              platform: esp32, archi: esp32, ... }
           - { board: esp32s2,            platform: esp32, archi: esp32, ... }

--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -44,8 +44,10 @@ namespace lgfx
     , board_SDL
     , board_M5StackCoreS3
     , board_M5AtomS3LCD
-    , board_HalloWingM4
     , board_HalloWingM0
+    , board_HalloWingM4
+    , board_Feather_ESP32_S2_TFT
+    , board_Feather_ESP32_S3_TFT
     };
   }
   using namespace boards;

--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -48,6 +48,7 @@ namespace lgfx
     , board_HalloWingM4
     , board_Feather_ESP32_S2_TFT
     , board_Feather_ESP32_S3_TFT
+    , board_FunHouse
     };
   }
   using namespace boards;

--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -49,6 +49,7 @@ namespace lgfx
     , board_Feather_ESP32_S2_TFT
     , board_Feather_ESP32_S3_TFT
     , board_FunHouse
+    , board_PyGamer
     };
   }
   using namespace boards;

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S2.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S2.hpp
@@ -26,6 +26,9 @@ Contributors:
 #include <driver/i2c.h>
 
 
+#if defined ( ARDUINO_ADAFRUIT_FEATHER_ESP32S2_TFT )
+  #define LGFX_FEATHER_ESP32_S2_TFT
+#endif
 
 
 namespace lgfx
@@ -218,6 +221,48 @@ namespace lgfx
         _bus_spi.release();
       }
 #endif
+
+// Feather S2 TFT screen is write-only, no LGFX_AUTODETECT
+#if defined ( LGFX_FEATHER_ESP32_S2_TFT )
+      if (board == 0 || board == board_t::board_Feather_ESP32_S2_TFT)
+      {
+        lgfx::pinMode(GPIO_NUM_21, lgfx::pin_mode_t::output);
+        lgfx::gpio_hi(GPIO_NUM_21); // Enable power to TFT
+        bus_cfg.pin_mosi = GPIO_NUM_35;
+        bus_cfg.pin_miso = -1;
+        bus_cfg.pin_sclk = GPIO_NUM_36;
+        bus_cfg.pin_dc   = GPIO_NUM_39;
+        bus_cfg.spi_mode = 0;
+        bus_cfg.spi_3wire = true;
+        _bus_spi.config(bus_cfg);
+        _bus_spi.init();
+        _pin_reset(GPIO_NUM_40, use_reset); // LCD RST
+        board = board_t::board_Feather_ESP32_S2_TFT;
+        ESP_LOGW(LIBRARY_NAME, "board_Feather_ESP32_S2_TFT");
+        bus_cfg.freq_write = 40000000;
+        _bus_spi.config(bus_cfg);
+        auto p = new Panel_ST7789();
+        p->bus(&_bus_spi);
+        {
+          auto cfg = p->config();
+          cfg.pin_cs  = GPIO_NUM_7;
+          cfg.pin_rst = GPIO_NUM_40;
+          cfg.panel_width  = 135;
+          cfg.panel_height = 240;
+          cfg.offset_x = 52;
+          cfg.offset_y = 40;
+          cfg.readable = false;
+          cfg.rgb_order = false;
+          cfg.invert = true;
+          cfg.offset_rotation = 1;
+          p->config(cfg);
+        }
+        _panel_last = p;
+        _set_pwm_backlight(GPIO_NUM_45, 0, 12000);
+
+        goto init_clear;
+      }
+#endif // end LGFX_FEATHER_ESP32_S2_TFT
 
       board = board_t::board_unknown;
 

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S2.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S2.hpp
@@ -30,6 +30,10 @@ Contributors:
   #define LGFX_FEATHER_ESP32_S2_TFT
 #endif
 
+#if defined ( ARDUINO_FUNHOUSE_ESP32S2 )
+  #define LGFX_FUNHOUSE
+#endif
+
 
 namespace lgfx
 {
@@ -259,6 +263,44 @@ namespace lgfx
         }
         _panel_last = p;
         _set_pwm_backlight(GPIO_NUM_45, 0, 12000);
+
+        goto init_clear;
+      }
+#endif // end LGFX_FEATHER_ESP32_S2_TFT
+
+// FunHouse screen is write-only, no LGFX_AUTODETECT
+#if defined ( LGFX_FUNHOUSE )
+      if (board == 0 || board == board_t::board_FunHouse)
+      {
+        bus_cfg.pin_mosi = GPIO_NUM_35;
+        bus_cfg.pin_miso = -1;
+        bus_cfg.pin_sclk = GPIO_NUM_36;
+        bus_cfg.pin_dc   = GPIO_NUM_39;
+        bus_cfg.spi_mode = 0;
+        bus_cfg.spi_3wire = true;
+        _bus_spi.config(bus_cfg);
+        _bus_spi.init();
+        _pin_reset(GPIO_NUM_41, use_reset); // LCD RST
+        board = board_t::board_FunHouse;
+        ESP_LOGW(LIBRARY_NAME, "board_FunHouse");
+        bus_cfg.freq_write = 40000000;
+        _bus_spi.config(bus_cfg);
+        auto p = new Panel_ST7789();
+        p->bus(&_bus_spi);
+        {
+          auto cfg = p->config();
+          cfg.pin_cs  = GPIO_NUM_40;
+          cfg.pin_rst = GPIO_NUM_41;
+          cfg.panel_width  = 240;
+          cfg.panel_height = 240;
+          cfg.readable = false;
+          cfg.rgb_order = false;
+          cfg.invert = true;
+          cfg.offset_rotation = 2;
+          p->config(cfg);
+        }
+        _panel_last = p;
+        _set_pwm_backlight(GPIO_NUM_21, 0, 12000);
 
         goto init_clear;
       }

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S3.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32S3.hpp
@@ -30,6 +30,10 @@ Contributors:
   #define LGFX_ESP32_S3_BOX
 #endif
 
+#if defined ( ARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT )
+  #define LGFX_FEATHER_ESP32_S3_TFT
+#endif
+
 
 namespace lgfx
 {
@@ -473,6 +477,48 @@ namespace lgfx
         _bus_spi.release();
       }
 #endif
+
+// Feather S3 TFT screen is write-only, no LGFX_AUTODETECT
+#if defined ( LGFX_FEATHER_ESP32_S3_TFT )
+      if (board == 0 || board == board_t::board_Feather_ESP32_S3_TFT)
+      {
+        lgfx::pinMode(GPIO_NUM_21, lgfx::pin_mode_t::output);
+        lgfx::gpio_hi(GPIO_NUM_21); // Enable power to TFT
+        bus_cfg.pin_mosi = GPIO_NUM_35;
+        bus_cfg.pin_miso = -1;
+        bus_cfg.pin_sclk = GPIO_NUM_36;
+        bus_cfg.pin_dc   = GPIO_NUM_39;
+        bus_cfg.spi_mode = 0;
+        bus_cfg.spi_3wire = true;
+        _bus_spi.config(bus_cfg);
+        _bus_spi.init();
+        _pin_reset(GPIO_NUM_40, use_reset); // LCD RST
+        board = board_t::board_Feather_ESP32_S3_TFT;
+        ESP_LOGW(LIBRARY_NAME, "board_Feather_ESP32_S3_TFT");
+        bus_cfg.freq_write = 40000000;
+        _bus_spi.config(bus_cfg);
+        auto p = new Panel_ST7789();
+        p->bus(&_bus_spi);
+        {
+          auto cfg = p->config();
+          cfg.pin_cs  = GPIO_NUM_7;
+          cfg.pin_rst = GPIO_NUM_40;
+          cfg.panel_width  = 135;
+          cfg.panel_height = 240;
+          cfg.offset_x = 52;
+          cfg.offset_y = 40;
+          cfg.readable = false;
+          cfg.rgb_order = false;
+          cfg.invert = true;
+          cfg.offset_rotation = 1;
+          p->config(cfg);
+        }
+        _panel_last = p;
+        _set_pwm_backlight(GPIO_NUM_45, 0, 12000);
+
+        goto init_clear;
+      }
+#endif // end LGFX_FEATHER_ESP32_S3_TFT
 
       board = board_t::board_unknown;
 

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD21.hpp
@@ -323,7 +323,6 @@ namespace lgfx
           cfg.readable = false;
           cfg.rgb_order = false;
           cfg.invert = false;
-          cfg.offset_rotation = 3;
           p->config(cfg);
         }
         p->setBus(&_bus_spi);

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
@@ -448,8 +448,6 @@ namespace lgfx
           cfg.pin_rst = samd51::PORT_B | 30;
           cfg.panel_width  = 240;
           cfg.panel_height = 240;
-          cfg.memory_width = 240;
-          cfg.memory_height = 320;
           cfg.readable = false;
           cfg.rgb_order = false;
           cfg.invert = true;

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_SAMD51.hpp
@@ -451,9 +451,9 @@ namespace lgfx
           cfg.memory_width = 240;
           cfg.memory_height = 320;
           cfg.readable = false;
-          cfg.rgb_order = true;
+          cfg.rgb_order = false;
           cfg.invert = true;
-          cfg.offset_rotation = 1;
+          cfg.offset_rotation = 2;
           p->config(cfg);
         }
         p->setBus(&_bus_spi);


### PR DESCRIPTION
Adding a few more Adafruit boards incrementally. This adds support for the Feather TFT ESP32 S2 and S3, and FunHouse. I’ll continue to do a few small groups like this rather than one big overwhelming pull request.

Additionally this fixes some small things in the prior PR for HalloWing boards; rotation offsets and RGB order were incorrect. Fixed now.

Haven’t tried adding an ESP32 board to the Arduino workflow before, so let’s see if this works. Thanks for looking!