### PR TITLE
Add missing SPI configuration with default value

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -322,6 +322,7 @@ namespace lgfx
             .address_bits = 0,
             .dummy_bits = 0,
             .mode = 0,
+            .clock_source = SPI_CLK_SRC_DEFAULT,
             .duty_cycle_pos = 0,
             .cs_ena_pretrans = 0,
             .cs_ena_posttrans = 0,


### PR DESCRIPTION
This was causing a NPE warning in ESP-IDF 5.1
```
[1129/1212] Building CXX object esp-idf/LovyanGFX/CMakeFiles/__idf_LovyanGFX.dir/src/lgfx/v1/platforms/esp32/common.cpp.objC:/.../src/lgfx/v1/platforms/esp32/common.cpp: In function 'cpp::bitwizeshift::result<void, lgfx::v1::error_t> lgfx::v1::spi::init(int, int, int, int, int)':
C:/.../src/lgfx/v1/platforms/esp32/common.cpp:334:31: warning: missing initializer for member 'spi_device_interface_config_t::clock_source' [-Wmissing-field-initializers]
  334 |             .post_cb = nullptr};
      |                               ^
[1211/1212] Generating binary image from built executableesptool.py v4.6.2\
```