### PR TITLE
arduino_default SPI and I2C enhancements

### DIFF
--- a/src/lgfx/v1/platforms/arduino_default/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_SPI.cpp
@@ -50,14 +50,19 @@ namespace lgfx
   {
     dc_h();
     pinMode(_cfg.pin_dc, pin_mode_t::output);
-  //SPI.pins(_cfg.pin_sclk, _cfg.pin_miso, _cfg.pin_mosi, -1);
-    SPI.begin();
+  //PrivateSPI->pins(_cfg.pin_sclk, _cfg.pin_miso, _cfg.pin_mosi, -1);
+    PrivateSPI->begin();
     return true;
   }
 
   void Bus_SPI::release(void)
   {
-    SPI.end();
+    PrivateSPI->end();
+  }
+
+  void Bus_SPI::spi_device(HardwareSPI *newSPI)
+  {
+    PrivateSPI = newSPI;
   }
 
   void Bus_SPI::beginTransaction(void)
@@ -65,26 +70,26 @@ namespace lgfx
     dc_h();
     //SPISettings setting(_cfg.freq_write, BitOrder::MSBFIRST, _cfg.spi_mode, true);
     SPISettings setting(_cfg.freq_write, MSBFIRST, _cfg.spi_mode);
-    SPI.beginTransaction(setting);
+    PrivateSPI->beginTransaction(setting);
   }
 
   void Bus_SPI::endTransaction(void)
   {
-    SPI.endTransaction();
+    PrivateSPI->endTransaction();
     dc_h();
   }
 
   void Bus_SPI::beginRead(void)
   {
-    SPI.endTransaction();
+    PrivateSPI->endTransaction();
     //SPISettings setting(_cfg.freq_read, BitOrder::MSBFIRST, _cfg.spi_mode, false);
     SPISettings setting(_cfg.freq_read, MSBFIRST, _cfg.spi_mode);
-    SPI.beginTransaction(setting);
+    PrivateSPI->beginTransaction(setting);
   }
 
   void Bus_SPI::endRead(void)
   {
-    SPI.endTransaction();
+    PrivateSPI->endTransaction();
     beginTransaction();
   }
 
@@ -100,14 +105,14 @@ namespace lgfx
   bool Bus_SPI::writeCommand(uint32_t data, uint_fast8_t bit_length)
   {
     dc_l();
-    SPI.transfer((uint8_t*)&data, bit_length >> 3);
+    PrivateSPI->transfer((uint8_t*)&data, bit_length >> 3);
     dc_h();
     return true;
   }
 
   void Bus_SPI::writeData(uint32_t data, uint_fast8_t bit_length)
   {
-    SPI.transfer((uint8_t*)&data, bit_length >> 3);
+    PrivateSPI->transfer((uint8_t*)&data, bit_length >> 3);
   }
 
   void Bus_SPI::writeDataRepeat(uint32_t data, uint_fast8_t bit_length, uint32_t length)
@@ -116,7 +121,7 @@ namespace lgfx
     auto bytes = bit_length >> 3;
     do
     {
-      SPI.send(reinterpret_cast<uint8_t*>(&data), bytes);
+      PrivateSPI->send(reinterpret_cast<uint8_t*>(&data), bytes);
     } while (--length);
 /*/
     const uint8_t dst_bytes = bit_length >> 3;
@@ -137,7 +142,7 @@ namespace lgfx
         fillpos += fillpos;
       }
 
-      SPI.transfer(buf, len * dst_bytes);
+      PrivateSPI->transfer(buf, len * dst_bytes);
     } while (length -= len);
 //*/
   }
@@ -153,7 +158,7 @@ namespace lgfx
       if (limit <= 32) limit <<= 1;
       auto buf = _flip_buffer.getBuffer(len * dst_bytes);
       param->fp_copy(buf, 0, len, param);
-      SPI.transfer(buf, len * dst_bytes);
+      PrivateSPI->transfer(buf, len * dst_bytes);
     } while (length -= len);
   }
 
@@ -161,7 +166,7 @@ namespace lgfx
   {
     if (dc) dc_h();
     else dc_l();
-    SPI.transfer(const_cast<uint8_t*>(data), length);
+    PrivateSPI->transfer(const_cast<uint8_t*>(data), length);
     if (!dc) dc_h();
   }
 
@@ -173,7 +178,7 @@ namespace lgfx
     int idx = 0;
     do
     {
-      res |= SPI.transfer(0) << idx;
+      res |= PrivateSPI->transfer(0) << idx;
       idx += 8;
     } while (--bit_length);
     return res;
@@ -183,7 +188,7 @@ namespace lgfx
   {
     do
     {
-      dst[0] = SPI.transfer(0);
+      dst[0] = PrivateSPI->transfer(0);
       ++dst;
     } while (--length);
     return true;

--- a/src/lgfx/v1/platforms/arduino_default/Bus_SPI.hpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_SPI.hpp
@@ -52,6 +52,7 @@ namespace lgfx
 
     bool init(void) override;
     void release(void) override;
+    void spi_device(HardwareSPI *newSPI);
 
     void beginTransaction(void) override;
     void endTransaction(void) override;
@@ -76,7 +77,7 @@ namespace lgfx
     bool readBytes(uint8_t* dst, uint32_t length, bool use_dma) override;
     void readPixels(void* dst, pixelcopy_t* param, uint32_t length) override;
 
-  private:
+  protected:
 
     __attribute__ ((always_inline)) inline void dc_h(void) {
       gpio_hi(_cfg.pin_dc);
@@ -85,6 +86,7 @@ namespace lgfx
       gpio_lo(_cfg.pin_dc);
     }
 
+    HardwareSPI *PrivateSPI = &SPI;
     config_t _cfg;
     FlipBuffer _flip_buffer;
     bool _need_wait;

--- a/src/lgfx/v1/platforms/arduino_default/common.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.cpp
@@ -79,9 +79,93 @@ namespace lgfx
 
 //----------------------------------------------------------------------------
 
-  /// unimplemented.
+
   namespace i2c
   {
+#ifdef TwoWire_h
+    cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl) { Wire.begin(); return {};}
+    cpp::result<void, error_t> release(int i2c_port) { Wire.end(); return {};}
+    cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read) {  Wire.endTransmission(true); Wire.beginTransmission(i2c_addr); return {};}
+    cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read) { Wire.beginTransmission(i2c_addr); return {};}
+    cpp::result<void, error_t> endTransaction(int i2c_port) { Wire.endTransmission(true); return {};}
+    cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length) { Wire.write(data, length); return {};}
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length)
+      {
+        Wire.readBytes((char *)data, (size_t)length);
+        /*
+        printf("0x");
+        for (int i=0; i< length; i++) {
+          printf("%02x ", data[i]);
+        }
+        printf("\n");
+        */
+        return {};
+      }
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack)
+    {
+      Wire.readBytes((char *)data, (size_t)length);
+      /*
+      printf("0x");
+      for (int i=0; i< length; i++) {
+        printf("%02x ", data[i]);
+      }
+      printf("\n");
+      */
+      return {};
+    }
+
+    cpp::result<void, error_t> transactionWrite(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint32_t freq)  {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = writeBytes(i2c_port, writedata, writelen)).has_value())
+      {
+        res = endTransaction(i2c_port);
+      }
+      return res;
+     }
+
+    cpp::result<void, error_t> transactionRead(int i2c_port, int addr, uint8_t *readdata, uint8_t readlen, uint32_t freq)  {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = readBytes(i2c_port, readdata, readlen)).has_value())
+      {
+        res = endTransaction(i2c_port);
+      }
+      return res;
+       }
+
+    cpp::result<void, error_t> transactionWriteRead(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint8_t *readdata, size_t readlen, uint32_t freq)  {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = writeBytes(i2c_port, writedata, writelen)).has_value() &&
+      (res = restart(i2c_port, addr, freq, false)).has_value() && (res = readBytes(i2c_port, readdata, readlen)).has_value())
+      {
+        res = endTransaction(i2c_port);
+      }
+      return res;
+       }
+
+    cpp::result<uint8_t, error_t> readRegister8(int i2c_port, int addr, uint8_t reg, uint32_t freq)  {
+            auto res = transactionWriteRead(i2c_port, addr, &reg, 1, &reg, 1, freq);
+      if (res.has_value())
+      {
+        return reg;
+      }
+      return cpp::fail(res.error());
+     }
+
+    cpp::result<void, error_t> writeRegister8(int i2c_port, int addr, uint8_t reg, uint8_t data, uint8_t mask, uint32_t freq)  {
+            uint8_t tmp[2] = {reg, data};
+      if (mask != 0)
+      {
+        auto res = transactionWriteRead(i2c_port, addr, &reg, 1, &tmp[1], 1, freq);
+        if (res.has_error())
+        {
+          return res;
+        }
+        tmp[1] = (tmp[1] & mask) | data;
+      }
+      return transactionWrite(i2c_port, addr, tmp, 2, freq);
+     }
+
+     #else
     cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl) { return cpp::fail(error_t::unknown_err); }
     cpp::result<void, error_t> release(int i2c_port) { return cpp::fail(error_t::unknown_err); }
     cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read) { return cpp::fail(error_t::unknown_err); }
@@ -99,6 +183,7 @@ namespace lgfx
 
     cpp::result<uint8_t, error_t> readRegister8(int i2c_port, int addr, uint8_t reg, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
     cpp::result<void, error_t> writeRegister8(int i2c_port, int addr, uint8_t reg, uint8_t data, uint8_t mask, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+#endif
   }
 
 //----------------------------------------------------------------------------

--- a/src/lgfx/v1/touch/Touch_FT5x06.cpp
+++ b/src/lgfx/v1/touch/Touch_FT5x06.cpp
@@ -117,6 +117,10 @@ if (_inited)
         uint_fast8_t points = std::min<uint_fast8_t>(max_touch_points, readdata[0] & 0x0Fu);
         if (points)
         {
+#if ARCH_PORTDUINO
+          readdata[1] = 0x03;
+          lgfx::i2c::writeBytes(_cfg.i2c_port, &readdata[1], 1);
+#endif
           if (lgfx::i2c::readBytes(_cfg.i2c_port, &readdata[1], points * 6 - 2))
           {
             res = points * 6 - 1;

--- a/src/lgfx/v1/touch/Touch_FT5x06.cpp
+++ b/src/lgfx/v1/touch/Touch_FT5x06.cpp
@@ -117,7 +117,7 @@ if (_inited)
         uint_fast8_t points = std::min<uint_fast8_t>(max_touch_points, readdata[0] & 0x0Fu);
         if (points)
         {
-#if ARCH_PORTDUINO
+#ifdef PORTDUINO_LINUX_HARDWARE
           readdata[1] = 0x03;
           lgfx::i2c::writeBytes(_cfg.i2c_port, &readdata[1], 1);
 #endif


### PR DESCRIPTION
There's a trio of changes here. Up first is adding I2C support to arduino_default, ifdef'd behind whether the Wire library is available.

Then there's an added quirk to Touch_FT5x06.cpp, as on native Linux, it seems any repeated I2C reads trigger a re-read of already read registers.

And finally, the arduino_default bus_spi gets a configurable SPI device, again for native systems that have multiple SPI devices.