### PR TITLE
Add three new Elecrow ESP32 Display devices

### DIFF
--- a/src/lgfx_user/LGFX_Elecrow_ESP32_Display_DLC35010R.h
+++ b/src/lgfx_user/LGFX_Elecrow_ESP32_Display_DLC35010R.h
@@ -1,0 +1,96 @@
+#define LGFX_USE_V1
+#include <LovyanGFX.hpp>
+
+#include <lgfx/v1/panel/Panel_ILI948x.hpp>
+#include <lgfx/v1/platforms/esp32s3/Bus_Parallel16.hpp>
+
+// LGFX for Elecrow 3.5" 480x320 ESP32 parallel touch display with ILI9488 (DLC35010R)
+// https://www.elecrow.com/esp-terminal-with-esp32-3-5-inch-parallel-480x320-tft-capacitive-touch-display-rgb-by-chip-ili9488.html
+
+class LGFX : public lgfx::LGFX_Device
+{
+public:
+  lgfx::Bus_Parallel16 _bus_instance;
+  lgfx::Panel_ILI9488 _panel_instance;
+  lgfx::Light_PWM     _light_instance;
+  lgfx::Touch_FT5x06  _touch_instance;
+
+  LGFX(void)
+  {
+    {
+      auto cfg = _bus_instance.config();
+
+      cfg.freq_write = 40000000;
+      cfg.pin_wr = GPIO_NUM_18;
+      cfg.pin_rd = GPIO_NUM_48;
+      cfg.pin_rs = GPIO_NUM_45;
+
+      cfg.pin_d0  = GPIO_NUM_47;
+      cfg.pin_d1  = GPIO_NUM_21;
+      cfg.pin_d2  = GPIO_NUM_14;
+      cfg.pin_d3  = GPIO_NUM_13;
+      cfg.pin_d4  = GPIO_NUM_12;
+      cfg.pin_d5  = GPIO_NUM_11;
+      cfg.pin_d6  = GPIO_NUM_10;
+      cfg.pin_d7  = GPIO_NUM_9;
+      cfg.pin_d8  = GPIO_NUM_3;
+      cfg.pin_d9  = GPIO_NUM_8;
+      cfg.pin_d10 = GPIO_NUM_16;
+      cfg.pin_d11 = GPIO_NUM_15;
+      cfg.pin_d12 = GPIO_NUM_7;
+      cfg.pin_d13 = GPIO_NUM_6;
+      cfg.pin_d14 = GPIO_NUM_5;
+      cfg.pin_d15 = GPIO_NUM_4;
+      _bus_instance.config(cfg);
+      _panel_instance.bus(&_bus_instance);
+    }
+
+    {
+      auto cfg = _panel_instance.config();
+      cfg.panel_width     = 320;
+      cfg.panel_height    = 480;
+      cfg.offset_x        = 0;
+      cfg.offset_y        = 0;
+      cfg.pin_cs          = GPIO_NUM_NC;
+      cfg.pin_rst         = GPIO_NUM_NC;
+      cfg.pin_busy        = GPIO_NUM_NC;
+      cfg.offset_rotation = 3;
+      cfg.readable        = true;
+      cfg.invert          = false;
+      cfg.rgb_order       = false;
+      cfg.dlen_16bit      = true;
+      cfg.bus_shared      = false;
+
+      _panel_instance.config(cfg);
+    }
+
+    {
+      auto cfg = _light_instance.config();
+
+      cfg.pin_bl = GPIO_NUM_46;
+
+      _light_instance.config(cfg);
+      _panel_instance.light(&_light_instance);
+    }
+
+    {
+      auto cfg = _touch_instance.config();
+      cfg.i2c_port = 0;
+      cfg.i2c_addr = 0x38;
+      cfg.pin_sda  = GPIO_NUM_38;
+      cfg.pin_scl  = GPIO_NUM_39;
+      cfg.pin_int  = GPIO_NUM_NC;
+      cfg.freq     = 400000;
+      
+      cfg.x_min = 0;
+      cfg.x_max = 319;
+      cfg.y_min = 0;
+      cfg.y_max = 479;
+
+      _touch_instance.config(cfg);
+      _panel_instance.setTouch(&_touch_instance);
+    }
+
+    setPanel(&_panel_instance);
+  }
+};

--- a/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C050.h
+++ b/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C050.h
@@ -1,0 +1,105 @@
+#define LGFX_USE_V1
+#include <LovyanGFX.hpp>
+
+#include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
+#include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
+#include <driver/i2c.h>
+
+// LGFX for Elecrow 5" 800x480 ESP32 RGB touch display (WZ8048C050)
+// https://www.elecrow.com/esp32-display-5-inch-hmi-display-rgb-tft-lcd-touch-screen-support-lvgl.html
+
+class LGFX : public lgfx::LGFX_Device
+{
+public:
+  lgfx::Bus_RGB _bus_instance;
+  lgfx::Panel_RGB _panel_instance;
+  lgfx::Light_PWM _light_instance;
+  lgfx::Touch_GT911 _touch_instance;
+  LGFX(void)
+  {
+    {
+      auto cfg = _panel_instance.config();
+      cfg.memory_width  = 800;
+      cfg.memory_height = 480;
+      cfg.panel_width   = 800;
+      cfg.panel_height  = 480;
+      cfg.offset_x      = 0;
+      cfg.offset_y      = 0;
+      _panel_instance.config(cfg);
+    }
+
+    {
+      auto cfg = _bus_instance.config();
+      cfg.panel = &_panel_instance;
+
+      cfg.pin_d0  = GPIO_NUM_8;  // B0
+      cfg.pin_d1  = GPIO_NUM_3;  // B1
+      cfg.pin_d2  = GPIO_NUM_46; // B2
+      cfg.pin_d3  = GPIO_NUM_9;  // B3
+      cfg.pin_d4  = GPIO_NUM_1;  // B4
+
+      cfg.pin_d5  = GPIO_NUM_5;  // G0
+      cfg.pin_d6  = GPIO_NUM_6;  // G1
+      cfg.pin_d7  = GPIO_NUM_7;  // G2
+      cfg.pin_d8  = GPIO_NUM_15; // G3
+      cfg.pin_d9  = GPIO_NUM_16; // G4
+      cfg.pin_d10 = GPIO_NUM_4;  // G5
+
+      cfg.pin_d11 = GPIO_NUM_45; // R0
+      cfg.pin_d12 = GPIO_NUM_48; // R1
+      cfg.pin_d13 = GPIO_NUM_47; // R2
+      cfg.pin_d14 = GPIO_NUM_21; // R3
+      cfg.pin_d15 = GPIO_NUM_14; // R4
+
+      cfg.pin_henable = GPIO_NUM_40;
+      cfg.pin_vsync   = GPIO_NUM_41;
+      cfg.pin_hsync   = GPIO_NUM_39;
+      cfg.pin_pclk    = GPIO_NUM_0;
+      cfg.freq_write  = 12000000;
+
+      cfg.hsync_polarity    = 0;
+      cfg.hsync_front_porch = 8;
+      cfg.hsync_pulse_width = 4;
+      cfg.hsync_back_porch  = 43;
+
+      cfg.vsync_polarity    = 0;
+      cfg.vsync_front_porch = 8;
+      cfg.vsync_pulse_width = 4;
+      cfg.vsync_back_porch  = 12;
+
+      cfg.pclk_active_neg = 1;
+      cfg.de_idle_high    = 0;
+      cfg.pclk_idle_high  = 0;
+
+      _bus_instance.config(cfg);
+    }
+    _panel_instance.setBus(&_bus_instance);
+
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_bl = GPIO_NUM_2;
+      _light_instance.config(cfg);
+    }
+    _panel_instance.light(&_light_instance);
+
+    {
+      auto cfg = _touch_instance.config();
+      cfg.x_min       = 0;
+      cfg.x_max       = 799;
+      cfg.y_min       = 0;
+      cfg.y_max       = 479;
+      cfg.pin_int     = -1;
+      cfg.pin_rst     = -1;
+      cfg.bus_shared  = false;
+      cfg.offset_rotation = 0;
+      cfg.i2c_port    = I2C_NUM_1;
+      cfg.pin_sda     = GPIO_NUM_19;
+      cfg.pin_scl     = GPIO_NUM_20;
+      cfg.freq        = 400000;
+      cfg.i2c_addr    = 0x14;
+      _touch_instance.config(cfg);
+      _panel_instance.setTouch(&_touch_instance);
+    }
+    setPanel(&_panel_instance);
+  }
+};

--- a/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C070.h
+++ b/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C070.h
@@ -1,0 +1,105 @@
+#define LGFX_USE_V1
+#include <LovyanGFX.hpp>
+
+#include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
+#include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
+#include <driver/i2c.h>
+
+// LGFX for Elecrow 7" 800x480 ESP32 RGB touch display (WZ8048C070)
+// https://www.elecrow.com/esp32-display-7-inch-hmi-display-rgb-tft-lcd-touch-screen-support-lvgl.html
+
+class LGFX : public lgfx::LGFX_Device
+{
+public:
+  lgfx::Bus_RGB _bus_instance;
+  lgfx::Panel_RGB _panel_instance;
+  lgfx::Light_PWM _light_instance;
+  lgfx::Touch_GT911 _touch_instance;
+  LGFX(void)
+  {
+    {
+      auto cfg = _panel_instance.config();
+      cfg.memory_width  = 800;
+      cfg.memory_height = 480;
+      cfg.panel_width   = 800;
+      cfg.panel_height  = 480;
+      cfg.offset_x      = 0;
+      cfg.offset_y      = 0;
+      _panel_instance.config(cfg);
+    }
+
+    {
+      auto cfg = _bus_instance.config();
+      cfg.panel = &_panel_instance;
+
+      cfg.pin_d0  = GPIO_NUM_15; // B0
+      cfg.pin_d1  = GPIO_NUM_7;  // B1
+      cfg.pin_d2  = GPIO_NUM_6;  // B2
+      cfg.pin_d3  = GPIO_NUM_5;  // B3
+      cfg.pin_d4  = GPIO_NUM_4;  // B4
+
+      cfg.pin_d5  = GPIO_NUM_9;  // G0
+      cfg.pin_d6  = GPIO_NUM_46; // G1
+      cfg.pin_d7  = GPIO_NUM_3;  // G2
+      cfg.pin_d8  = GPIO_NUM_8;  // G3
+      cfg.pin_d9  = GPIO_NUM_16; // G4
+      cfg.pin_d10 = GPIO_NUM_1;  // G5
+
+      cfg.pin_d11 = GPIO_NUM_14; // R0
+      cfg.pin_d12 = GPIO_NUM_21; // R1
+      cfg.pin_d13 = GPIO_NUM_47; // R2
+      cfg.pin_d14 = GPIO_NUM_48; // R3
+      cfg.pin_d15 = GPIO_NUM_45; // R4
+
+      cfg.pin_henable = GPIO_NUM_41;
+      cfg.pin_vsync   = GPIO_NUM_40;
+      cfg.pin_hsync   = GPIO_NUM_39;
+      cfg.pin_pclk    = GPIO_NUM_0;
+      cfg.freq_write  = 12000000;
+
+      cfg.hsync_polarity    = 0;
+      cfg.hsync_front_porch = 40;
+      cfg.hsync_pulse_width = 48;
+      cfg.hsync_back_porch  = 40;
+
+      cfg.vsync_polarity    = 0;
+      cfg.vsync_front_porch = 1;
+      cfg.vsync_pulse_width = 31;
+      cfg.vsync_back_porch  = 13;
+
+      cfg.pclk_active_neg = 1;
+      cfg.de_idle_high    = 0;
+      cfg.pclk_idle_high  = 0;
+
+      _bus_instance.config(cfg);
+    }
+    _panel_instance.setBus(&_bus_instance);
+
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_bl = GPIO_NUM_2;
+      _light_instance.config(cfg);
+    }
+    _panel_instance.light(&_light_instance);
+
+    {
+      auto cfg = _touch_instance.config();
+      cfg.x_min       = 0;
+      cfg.x_max       = 799;
+      cfg.y_min       = 0;
+      cfg.y_max       = 479;
+      cfg.pin_int     = -1;
+      cfg.pin_rst     = -1;
+      cfg.bus_shared  = false;
+      cfg.offset_rotation = 0;
+      cfg.i2c_port    = I2C_NUM_1;
+      cfg.pin_sda     = GPIO_NUM_19;
+      cfg.pin_scl     = GPIO_NUM_20;
+      cfg.freq        = 400000;
+      cfg.i2c_addr    = 0x14;
+      _touch_instance.config(cfg);
+      _panel_instance.setTouch(&_touch_instance);
+    }
+    setPanel(&_panel_instance);
+  }
+};


### PR DESCRIPTION
Adding configs for these three displays.
* https://www.elecrow.com/esp-terminal-with-esp32-3-5-inch-parallel-480x320-tft-capacitive-touch-display-rgb-by-chip-ili9488.html
* https://www.elecrow.com/esp32-display-5-inch-hmi-display-rgb-tft-lcd-touch-screen-support-lvgl.html
* https://www.elecrow.com/esp32-display-7-inch-hmi-display-rgb-tft-lcd-touch-screen-support-lvgl.html