### PR TITLE
make the CMake_WASM example work again

### DIFF
--- a/examples_for_PC/CMake_WASM/CMakeLists.txt
+++ b/examples_for_PC/CMake_WASM/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 project (lv_wasm)
 
 add_definitions(-DLGFX_SDL)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -s USE_SDL=2")
+set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -g -s USE_SDL=2")
 
 include_directories(../../../LovyanGFX/src/)
 

--- a/examples_for_PC/CMake_WASM/LGFX_WASM.cpp
+++ b/examples_for_PC/CMake_WASM/LGFX_WASM.cpp
@@ -6,16 +6,15 @@
 void setup(void);
 void loop(void);
 
-void loopThread(void *arg)
+void loopThread(void)
 {
+  lgfx::Panel_sdl::loop();
   loop();
-  lgfx::Panel_sdl::sdl_event_handler();
 }
-
-int monitor_hor_res, monitor_ver_res;
 
 int main(int argc, char **argv)
 {
   setup();
-  emscripten_set_main_loop_arg(loopThread, NULL, -1, true);
+  lgfx::Panel_sdl::setup();
+  emscripten_set_main_loop(loopThread, -1, true);
 }

--- a/examples_for_PC/CMake_WASM/README.md
+++ b/examples_for_PC/CMake_WASM/README.md
@@ -14,4 +14,19 @@
 2. `cd build`
 3. `emcmake cmake ..`
 4. `emmake make`
+5. `http-server`
 5. open `index.html` in your browser.
+
+## Notes
+this is a debug build: `set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -g -s USE_SDL=2")`
+It uses the SDL2 library bundled with the Emscripten SDK so I think the `Install SDL``
+is not necessary
+
+### Debugging 
+I followed the [Debugging WebAssembly with modern tools](https://developer.chrome.com/blog/wasm-debugging-2020/) tutorial and was able to debug at the C source level just fine
+
+
+Steps:
+1. Install Chrome Canary
+2. Install the  C/C++ DevTools Support (DWARF) as outline 
+3. serve `index.html`  via `http-server` - opening file//wherever/index.html breaks debugging


### PR DESCRIPTION
this works for me including in-browser C-level debugging with the modified `lgfx::Panel_sdl` API 

unsure if this is the right way to do it - grateful for a review