### PR TITLE
XPT2046 portduino tweaks

### DIFF
--- a/src/lgfx/v1/touch/Touch_XPT2046.cpp
+++ b/src/lgfx/v1/touch/Touch_XPT2046.cpp
@@ -29,10 +29,11 @@ namespace lgfx
   bool Touch_XPT2046::init(void)
   {
     _inited = false;
-    if (!isSPI()) return false;
 
-    lgfx::gpio_hi(_cfg.pin_cs);
-    lgfx::pinMode(_cfg.pin_cs, lgfx::pin_mode_t::output);
+    if (_cfg.pin_cs > -1) {
+      lgfx::gpio_hi(_cfg.pin_cs);
+      lgfx::pinMode(_cfg.pin_cs, lgfx::pin_mode_t::output);
+    }
     if (_cfg.spi_host < 0)
     {
       pinMode(_cfg.pin_sclk, lgfx::pin_mode_t::output);
@@ -110,9 +111,11 @@ namespace lgfx
     else
     {
       spi::beginTransaction(_cfg.spi_host, _cfg.freq, 0);
-      lgfx::gpio_lo(_cfg.pin_cs);
+      if (_cfg.pin_cs > -1)
+        lgfx::gpio_lo(_cfg.pin_cs);
       spi::readBytes(_cfg.spi_host, data, 57);
-      lgfx::gpio_hi(_cfg.pin_cs);
+      if (_cfg.pin_cs > -1)
+        lgfx::gpio_hi(_cfg.pin_cs);
       spi::endTransaction(_cfg.spi_host);
     }
 


### PR DESCRIPTION
This works for me, but may be a problem for other targets. If so, I think we can add some ifdef ARDUINO to fix it up. Feedback welcome.

The basic idea here is that some targets (namely Portduino) may have SPI devices that automatically manage their Chip Select lines, and are not just the "SPI" device. So this adds a configurable SPI device for touch, and doesn't fail when CS is unset.