### PR TITLE
Some 2432 CYD displays have D0WDQ6 ESP32 package

### DIFF
--- a/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32_all.hpp
+++ b/src/lgfx/v1_autodetect/LGFX_AutoDetect_ESP32_all.hpp
@@ -3598,6 +3598,10 @@ namespace lgfx
 #if defined ( LGFX_AUTODETECT ) || defined ( LGFX_ODROID_GO )
         &detector_ODROID_GO,
 #endif
+#if defined ( LGFX_AUTODETECT ) || defined ( LGFX_ESP32_2432S028 ) || defined ( LGFX_SUNTON_ESP32_2432S028 )
+        &detector_Sunton_2432S028_9341,
+        &detector_Sunton_2432S028_7789,
+#endif
 
         nullptr // terminator
       };


### PR DESCRIPTION
... so modify the Q6 detector list to detect them

Most 2432S028 "Cheap Yellow Displays" have an ESP32 in the D0WDQ5 package, but there are some that use a D0WDQ6 ESP32.  The Q5 detector list current detects such displays, but the Q6 detector list does not.  This PR adds appropriate entries to the Q6 detector list to recognize these 2432S028 variants.