### PR TITLE
fix Light_PWM backlight not works under arduino-esp32 v3.0 (IDF 5)

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -109,7 +109,11 @@ namespace lgfx
     if (_cfg.invert) duty = (1 << PWM_BITS) - duty;
 
 #if defined ( ARDUINO )
+#if defined LEDC_USE_IDF_V5
+      ledcWrite(_cfg.pin_bl, duty);
+#else
       ledcWrite(_cfg.pwm_channel, duty);
+#endif
 #elif SOC_LEDC_SUPPORT_HS_MODE
       ledc_set_duty(LEDC_HIGH_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel, duty);
       ledc_update_duty(LEDC_HIGH_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel);


### PR DESCRIPTION
With arduino-esp32 v3.0, in the new ledcWrite() API we should use the GPIO pin number instead of pwm channel number ([ref](https://espressif-docs.readthedocs-hosted.com/projects/arduino-esp32/en/latest/api/ledc.html#ledcwrite)).