### PR TITLE
Autodetect for Guition JC2432W328C

### DIFF
--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -64,6 +64,7 @@ namespace lgfx
     , board_ESP32_S3_BOX_Lite
     , board_LoLinS3Pro
     , board_ESP32_S3_BOX_V3
+    , board_Guition_ESP32_2432W328
     };
   }
   using namespace boards;

--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32_all.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32_all.hpp
@@ -3187,6 +3187,67 @@ namespace lgfx
         }
       };
 
+      struct _detector_Guition_JC2432W328C_t : public _detector_Sunton_ESP32_2432S028_t
+      {
+        constexpr _detector_Guition_JC2432W328C_t(void)
+        : _detector_Sunton_ESP32_2432S028_t
+        { board_t::board_Guition_ESP32_2432W328
+        , 0x04, 0xFFFF00, 0xb38100
+        , 55000000, 20000000
+        , GPIO_NUM_13     // MOSI
+        , GPIO_NUM_12     // MISO
+        , GPIO_NUM_14     // SCLK
+        , GPIO_NUM_2      // DC
+        , GPIO_NUM_15     // CS
+        , (gpio_num_t)-1  // RST
+        , (gpio_num_t)-1  // TF CARD CS
+        , 0               // SPI MODE
+        , false           // SPI 3wire
+        , HSPI_HOST       // SPI HOST
+        } {}
+
+        void setup(_detector_result_t* result) const override
+        {
+          ESP_LOGI(LIBRARY_NAME, "[Autodetect] Guition_JC2432W328C");
+
+          result->panel = new Panel_ILI9341_2();
+
+          auto p = result->panel;
+          {
+            auto cfg = p->config();
+            cfg.offset_x         =     0;
+            cfg.offset_y         =     0;
+            cfg.offset_rotation  =     6;
+            cfg.dummy_read_pixel =     8;
+            cfg.dummy_read_bits  =     1;
+            cfg.readable         = true;
+            cfg.invert           = true;
+            cfg.rgb_order        = false;
+            cfg.dlen_16bit       = false;
+            cfg.bus_shared       = false;
+            p->config(cfg);
+
+            p->light(_create_pwm_backlight(GPIO_NUM_27, 7));
+          }
+          {
+              auto t = new lgfx::Touch_CST816S();
+
+              auto cfg = t->config();
+              cfg.i2c_port = I2C_NUM_0;
+              cfg.pin_sda = GPIO_NUM_33;
+              cfg.pin_scl = GPIO_NUM_32;
+              cfg.pin_rst = GPIO_NUM_25;
+              cfg.pin_int = -1;
+              cfg.offset_rotation = 6;
+              cfg.freq = 400000;
+              cfg.x_max = 240;
+              cfg.y_max = 320;
+              t->config(cfg);
+              p->touch(t);
+          }
+        }
+      };
+
       struct _detector_WT32_SC01_t : public _detector_spi_t
       {
         constexpr _detector_WT32_SC01_t(void)
@@ -3427,6 +3488,7 @@ namespace lgfx
       static constexpr const _detector_board_LoLinD32_9341_t   detector_board_LoLinD32_9341;
       static constexpr const _detector_ESP_WROVER_KIT_7789_t   detector_ESP_WROVER_KIT_7789;
       static constexpr const _detector_ESP_WROVER_KIT_9341_t   detector_ESP_WROVER_KIT_9341;
+      static constexpr const _detector_Guition_JC2432W328C_t   detector_Guition_JC2432W328C;
       static constexpr const _detector_Sunton_2432S028_9341_t  detector_Sunton_2432S028_9341;
       static constexpr const _detector_Sunton_2432S028_7789_t  detector_Sunton_2432S028_7789;
       static constexpr const _detector_ODROID_GO_t             detector_ODROID_GO;
@@ -3475,6 +3537,9 @@ namespace lgfx
 #if defined ( LGFX_AUTODETECT ) || defined ( LGFX_ESP_WROVER_KIT )
         &detector_ESP_WROVER_KIT_7789,
         &detector_ESP_WROVER_KIT_9341,
+#endif
+#if defined ( LGFX_AUTODETECT ) || defined ( LGFX_ESP32_2432W328 ) || defined ( LGFX_GUITION_ESP32_2432W328 )
+        &detector_Guition_JC2432W328C,
 #endif
 #if defined ( LGFX_AUTODETECT ) || defined ( LGFX_ESP32_2432S028 ) || defined ( LGFX_SUNTON_ESP32_2432S028 )
         &detector_Sunton_2432S028_9341,


### PR DESCRIPTION
The board is similar to 2432S028 "cheap yellow displays", but it has a capacitive touch screen using CS820 and the backlight is on GPIO 27 instead of GPIO 21.  The panel is ILI9341_2.

I gave it its own board ID value so application code can support both kinds of boards, automatically adapting to the GPIO differences.

The board can be purchased at <https://www.aliexpress.us/item/3256806545687380.html>