### PR TITLE
Adafruit Monster M4sk support

### DIFF
--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -50,6 +50,7 @@ namespace lgfx
     , board_Feather_ESP32_S3_TFT
     , board_FunHouse
     , board_PyGamer
+    , board_MonsterM4sk
     };
   }
   using namespace boards;


### PR DESCRIPTION
This tentatively adds support for the Adafruit Monster M4sk board (SAMD51). It’s _very_ strange and I’ll understand if this doesn’t get merged, or requires changes.

This board is fairly unique in that it has two displays, each on a separate SPI bus, and one of them has non-speed-critical control lines (reset & backlight) managed through an I2C I/O expander (Adafruit Seesaw). As implemented here, the screens are distinct objects, there’s no attempt to “tile” them into a single raster. Probably for the best.

I was unsure what would be the most “LovyanGFX-like” way to handle the port expander. What’s done here, and this might be The Wrong Way, is that on Monster M4sk (and ONLY this board), the LGFX constructor can accept 1-2 arguments (pointer to an Adafruit_seesaw object, and optionally an I2C address). User code would have two LGFX objects, one per screen, one declared the conventional way and the other passing in the Seesaw object. e.g.:
```
Adafruit_seesaw seesaw;
LGFX lcd1;
LGFX lcd2(&seesaw, 0x49);
[...]
lcd1.init();
lcd2.init();
```
Nothing has been added to the Arduino workflow for this, as I was unsure how to add the two dependent libraries needed only for this board (Adafruit_seesaw and Adafruit_BusIO).

Additionally, this adds TCC PWM support (a slightly distinct peripheral from the TCs) for backlights, and fixes a compilation error in the TC code on odd SAMD51s like this one where there are fewer timers available.