### PR TITLE
For Situation where we are emulating a ARDUINO with portdunio on a LINUX Machine

### DIFF
--- a/src/lgfx/v1/platforms/arduino_default/common.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.cpp
@@ -15,6 +15,7 @@ Contributors:
  [mongonta0716](https://github.com/mongonta0716)
  [tobozo](https://github.com/tobozo)
 /----------------------------------------------------------------------------*/
+#ifndef PORTDUINO_LINUX_HARDWARE
 #if defined (ESP_PLATFORM)
 #elif defined (ESP8266)
 #elif defined (__SAMD21__) || defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
@@ -105,4 +106,5 @@ namespace lgfx
  }
 }
 
+#endif
 #endif

--- a/src/lgfx/v1/platforms/arduino_default/common.hpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.hpp
@@ -16,7 +16,7 @@ Contributors:
  [tobozo](https://github.com/tobozo)
 /----------------------------------------------------------------------------*/
 #pragma once
-
+#ifndef PORTDUINO_LINUX_HARDWARE
 #include "../../misc/DataWrapper.hpp"
 #include "../../misc/enum.hpp"
 #include "../../../utility/result.hpp"
@@ -175,3 +175,4 @@ namespace lgfx
 //----------------------------------------------------------------------------
  }
 }
+#endif

--- a/src/lgfx/v1/platforms/common.hpp
+++ b/src/lgfx/v1/platforms/common.hpp
@@ -45,13 +45,14 @@ Contributors:
 
 #include "rp2040/common.hpp"
 
-#elif defined (ARDUINO)
-
-#include "arduino_default/common.hpp"
-
-#elif __has_include(<SDL2/SDL.h>) || __has_include(<SDL.h>)
-
-#include "sdl/common.hpp"
+#elif defined (ARDUINO) 
+ #if __has_include(<SDL2/SDL.h>) || __has_include(<SDL.h>)
+  #include "sdl/common.hpp"
+ #else
+  #include "arduino_default/common.hpp"
+ #endif
+//#elif __has_include(<SDL2/SDL.h>) || __has_include(<SDL.h>)
+//#include "sdl/common.hpp"
 
 #elif __has_include(<opencv2/opencv.hpp>)
 


### PR DESCRIPTION
During the development of a GUI for the meshtastic project we faced a problem during build in a situation where we are emulating a ARDUINO on linux with portdunio lib, but want to use SDL2 for native X11 GUI. At the moment we can just be ARDUINO or SDL2. But with portduino we need to be a ARDUINO using the SDL2 includes. There for I have changed the decission tree what should be included if we are a Arduino but with Portdunio Lib it uses SDL2 when included. Another way would maybe just to change order of the elifs starting with SDL and not ARDUINO. Then even if you have ARDUINO defined SDL2 would be included as first leaving out the ARDUINO includes. This is a special constellation where LINUX emulates a ARDUINO device and wants to use X11 or FrameBuffer.   