### PR TITLE
Add portduino platform, encode SPI device in spi_host

### DIFF
--- a/examples/Test/build_test/platformio_native.ini
+++ b/examples/Test/build_test/platformio_native.ini
@@ -1,4 +1,3 @@
-
 [env:native-default]
 platform = https://github.com/geeksville/platform-native.git
 ;build_flags = ${env.build_flags} -O0 -lgpiod
@@ -24,7 +23,7 @@ build_flags = -O0 -xc++ -std=c++14
 
 
 [env:native-portduino]
-platform          = https://github.com/meshtastic/platform-native.git#659e49346aa33008b150dfb206b1817ddabc7132
+platform          = https://github.com/meshtastic/platform-native.git#784007630ca43b4811c6637606440588bb5acf39
 framework         = arduino
 board             = cross_platform
 ;build_src_filter  = +<**/*.cpp> -<main/>

--- a/examples/Test/build_test/portduino/main.cpp
+++ b/examples/Test/build_test/portduino/main.cpp
@@ -8,8 +8,6 @@ void setup()
   initGPIOPin(25, "gpiochip4");
   initGPIOPin(24, "gpiochip4");
 
-  DisplaySPI = new HardwareSPI;
-  DisplaySPI->begin("/dev/spidev0.0");
   Wire.begin(1);
   display = new LGFX();
   display->init();
@@ -18,6 +16,10 @@ void setup()
   canvas.setFont(&fonts::lgfxJapanMinchoP_32);
   canvas.setTextWrap(false);        // 右端到達時のカーソル折り返しを禁止
   canvas.createSprite(display->width(), 36);
+  canvas.clear();
+  canvas.setCursor(0, 0);
+  canvas.printf("Touch to start\n");
+  canvas.pushSprite(display, 0, 0);
 }
 
 

--- a/examples/Test/build_test/portduino/main.h
+++ b/examples/Test/build_test/portduino/main.h
@@ -6,7 +6,6 @@
 #include "PortduinoGPIO.h"
 #include <iostream>
 
-HardwareSPI *DisplaySPI;
 int initGPIOPin(int pinNum, std::string gpioChipName);
 
 class LGFX : public lgfx::LGFX_Device
@@ -25,7 +24,11 @@ public:
       auto buscfg = _bus_instance.config();
       buscfg.spi_mode = 0;
       buscfg.pin_dc = 25;
-      _bus_instance.spi_device(DisplaySPI);
+      
+      // to use spidevX.Y
+      int x = 0;
+      int y = 0;
+      buscfg.spi_host = x + y << 4;
       _bus_instance.config(buscfg);            // applies the set value to the bus.
       _panel_instance.setBus(&_bus_instance); // set the bus on the panel.
     }

--- a/src/lgfx/v1/platforms/arduino_default/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_SPI.cpp
@@ -50,46 +50,42 @@ namespace lgfx
   {
     dc_h();
     pinMode(_cfg.pin_dc, pin_mode_t::output);
-  //PrivateSPI->pins(_cfg.pin_sclk, _cfg.pin_miso, _cfg.pin_mosi, -1);
-    PrivateSPI->begin();
+    spi = new HardwareSPI(_cfg.spi_host);
+    spi->begin();
     return true;
   }
 
   void Bus_SPI::release(void)
   {
-    PrivateSPI->end();
+    spi->end();
   }
 
-  void Bus_SPI::spi_device(HardwareSPI *newSPI)
-  {
-    PrivateSPI = newSPI;
-  }
 
   void Bus_SPI::beginTransaction(void)
   {
     dc_h();
     //SPISettings setting(_cfg.freq_write, BitOrder::MSBFIRST, _cfg.spi_mode, true);
     SPISettings setting(_cfg.freq_write, MSBFIRST, _cfg.spi_mode);
-    PrivateSPI->beginTransaction(setting);
+    spi->beginTransaction(setting);
   }
 
   void Bus_SPI::endTransaction(void)
   {
-    PrivateSPI->endTransaction();
+    spi->endTransaction();
     dc_h();
   }
 
   void Bus_SPI::beginRead(void)
   {
-    PrivateSPI->endTransaction();
+    spi->endTransaction();
     //SPISettings setting(_cfg.freq_read, BitOrder::MSBFIRST, _cfg.spi_mode, false);
     SPISettings setting(_cfg.freq_read, MSBFIRST, _cfg.spi_mode);
-    PrivateSPI->beginTransaction(setting);
+    spi->beginTransaction(setting);
   }
 
   void Bus_SPI::endRead(void)
   {
-    PrivateSPI->endTransaction();
+    spi->endTransaction();
     beginTransaction();
   }
 
@@ -105,14 +101,14 @@ namespace lgfx
   bool Bus_SPI::writeCommand(uint32_t data, uint_fast8_t bit_length)
   {
     dc_l();
-    PrivateSPI->transfer((uint8_t*)&data, bit_length >> 3);
+    spi->transfer((uint8_t*)&data, bit_length >> 3);
     dc_h();
     return true;
   }
 
   void Bus_SPI::writeData(uint32_t data, uint_fast8_t bit_length)
   {
-    PrivateSPI->transfer((uint8_t*)&data, bit_length >> 3);
+    spi->transfer((uint8_t*)&data, bit_length >> 3);
   }
 
   void Bus_SPI::writeDataRepeat(uint32_t data, uint_fast8_t bit_length, uint32_t length)
@@ -121,7 +117,7 @@ namespace lgfx
     auto bytes = bit_length >> 3;
     do
     {
-      PrivateSPI->send(reinterpret_cast<uint8_t*>(&data), bytes);
+      spi->send(reinterpret_cast<uint8_t*>(&data), bytes);
     } while (--length);
 /*/
     const uint8_t dst_bytes = bit_length >> 3;
@@ -142,7 +138,7 @@ namespace lgfx
         fillpos += fillpos;
       }
 
-      PrivateSPI->transfer(buf, len * dst_bytes);
+      spi->transfer(buf, len * dst_bytes);
     } while (length -= len);
 //*/
   }
@@ -158,7 +154,7 @@ namespace lgfx
       if (limit <= 32) limit <<= 1;
       auto buf = _flip_buffer.getBuffer(len * dst_bytes);
       param->fp_copy(buf, 0, len, param);
-      PrivateSPI->transfer(buf, len * dst_bytes);
+      spi->transfer(buf, len * dst_bytes);
     } while (length -= len);
   }
 
@@ -166,7 +162,7 @@ namespace lgfx
   {
     if (dc) dc_h();
     else dc_l();
-    PrivateSPI->transfer(const_cast<uint8_t*>(data), length);
+    spi->transfer(const_cast<uint8_t*>(data), length);
     if (!dc) dc_h();
   }
 
@@ -178,7 +174,7 @@ namespace lgfx
     int idx = 0;
     do
     {
-      res |= PrivateSPI->transfer(0) << idx;
+      res |= spi->transfer(0) << idx;
       idx += 8;
     } while (--bit_length);
     return res;
@@ -188,7 +184,7 @@ namespace lgfx
   {
     do
     {
-      dst[0] = PrivateSPI->transfer(0);
+      dst[0] = spi->transfer(0);
       ++dst;
     } while (--length);
     return true;

--- a/src/lgfx/v1/platforms/arduino_default/Bus_SPI.hpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_SPI.hpp
@@ -42,6 +42,8 @@ namespace lgfx
       int16_t pin_mosi = -1;
       int16_t pin_dc   = -1;
       uint8_t spi_mode = 0;
+      int8_t spi_host = 0;
+
     };
 
     const config_t& config(void) const { return _cfg; }
@@ -52,7 +54,6 @@ namespace lgfx
 
     bool init(void) override;
     void release(void) override;
-    void spi_device(HardwareSPI *newSPI);
 
     void beginTransaction(void) override;
     void endTransaction(void) override;
@@ -86,7 +87,7 @@ namespace lgfx
       gpio_lo(_cfg.pin_dc);
     }
 
-    HardwareSPI *PrivateSPI = &SPI;
+    HardwareSPI *spi;
     config_t _cfg;
     FlipBuffer _flip_buffer;
     bool _need_wait;

--- a/src/lgfx/v1/platforms/arduino_default/common.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.cpp
@@ -67,15 +67,20 @@ namespace lgfx
   /// unimplemented.
   namespace spi
   {
-    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)  { cpp::result<void, error_t> res = {}; return res; }
+    HardwareSPI *spi;
+    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)  {
+      cpp::result<void, error_t> res = {};
+      spi = new HardwareSPI(spi_host);
+      spi->begin();
+      return res; }
     void release(int spi_host) {}
     void beginTransaction(int spi_host, uint32_t freq, int spi_mode) {
       SPISettings setting(freq, MSBFIRST, SPI_MODE0);
-      SPI.beginTransaction(setting);
+      spi->beginTransaction(setting);
     }
-    void endTransaction(int spi_host) {SPI.endTransaction();}
+    void endTransaction(int spi_host) {spi->endTransaction();}
     void writeBytes(int spi_host, const uint8_t* data, size_t length) {}
-    void readBytes(int spi_host, uint8_t* data, size_t length) {SPI.transfer(data, length);}  }
+    void readBytes(int spi_host, uint8_t* data, size_t length) {spi->transfer(data, length);}  }
 
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
@mverch and I hashed out the SPI device problem, and what we came up with was a scheme to encode the SPI bus as the lower 4 bits of spi_host, and the device as the upper 4 bits. The change on the Portduino side was to make sure that multiple HardwareSPI objects could be created, and safely point to the same device.