### PR TITLE
User function and plugins support for LGFX_Base and LGFX_Sprite

### DIFF
--- a/src/lgfx/v1/LGFXBase.hpp
+++ b/src/lgfx/v1/LGFXBase.hpp
@@ -1369,6 +1369,10 @@ namespace lgfx
     inline uint_fast8_t getTouch(touch_point_t *tp, uint_fast8_t count = 1) { return panel()->getTouch(tp, count); }
     inline void convertRawXY(touch_point_t *tp, uint_fast8_t count = 1) { panel()->convertRawXY(tp, count); }
 
+    // LGFX plugin support!
+    template <typename Fn, typename... Args>
+    void userFunc(Fn fn, Args... args) { fn(this, args...); }
+
     template <typename T>
     uint_fast8_t getTouchRaw(T *x, T *y, uint_fast8_t index = 0)
     {

--- a/src/lgfx/v1/LGFX_Sprite.hpp
+++ b/src/lgfx/v1/LGFX_Sprite.hpp
@@ -369,6 +369,11 @@ namespace lgfx
                          void pushAffineWithAA(                const float matrix[6])                  { push_affine_aa(_parent, matrix); }
                          void pushAffineWithAA(LovyanGFX* dst, const float matrix[6])                  { push_affine_aa(    dst, matrix); }
 
+    // LGFX plugin support!
+    template <typename Fn, typename... Args>
+    void userFunc(Fn fn, Args... args) { fn(this, args...); }
+
+
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
This change adds the possibility to call LGFX object with a user function, it can make life easier when creating plugins that work on top of LovyanGFX.

Example:

```cpp

void my_circle_function( LovyanGFX* dst, int32_t x, int32_t y, uint32_t radius,  uint32_t color1 , uint32_t color2 )
{
   dst->fillCircle( x, y, radius, color1 );
   dst->fillCircle( x, y, radius/2, color2 );
}

// optional macro to use tft.funCircle(...) without calling 'userFunc'
#define funCircle(...)  userFunc( my_circle_function, __VA_ARGS__);

void setup()
{
  tft.init();

  tft.userFunc( my_circle_function, 100, 100, 50, 0xff0000u, 0x00ffffu );
  // or if using the optional macro:
  tft.funCircle( 100, 100, 50, 0xff0000u, 0x00ffffu );
}

```

