### PR TITLE
Fixes to Platformio env=native

### DIFF
--- a/examples_for_PC/PlatformIO_SDL/README-en.md
+++ b/examples_for_PC/PlatformIO_SDL/README-en.md
@@ -1,0 +1,106 @@
+
+## Steps to use LovyanGFX in Visual Studio Code + PlatformIO + SDL2 environment
+
+First, install Visual Studio Code and install its PlatformIO extension.
+
+ ---
+
+### Install tools for PlatformIO `platform = native` builds
+
+`Installation` Follow the installation steps from this URL
+https://docs.platformio.org/en/latest/platforms/native.html#installation
+
+The instructions below repeat the instructions given by the URL above with additional clarifications.
+
+#### For Linux
+
+Use `apt` to install the basic compilation tools from a shell prompt
+```
+sudo apt update
+sudo apt install build-essential
+```
+
+#### For macOS
+Use `xcode-select` to install xcode compilation tools from a Terminal
+```
+xcode-select --install
+```
+
+#### For Windows
+Get `MSYS2` from  https://www.msys2.org/ and install it.  From the MSYS command window that appears after installation, run this command to install the compiler:
+```
+pacman -S mingw-w64-ucrt-x86_64-gcc
+```
+
+Edit the Windows System Environment Variables (search the web for instructions) and add these to the System variables `Path` variable
+```
+C:\msys64\mingw32\bin
+C:\msys64\ucrt64\bin
+C:\msys64\usr\bin
+```
+
+
+ ---
+
+### Install SDL2
+
+Install `SDL2` per these instructions
+https://docs.lvgl.io/latest/en/html/get-started/pc-simulator.html#install-sdl-2
+
+
+#### For Linux
+
+Install libsdl2 using apt-get
+
+```
+sudo apt-get install libsdl2 libsdl2-dev
+```
+
+#### For MacOS OSX
+
+Install sdl2 using Homebrew
+```
+ brew install sdl2
+```
+
+#### For Windows
+
+`platform = native`  In the steps above, msys2 was installed, so get the SDL2-devel-x.xx.x-mingw release package from the SDL2 Github repository at
+https://github.com/libsdl-org/SDL/releases
+
+The filename at the time these instructions were written was `SDL2-devel-2.30.0-mingw.zip`.
+Unzip it, open the folder inside `x86_64-w64-mingw32`, and confirm that the following four folders appear inside.
+ - share
+ - bin
+ - include
+ - lib
+
+Open `C:\msys64\mingw32\` and confirm that it also contains those four folders, then add the contents of the fourfSDL2 folders to those inside `C:\msys64\mingw32\`.  Typically, those four mingw32 folders are initially empty, so you can simply overwrite the mingw32 folders with the SDL2 ones.
+
+ ---
+
+### Compiling and Running the example program
+
+#### Copy files
+
+Copy files from this directory to the top level directory of this repostory
+
+<LovyanGFX>/examples_for_PC/PlatformIO_SDL/platformio.ini to <LovyanGFX>/platformio.ini
+<LovyanGFX>/examples_for_PC/PlatformIO_SDL/src/user_code.cpp to <LovyanGFX>/src/user_code.cpp
+<LovyanGFX>/examples_for_PC/PlatformIO_SDL/src/sdl_main.cpp to <LovyanGFX>/src/sdl_main.cpp
+
+#### Build the program
+
+In VsCode, open the folder at the top level of this repository.  The first time that you do so, PlatformIO will install a lot of packages.
+
+Select the native build environment.  At the bottom of the VsCode window, there should be an icon to select the environment.  Its initial value should be like `Default (LoyvanGFX)`.  Click on it and select `env:native` from the dropdown menu.
+
+Build the program by clicking on the checkmark icon at the bottom of the VsCode window; its tooltip is PlatformIO:Build. 
+
+#### Run the program
+
+Run the program by starting a terminal - click on the icon at the bottom of the VsCode window whose tooltip is PlatformIO:New Terminal .  Inside the terminal window that appears, type this command
+
+```
+.pio/build/native/program
+```

--- a/examples_for_PC/PlatformIO_SDL/README-en.md
+++ b/examples_for_PC/PlatformIO_SDL/README-en.md
@@ -83,14 +83,6 @@ Open `C:\msys64\mingw32\` and confirm that it also contains those four folders, 
 
 #### Build the program
 
-#### Copy files
-
-Copy files from this directory to the top level directory of this repostory
-
-<LovyanGFX>/examples_for_PC/PlatformIO_SDL/platformio.ini to <LovyanGFX>/platformio.ini
-<LovyanGFX>/src/user_code.cpp to <LovyanGFX>/src/user_code.cpp
-<LovyanGFX>/examples_for_PC/PlatformIO_SDL/src/sdl_main.cpp to <LovyanGFX>/src/sdl_main.cpp
-
 In VsCode, open this folder, i.e. <LovyanGFX>/examples_for_PC/PlatformIO_SDL/.  The first time that you do so, PlatformIO will install a lot of packages.
 
 Build the program by clicking on the checkmark icon at the bottom of the VsCode window; its tooltip is PlatformIO:Build. 

--- a/examples_for_PC/PlatformIO_SDL/README-en.md
+++ b/examples_for_PC/PlatformIO_SDL/README-en.md
@@ -81,25 +81,23 @@ Open `C:\msys64\mingw32\` and confirm that it also contains those four folders, 
 
 ### Compiling and Running the example program
 
+#### Build the program
+
 #### Copy files
 
 Copy files from this directory to the top level directory of this repostory
 
 <LovyanGFX>/examples_for_PC/PlatformIO_SDL/platformio.ini to <LovyanGFX>/platformio.ini
-<LovyanGFX>/examples_for_PC/PlatformIO_SDL/src/user_code.cpp to <LovyanGFX>/src/user_code.cpp
+<LovyanGFX>/src/user_code.cpp to <LovyanGFX>/src/user_code.cpp
 <LovyanGFX>/examples_for_PC/PlatformIO_SDL/src/sdl_main.cpp to <LovyanGFX>/src/sdl_main.cpp
 
-#### Build the program
-
-In VsCode, open the folder at the top level of this repository.  The first time that you do so, PlatformIO will install a lot of packages.
-
-Select the native build environment.  At the bottom of the VsCode window, there should be an icon to select the environment.  Its initial value should be like `Default (LoyvanGFX)`.  Click on it and select `env:native` from the dropdown menu.
+In VsCode, open this folder, i.e. <LovyanGFX>/examples_for_PC/PlatformIO_SDL/.  The first time that you do so, PlatformIO will install a lot of packages.
 
 Build the program by clicking on the checkmark icon at the bottom of the VsCode window; its tooltip is PlatformIO:Build. 
 
 #### Run the program
 
-Run the program by starting a terminal - click on the icon at the bottom of the VsCode window whose tooltip is PlatformIO:New Terminal .  Inside the terminal window that appears, type this command
+Run the program by starting a terminal - click on the icon at the bottom of the VsCode window whose tooltip is "PlatformIO:New Terminal" .  Inside the terminal window that appears, type this command
 
 ```
 .pio/build/native/program

--- a/examples_for_PC/PlatformIO_SDL/platformio.ini
+++ b/examples_for_PC/PlatformIO_SDL/platformio.ini
@@ -16,6 +16,8 @@ build_flags = -O0 -xc++ -std=c++14 -lSDL2
   -L"/usr/local/lib"                         ; for intel mac homebrew SDL2
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2" ; for arm mac homebrew SDL2
   -L"${sysenv.HOMEBREW_PREFIX}/lib"          ; for arm mac homebrew SDL2
+  -I"C:/msys64/mingw32/include/SDL2"         ; for Windows SDL2
+  -L"C:/msys64/mingw32/lib"                  ; for Windows SDL2
 
 [esp32_base]
 build_type = debug

--- a/examples_for_PC/PlatformIO_SDL/platformio.ini
+++ b/examples_for_PC/PlatformIO_SDL/platformio.ini
@@ -8,6 +8,12 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+default_envs = native
+
+[env]
+lib_extra_dirs=../../
+
 [env:native]
 platform = native
 build_type = debug


### PR DESCRIPTION
This patch adds Windows entries to the include and library paths in examples_for_PC/PlatformIO_SDL/platformio.ini and adds an English language version of the README.md file in that directory.  README-en.md contains additional information about final setup, compilation, and running the program under VsCode/PlatformIO that is not in the original version. 