### PR TITLE
Set default CPU for SPI ISR

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -479,6 +479,9 @@ namespace lgfx
         buscfg.max_transfer_sz = 1;
         buscfg.flags = SPICOMMON_BUSFLAG_MASTER;
         buscfg.intr_flags = 0;
+#if ESP_IDF_VERSION_MAJOR > 5 || (ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1)
+        buscfg.isr_cpu_id = INTR_CPU_ID_AUTO;
+#endif
 
         if (ESP_OK != spi_bus_initialize(static_cast<spi_host_device_t>(spi_host), &buscfg, dma_channel))
         {


### PR DESCRIPTION
Fixes the error during SPI initialization with the ESP-IDF 5.1+:
```
E (417) spi_master: spi_master_init_driver(236): invalid core id
W (417) LGFX: Failed to spi_bus_add_device.
```