### PR TITLE
Enable stdio filesystem support

### DIFF
--- a/src/lgfx/v1/lgfx_filesystem_support.hpp
+++ b/src/lgfx/v1/lgfx_filesystem_support.hpp
@@ -264,9 +264,9 @@ namespace lgfx
   #endif
  #endif
 
-#elif defined(stdin) // ESP-IDF, Harmony, stdio
-      // #elif defined (ESP_PLATFORM) || defined(__SAMD51_HARMONY__) || defined(stdin) // ESP-IDF, Harmony, stdio
+#elif defined (ESP_PLATFORM) || defined(__SAMD51_HARMONY__)
       // esp32 and samd51 platforms do not have FileWrapper
+#elif defined(stdin)
 
   #define LGFX_FUNCTION_GENERATOR(drawImg) \
     inline bool drawImg##File(const char *path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left) \

--- a/src/lgfx/v1/lgfx_filesystem_support.hpp
+++ b/src/lgfx/v1/lgfx_filesystem_support.hpp
@@ -62,6 +62,7 @@ namespace lgfx
     using Base::drawPngFile;
     using Base::drawQoiFile;
     using Base::loadFont;
+    using Base::load_font_with_path;
 
 #if defined (ARDUINO)
 
@@ -262,7 +263,7 @@ namespace lgfx
 
   #endif
  #endif
-/*
+
 #elif defined (ESP_PLATFORM) || defined(__SAMD51_HARMONY__) || defined(stdin) // ESP-IDF, Harmony, stdio
 
   #define LGFX_FUNCTION_GENERATOR(drawImg) \
@@ -290,7 +291,7 @@ namespace lgfx
       init_font_file<FileWrapper>();
       return load_font_with_path(path);
     }
-//*/
+
 #endif
 
 #define LGFX_URL_MAXLENGTH 2083

--- a/src/lgfx/v1/lgfx_filesystem_support.hpp
+++ b/src/lgfx/v1/lgfx_filesystem_support.hpp
@@ -264,7 +264,9 @@ namespace lgfx
   #endif
  #endif
 
-#elif defined (ESP_PLATFORM) || defined(__SAMD51_HARMONY__) || defined(stdin) // ESP-IDF, Harmony, stdio
+#elif defined(stdin) // ESP-IDF, Harmony, stdio
+      // #elif defined (ESP_PLATFORM) || defined(__SAMD51_HARMONY__) || defined(stdin) // ESP-IDF, Harmony, stdio
+      // esp32 and samd51 platforms do not have FileWrapper
 
   #define LGFX_FUNCTION_GENERATOR(drawImg) \
     inline bool drawImg##File(const char *path, int32_t x = 0, int32_t y = 0, int32_t maxWidth = 0, int32_t maxHeight = 0, int32_t offX = 0, int32_t offY = 0, float scale_x = 1.0f, float scale_y = 0.0f, datum_t datum = datum_t::top_left) \


### PR DESCRIPTION
It was commented out.  Uncommenting it and adding a namespace qualifier to load_font_with_path made it work great.  Tested with platformio native builds on Windows/Mingw32

I'm not sure why it was not enabled.  My guess is that it failed to compile due to the missing Base:: on load_font_with_path(), and nobody had time to track down that problem.