### PR TITLE
Adds handling for arduino_default for specifying SPI device, and not CS

### DIFF
--- a/src/lgfx/v1/Touch.hpp
+++ b/src/lgfx/v1/Touch.hpp
@@ -67,6 +67,7 @@ namespace lgfx
         };
       };
       int16_t pin_cs = -1;
+      bool is_SPI = false;
     };
 
     virtual ~ITouch(void) = default;
@@ -74,7 +75,7 @@ namespace lgfx
     config_t config(void) const { return _cfg; }
     void config(const config_t& config) { _cfg = config; }
 
-    inline bool isSPI(void) const { return _cfg.pin_cs >= 0; }
+    inline bool isSPI(void) const { return _cfg.pin_cs >= 0 || _cfg.is_SPI; }
 
     virtual bool init(void) = 0;
     virtual void wakeup(void) = 0;

--- a/src/lgfx/v1/platforms/arduino_default/common.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.cpp
@@ -64,18 +64,26 @@ namespace lgfx
 
 //----------------------------------------------------------------------------
 
-  /// unimplemented.
   namespace spi
   {
-    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)  { cpp::result<void, error_t> res = {}; return res; }
+    HardwareSPI *SPI_dev = &SPI;
+    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)  {
+      cpp::result<void, error_t> res = {};
+      if (spi_host == 1)
+        SPI_dev = &SPI1;
+      else if (spi_host == 2)
+        SPI_dev = &SPI2;
+      return res; }
     void release(int spi_host) {}
     void beginTransaction(int spi_host, uint32_t freq, int spi_mode) {
       SPISettings setting(freq, MSBFIRST, SPI_MODE0);
-      SPI.beginTransaction(setting);
+      SPI_dev->beginTransaction(setting);
     }
-    void endTransaction(int spi_host) {SPI.endTransaction();}
+    void endTransaction(int spi_host) { SPI_dev->endTransaction();}
     void writeBytes(int spi_host, const uint8_t* data, size_t length) {}
-    void readBytes(int spi_host, uint8_t* data, size_t length) {SPI.transfer(data, length);}  }
+    void readBytes(int spi_host, uint8_t* data, size_t length) {
+      SPI_dev->transfer(data, length);
+      }  }
 
 //----------------------------------------------------------------------------
 

--- a/src/lgfx/v1/touch/Touch_XPT2046.cpp
+++ b/src/lgfx/v1/touch/Touch_XPT2046.cpp
@@ -31,8 +31,10 @@ namespace lgfx
     _inited = false;
     if (!isSPI()) return false;
 
-    lgfx::gpio_hi(_cfg.pin_cs);
-    lgfx::pinMode(_cfg.pin_cs, lgfx::pin_mode_t::output);
+    if (_cfg.pin_cs > -1) {
+      lgfx::gpio_hi(_cfg.pin_cs);
+      lgfx::pinMode(_cfg.pin_cs, lgfx::pin_mode_t::output);
+    }
     if (_cfg.spi_host < 0)
     {
       pinMode(_cfg.pin_sclk, lgfx::pin_mode_t::output);
@@ -110,9 +112,11 @@ namespace lgfx
     else
     {
       spi::beginTransaction(_cfg.spi_host, _cfg.freq, 0);
-      lgfx::gpio_lo(_cfg.pin_cs);
+      if (_cfg.pin_cs > -1)
+        lgfx::gpio_lo(_cfg.pin_cs);
       spi::readBytes(_cfg.spi_host, data, 57);
-      lgfx::gpio_hi(_cfg.pin_cs);
+      if (_cfg.pin_cs > -1)
+        lgfx::gpio_hi(_cfg.pin_cs);
       spi::endTransaction(_cfg.spi_host);
     }
 


### PR DESCRIPTION
This is the so-simple-its-dumb approach to the SPI touchscreen issue. The idea is that we'd add SPI1 and SPI2 to portduino as extern defines, so they're always available. We can tie them to a real hardware device in our init code, and here we just use the spi_host int to specify which one to use. This is an alternative solution to #559 

Edit: the addition of is_SPI is because now that we don't necessarily need a CS, there's no other way to determine for sure that it's an SPI device.