### PR TITLE
add RA8875 Touch

### DIFF
--- a/src/lgfx/v1/touch/Touch_RA8875.cpp
+++ b/src/lgfx/v1/touch/Touch_RA8875.cpp
@@ -1,0 +1,159 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#include "Touch_RA8875.hpp"
+
+#include "../../internal/algorithm.h"
+#include "../platforms/common.hpp"
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  bool Touch_RA8875::init(void)
+  {
+    _inited = false;
+
+    lgfx::gpio_hi(_cfg.pin_cs);
+    lgfx::pinMode(_cfg.pin_cs, lgfx::pin_mode_t::output);
+    if (!lgfx::spi::init(_cfg.spi_host, _cfg.pin_sclk, _cfg.pin_miso, _cfg.pin_mosi).has_value()) return false;
+
+    // enable Touch Panel
+    // RA8875_TPCR0: RA8875_TPCR0_ENABLE | RA8875_TPCR0_WAIT_4096CLK | RA8875_TPCR0_WAKEENABLE | adcClk
+    digitalWrite(4, HIGH);
+    writeRegister8(0x70, 0x80 | 0x30 | 0x08 | 0x04); // 10mhz max!
+    digitalWrite(4, LOW);
+
+    // Set Auto Mode
+    // RA8875_TPCR1, RA8875_TPCR1_AUTO | RA8875_TPCR1_DEBOUNCE
+    writeRegister8(0x71, 0x00 | 0x04);
+
+    // Enable TP INT
+    writeRegister8(0xF0, 0x04);
+    // better solution:
+    // writeReg(RA8875_INTC1, readReg(RA8875_INTC1) | RA8875_INTC1_TP);
+
+    delay(2);
+    writeRegister8(0xF1, 0x04); // clear interrupt
+
+    _inited = true;
+    return true;
+  }
+
+  uint_fast8_t Touch_RA8875::getTouchRaw(touch_point_t* tp, uint_fast8_t count)
+  {
+    // check int state F1h
+    if (!_inited || count == 0) return 0;   // ToDo: figure what count does
+
+    // what does it do??
+    // if (_cfg.pin_int >= 0 && lgfx::gpio_in(_cfg.pin_int))
+    // {
+    //   return 0;
+    // }
+
+    uint16_t tx, ty;
+    uint8_t temp, interrupt_reg;
+
+    tx = readRegister8(0x72); // RA8875_TPXH
+    ty = readRegister8(0x73); // RA8875_TPYH 
+    temp = readRegister8(0x74); // RA8875_TPXYL
+    interrupt_reg = readRegister8(0xF1);  // INTC2
+
+    tx <<= 2;
+    ty <<= 2;
+    tx |= temp & 0x03;        // get the bottom x bits
+    ty |= (temp >> 2) & 0x03; // get the bottom y bits
+
+    if(interrupt_reg & (1 << 2)){   // touch interrupt has been triggered
+      tp->x = tx;
+      tp->y = ty;
+      tp->size = 1;
+    }else{
+      tp->x = 0;
+      tp->y = 0;
+      tp->size = 0;
+    }
+    
+
+    writeRegister8(0xF1, 0x04); // clear interrupt
+
+    return tp->size ? 1 : 0;
+  }
+
+  uint8_t Touch_RA8875::readRegister8(uint8_t reg)
+  {
+    if (isSPI()) {
+      uint8_t tmp[3] = {0x80, reg, 0x40};
+      uint8_t res = 0;
+
+      spi::beginTransaction(_cfg.spi_host, _cfg.freq);
+      lgfx::gpio_lo(_cfg.pin_cs);
+
+      spi::writeBytes(_cfg.spi_host, tmp, 3);
+      spi::readBytes(_cfg.spi_host, &res, 1);
+
+      spi::endTransaction(_cfg.spi_host);
+      lgfx::gpio_hi(_cfg.pin_cs);
+
+      return res;
+    }
+    return 0;
+  }
+
+  void Touch_RA8875::writeRegister8(uint8_t reg, uint8_t data)
+  {
+    if (isSPI()) {
+      uint8_t tmp[4] = {0x80, reg, 0x00, data };
+
+      spi::beginTransaction(_cfg.spi_host, _cfg.freq);
+      lgfx::gpio_lo(_cfg.pin_cs);
+
+      spi::writeBytes(_cfg.spi_host, tmp, 4);
+
+      spi::endTransaction(_cfg.spi_host);
+      lgfx::gpio_hi(_cfg.pin_cs);
+    }
+  }
+
+  // uint8_t Touch_RA8875::readStat()
+  // {
+  //   if (isSPI()) {
+  //     uint8_t tmp[1] = {0xC0};
+  //     uint8_t res = 0;
+
+  //     digitalWrite(4, HIGH);
+  //     spi::beginTransaction(_cfg.spi_host, _cfg.freq);
+  //     lgfx::gpio_lo(_cfg.pin_cs);
+
+  //     spi::writeBytes(_cfg.spi_host, tmp, 1);
+  //     spi::readBytes(_cfg.spi_host, &res, 3);
+
+  //     spi::endTransaction(_cfg.spi_host);
+  //     lgfx::gpio_hi(_cfg.pin_cs);
+  //     digitalWrite(4, LOW);
+
+  //     return res;
+  //   }
+  //   return 0;
+  // }
+
+
+//----------------------------------------------------------------------------
+ }
+}

--- a/src/lgfx/v1/touch/Touch_RA8875.cpp
+++ b/src/lgfx/v1/touch/Touch_RA8875.cpp
@@ -45,9 +45,8 @@ namespace lgfx
     writeRegister8(0x71, 0x00 | 0x04);
 
     // Enable TP INT
+    // ToDo: you might want to mask the other bits of the register
     writeRegister8(0xF0, 0x04);
-    // better solution:
-    // writeReg(RA8875_INTC1, readReg(RA8875_INTC1) | RA8875_INTC1_TP);
 
     delay(2);
     writeRegister8(0xF1, 0x04); // clear interrupt
@@ -58,7 +57,6 @@ namespace lgfx
 
   uint_fast8_t Touch_RA8875::getTouchRaw(touch_point_t* tp, uint_fast8_t count)
   {
-    // check int state F1h
     if (!_inited || count == 0) return 0;   // ToDo: figure what count does
 
     // what does it do??
@@ -88,8 +86,7 @@ namespace lgfx
       tp->x = 0;
       tp->y = 0;
       tp->size = 0;
-    }
-    
+    }    
 
     writeRegister8(0xF1, 0x04); // clear interrupt
 
@@ -130,30 +127,6 @@ namespace lgfx
       lgfx::gpio_hi(_cfg.pin_cs);
     }
   }
-
-  // uint8_t Touch_RA8875::readStat()
-  // {
-  //   if (isSPI()) {
-  //     uint8_t tmp[1] = {0xC0};
-  //     uint8_t res = 0;
-
-  //     digitalWrite(4, HIGH);
-  //     spi::beginTransaction(_cfg.spi_host, _cfg.freq);
-  //     lgfx::gpio_lo(_cfg.pin_cs);
-
-  //     spi::writeBytes(_cfg.spi_host, tmp, 1);
-  //     spi::readBytes(_cfg.spi_host, &res, 3);
-
-  //     spi::endTransaction(_cfg.spi_host);
-  //     lgfx::gpio_hi(_cfg.pin_cs);
-  //     digitalWrite(4, LOW);
-
-  //     return res;
-  //   }
-  //   return 0;
-  // }
-
-
 //----------------------------------------------------------------------------
  }
 }

--- a/src/lgfx/v1/touch/Touch_RA8875.hpp
+++ b/src/lgfx/v1/touch/Touch_RA8875.hpp
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../Touch.hpp"
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  struct Touch_RA8875 : public ITouch
+  {
+    Touch_RA8875(void)
+    {
+      _cfg.freq = 1000000;
+      _cfg.x_min = 300;
+      _cfg.x_max = 3900;
+      _cfg.y_min = 400;
+      _cfg.y_max = 3900;
+    }
+
+    bool init(void) override;
+
+    void wakeup(void) override {}
+    void sleep(void) override {}
+
+    uint_fast8_t getTouchRaw(touch_point_t* tp, uint_fast8_t count) override;
+    
+  private:
+    // int _spi_mode = 0;
+    uint8_t readRegister8(uint8_t reg);
+    void writeRegister8(uint8_t reg, uint8_t data);
+    // uint8_t readStat();
+  };
+
+//----------------------------------------------------------------------------
+ }
+}

--- a/src/lgfx/v1/touch/Touch_RA8875.hpp
+++ b/src/lgfx/v1/touch/Touch_RA8875.hpp
@@ -44,10 +44,8 @@ namespace lgfx
     uint_fast8_t getTouchRaw(touch_point_t* tp, uint_fast8_t count) override;
     
   private:
-    // int _spi_mode = 0;
     uint8_t readRegister8(uint8_t reg);
     void writeRegister8(uint8_t reg, uint8_t data);
-    // uint8_t readStat();
   };
 
 //----------------------------------------------------------------------------

--- a/src/lgfx/v1_init.hpp
+++ b/src/lgfx/v1_init.hpp
@@ -66,4 +66,4 @@ Contributors:
 #include "v1/touch/Touch_STMPE610.hpp"
 #include "v1/touch/Touch_TT21xxx.hpp"
 #include "v1/touch/Touch_XPT2046.hpp"
-
+#include "v1/touch/Touch_RA8875.hpp"


### PR DESCRIPTION
Added two header files to utilize the touch functionality of the RA8875 display driver. Copied from existing touch drivers, did'nt understand the meaning of all functions and variables but works so far.
`display.calibrateTouch(...)` and subsequent transfomation in display coordinates works nicely with the driver.

**Sample Config**
```
lgfx::Touch_RA8875  _touch_instance;

...

{ // タッチスクリーン制御の設定を行います。（必要なければ削除）
      auto cfg = _touch_instance.config();

      // SPI接続の場合
      cfg.bus_shared = true; // 画面と共通のバスを使用している場合 trueを設定
      cfg.spi_host = VSPI_HOST;// 使用するSPIを選択 (HSPI_HOST or VSPI_HOST)
      cfg.freq = 1000000;     // SPIクロックを設定
      cfg.pin_sclk = 18;
      cfg.pin_mosi = 23;
      cfg.pin_miso = 19;
      cfg.pin_cs   =  5;     //   CSが接続されているピン番号

      _touch_instance.config(cfg);
      _panel_instance.setTouch(&_touch_instance);  // タッチスクリーンをパネルにセットします。
}
```
