### PR TITLE
Change PWM bitdepth to SOC_LEDC_TIMER_BIT_WIDTH and freq to 1200

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -35,7 +35,7 @@ namespace lgfx
  {
 //----------------------------------------------------------------------------
 
-  static constexpr const uint8_t PWM_BITS = 9;
+  static constexpr const uint8_t PWM_BITS = SOC_LEDC_TIMER_BIT_WIDTH;
 
 
   bool Light_PWM::init(uint8_t brightness)

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32_all.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32_all.hpp
@@ -1270,7 +1270,7 @@ namespace lgfx
             cfg.offset_rotation = 2;
             p->config(cfg);
             p->setRotation(1);
-            p->light(_create_pwm_backlight(GPIO_NUM_45, 0, 12000, true));
+            p->light(_create_pwm_backlight(GPIO_NUM_45, 0, 1200, true));
           }
         }
       };


### PR DESCRIPTION
This PR sets the esp32 ledc backlight PWM to 1200Hz and bitdepth to SOC_LEDC_TIMER_BIT_WIDTH.

This makes for smoother dimming and keep the full ledc bitdepth available on the remaining ledc channels.

See #642 
