### PR TITLE
Add ILI9806G panel support

### DIFF
--- a/src/lgfx/v1/panel/Panel_ILI9806.hpp
+++ b/src/lgfx/v1/panel/Panel_ILI9806.hpp
@@ -1,0 +1,118 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "Panel_LCD.hpp"
+
+namespace lgfx
+{
+  inline namespace v1
+  {
+    //----------------------------------------------------------------------------
+
+    struct Panel_ILI9806 : public Panel_LCD
+    {
+      Panel_ILI9806(void)
+      {
+        _cfg.memory_width = _cfg.panel_width = 480;
+        _cfg.memory_height = _cfg.panel_height = 854;
+      }
+
+    protected:
+      static constexpr uint8_t CMD_EXTC   = 0xFF;
+      static constexpr uint8_t CMD_SPISET = 0xBA;
+      static constexpr uint8_t CMD_GIP1   = 0xBC;
+      static constexpr uint8_t CMD_GIP2   = 0xBD;
+      static constexpr uint8_t CMD_GIP3   = 0xBE;
+      static constexpr uint8_t CMD_VCOM   = 0xC7;
+      static constexpr uint8_t CMD_VOLT   = 0xED;
+      static constexpr uint8_t CMD_PWCTR1 = 0xC0;
+      static constexpr uint8_t CMD_LVGVOT = 0xFC;
+      static constexpr uint8_t CMD_ENGSET = 0xDF;
+      static constexpr uint8_t CMD_DVDD   = 0xF3;
+      static constexpr uint8_t CMD_DSPINV = 0xB4;
+      static constexpr uint8_t CMD_RESOL  = 0xF7;
+      static constexpr uint8_t CMD_FPSCTL = 0xB1;
+      static constexpr uint8_t CMD_TMCTR1 = 0xF1;
+      static constexpr uint8_t CMD_TMCTR2 = 0xF2;
+      static constexpr uint8_t CMD_PWCTR2 = 0xC1;
+      static constexpr uint8_t CMD_GAMMAP = 0xE0;
+      static constexpr uint8_t CMD_GAMMAN = 0xE1;
+      static constexpr uint8_t CMD_TEAR   = 0x35;
+      static constexpr uint8_t CMD_MACTL  = 0x36;
+      static constexpr uint8_t CMD_PIXFMT = 0x3A;
+      static constexpr uint8_t CMD_SLPOUT = 0x11;
+      static constexpr uint8_t CMD_DISPON = 0x29;
+
+      const uint8_t *getInitCommands(uint8_t listno) const override
+      {
+        static constexpr uint8_t list0[] =
+            {
+                CMD_EXTC, 3, 0xFF, 0x98, 0x06,
+                CMD_SPISET, 1, 0xE0,
+                CMD_GIP1, 21, 0x03, 0x0F, 0x63, 0x69,
+                              0x01, 0x01, 0x1B, 0x11,
+                              0x70, 0x73, 0xFF, 0xFF,
+                              0x08, 0x09, 0x05, 0x00,
+                              0xEE, 0xE2, 0x01, 0x00,
+                              0xC1,
+                CMD_GIP2, 8,  0x01, 0x23, 0x45, 0x67,
+                              0x01, 0x23, 0x45, 0x67,
+                CMD_GIP3, 9,  0x00, 0x22, 0x27, 0x6A,
+                              0xBC, 0xD8, 0x92, 0x22, 0x22,
+                CMD_VCOM, 1,  0x1E,
+                CMD_VOLT, 3,  0x7F, 0x0F, 0x00,
+                CMD_PWCTR1,3, 0xE3, 0x0B, 0x00,
+                CMD_LVGVOT,1, 0x08,
+                CMD_ENGSET,6, 0x00, 0x00, 0x00, 0x00,
+                              0x00, 0x02,
+                CMD_DVDD,1,   0x74,
+                CMD_DSPINV,3, 0x00, 0x00, 0x00,
+                CMD_RESOL,1,  0x81,
+                CMD_FPSCTL,3, 0x00, 0x10, 0x14,
+                CMD_TMCTR1,3, 0x29, 0x8A, 0x07,
+                CMD_TMCTR2,4, 0x40, 0xD2, 0x50, 0x28,
+                CMD_PWCTR2,4, 0x17, 0x85, 0x85, 0x20,
+                CMD_GAMMAP,16,0x00, 0x0C, 0x15, 0x0D,
+                              0x0F, 0x0C, 0x07, 0x05,
+                              0x07, 0x0B, 0x10, 0x10,
+                              0x0D, 0x17, 0x0F, 0x00,
+                CMD_GAMMAN,16,0x00, 0x0D, 0x15, 0x0E,
+                              0x10, 0x0D, 0x08, 0x06,
+                              0x07, 0x0C, 0x11, 0x11,
+                              0x0E, 0x17, 0x0F, 0x00,
+                CMD_TEAR,1,   0x00,
+                CMD_MACTL,1,  0x60,
+                CMD_PIXFMT,1, 0x55,
+                CMD_SLPOUT, 0 + CMD_INIT_DELAY, 120, // Exit sleep mode
+                CMD_DISPON, 0 + CMD_INIT_DELAY, 100,
+                0xFF, 0xFF, // end
+            };
+        switch (listno)
+        {
+        case 0:
+          return list0;
+        default:
+          return nullptr;
+        }
+      }
+    };
+
+    //----------------------------------------------------------------------------
+  }
+}

--- a/src/lgfx/v1_init.hpp
+++ b/src/lgfx/v1_init.hpp
@@ -32,6 +32,7 @@ Contributors:
 #include "v1/panel/Panel_ILI9163.hpp"
 #include "v1/panel/Panel_ILI9225.hpp"
 #include "v1/panel/Panel_ILI9341.hpp"
+#include "v1/panel/Panel_ILI9806.hpp"
 #include "v1/panel/Panel_ILI9342.hpp"
 #include "v1/panel/Panel_ILI948x.hpp"
 #include "v1/panel/Panel_NT35510.hpp"


### PR DESCRIPTION
Add ILI9806G panel support
Tested with ESP32-S3-N16R8 module with 16bit Parallel Bus.

Module model: [TK050F5590 v1.3](https://www.aliexpress.com/i/1005003515899840.html)
Panel Driver IC is [ILI9806G](https://datasheetspdf.com/datasheet/ILI9806.html)
With capacitive touch screen, Driver IC is FT5436DQQ (Compatible with built-in FT5X06 driver)

Code of Configurations:

```cpp
#define LGFX_USE_V1
#include <LovyanGFX.hpp>

class LGFX : public lgfx::LGFX_Device
{
    lgfx::Panel_ILI9806     _panel_instance;
    lgfx::Bus_Parallel16  _bus_instance;
    lgfx::Light_PWM     _light_instance;
    lgfx::Touch_FT5x06           _touch_instance; // FT5206, FT5306, FT5406, FT6206, FT6236, FT6336, FT6436
  public:
    LGFX(void)
    {
      {
        auto cfg = _bus_instance.config();    // バス設定用の構造体を取得します。
        cfg.port = 0;
        cfg.freq_write = 20000000;
        cfg.pin_wr = 14;
        cfg.pin_rd = 42;
        cfg.pin_rs = 38;
        cfg.pin_d0 = 12;
        cfg.pin_d1 = 11;
        cfg.pin_d2 = 10;
        cfg.pin_d3 = 9;
        cfg.pin_d4 = 20;
        cfg.pin_d5 = 19;
        cfg.pin_d6 = 8;
        cfg.pin_d7 = 18;
        cfg.pin_d8 = 17;
        cfg.pin_d9 = 16;
        cfg.pin_d10 = 15;
        cfg.pin_d11 = 7;
        cfg.pin_d12 = 6;
        cfg.pin_d13 = 5;
        cfg.pin_d14 = 4;
        cfg.pin_d15 = 1;
        _bus_instance.config(cfg);
        _panel_instance.setBus(&_bus_instance);
      }
      {
        auto cfg = _panel_instance.config();
        cfg.pin_cs           =    39;
        cfg.pin_rst          =    13;
        cfg.pin_busy         =    -1;
        cfg.panel_width      =   480;  // 実際に表示可能な幅
        cfg.panel_height     =   854;  // 実際に表示可能な高さ
        cfg.offset_x         =     0;  // パネルのX方向オフセット量
        cfg.offset_y         =     0;  // パネルのY方向オフセット量
        cfg.offset_rotation  =     1;  // 回転方向の値のオフセット 0~7 (4~7は上下反転)
        cfg.dummy_read_pixel =     8;  // ピクセル読出し前のダミーリードのビット数
        cfg.dummy_read_bits  =     1;  // ピクセル以外のデータ読出し前のダミーリードのビット数
        cfg.readable         =  false;  // データ読出しが可能な場合 trueに設定
        cfg.invert           = false;  // パネルの明暗が反転してしまう場合 trueに設定
        cfg.rgb_order        = true;  // パネルの赤と青が入れ替わってしまう場合 trueに設定
        cfg.dlen_16bit       = true;  // 16bitパラレルやSPIでデータ長を16bit単位で送信するパネルの場合 trueに設定
        cfg.bus_shared       =  true;  // SDカードとバスを共有している場合 trueに設定(drawJpgFile等でバス制御を行います)
        _panel_instance.config(cfg);
      }
      {
        auto cfg = _light_instance.config();    // バックライト設定用の構造体を取得します。
        cfg.pin_bl = 2;              // バックライトが接続されているピン番号
        cfg.invert = false;           // バックライトの輝度を反転させる場合 true
        cfg.freq   = 44100;           // バックライトのPWM周波数
        cfg.pwm_channel = 7;          // 使用するPWMのチャンネル番号
        _light_instance.config(cfg);
        _panel_instance.setLight(&_light_instance);  // バックライトをパネルにセットします。
      }
      {
        auto cfg = _touch_instance.config();
        cfg.x_min      = 0;    // タッチスクリーンから得られる最小のX値(生の値)
        cfg.x_max      = 854;  // タッチスクリーンから得られる最大のX値(生の値)
        cfg.y_min      = 0;    // タッチスクリーンから得られる最小のY値(生の値)
        cfg.y_max      = 480;  // タッチスクリーンから得られる最大のY値(生の値)
        cfg.pin_int    = 21;   // INTが接続されているピン番号
        cfg.bus_shared = true; // 画面と共通のバスを使用している場合 trueを設定
        cfg.offset_rotation = 3;// 表示とタッチの向きのが一致しない場合の調整 0~7の値で設定
        cfg.i2c_port = 0;      // 使用するI2Cを選択 (0 or 1)
        cfg.i2c_addr = 0x38;   // I2Cデバイスアドレス番号
        cfg.pin_sda  = 41;     // SDAが接続されているピン番号
        cfg.pin_scl  = 40;     // SCLが接続されているピン番号
        cfg.freq = 400000;     // I2Cクロックを設定
        _touch_instance.config(cfg);
        _panel_instance.setTouch(&_touch_instance);  // タッチスクリーンをパネルにセットします。
      }
      setPanel(&_panel_instance); // 使用するパネルをセットします。
    }
};

// 準備したクラスのインスタンスを作成します。
LGFX display;
```

![be00528bf08731bd8a974d4fb37d7c9](https://github.com/lovyan03/LovyanGFX/assets/17931025/e07f9cf5-126b-4617-a90d-b8072d267c85)
