### PR TITLE
esp32s3 compile error

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -643,7 +643,7 @@ namespace lgfx
         cmd_val |= (1 << 10); // ACK_VALUE (set NACK)
       }
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
-      (&dev->comd0)[index].val = cmd_val;
+      (&dev->comd[0])[index].val = cmd_val;
 #else
       dev->command[index].val = cmd_val;
 #endif

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -643,7 +643,11 @@ namespace lgfx
         cmd_val |= (1 << 10); // ACK_VALUE (set NACK)
       }
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
+ #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
       (&dev->comd[0])[index].val = cmd_val;
+ #else
+      (&dev->comd0)[index].val = cmd_val;
+ #endif
 #else
       dev->command[index].val = cmd_val;
 #endif


### PR DESCRIPTION
## Environment ( 実行環境 )

- MCU or Board name:  ESP-S3-WROOM-1
- Panel Driver IC:    ST7789
- Bus type:           SPI
- LovyanGFX version:  1.1.7
- FrameWork version:   ESP-IDF v5.0.2
- Build Environment :   vscode ESP-IDF
- Operating System:   mac os

Hello. I'm reporting because I think I found a bug.
I'm using ESP32-S3 and I wrote the code with ESP-IDF v5.0.2.
I wrote a code to output a simple GIF animation, but an error occurred on the common.cpp:646 line.

The error codes are as follows.
```cpp
{components_path}/LovyanGFX/src/lgfx/v1/platforms/esp32/common.cpp:646:14: 
error: 'struct i2c_dev_t' has no member named 'comd0'; did you mean 'comd'?
  646 |       (&dev->comd0)[index].val = cmd_val;
      |              ^~~~~
      |              comd
```

When I changed the code in this part, the LCD worked normally.
```cpp
// common.cpp:646
(&dev->comd[0])[index].val = cmd_val;
```

The code I executed is as follows.
```cpp
#include <LGFX_ST7789.hpp>

#include "duck.h"

static const char *TAG = "TFT";

static LGFX lcd;

extern "C" void app_main(void)
{
    lcd.init();
    lcd.setRotation(0);

    lcd.setSwapBytes(true);
    lcd.fillScreen(TFT_BLACK);

    // center x y
    int img_x = (lcd.width() - animation_width) / 2;
    int img_y = (lcd.height() - animation_height) / 2;

    int frame_delay = 20;

    while(1) {
        for(int i = 0; i < frames; i++)
        {
            vTaskDelay(frame_delay / portTICK_PERIOD_MS);
            lcd.pushImage(img_x, img_y, animation_width, animation_height, ani_img[i]);
        }
    }
}
```

Please check it out!
Thank you :D

