### PR TITLE
Fix #711 - mirrored LCDs rotate the wrong way

### DIFF
--- a/src/lgfx/v1/panel/Panel_LCD.hpp
+++ b/src/lgfx/v1/panel/Panel_LCD.hpp
@@ -91,9 +91,9 @@ namespace lgfx
                MAD_MX|MAD_MH|MAD_MY|MAD_ML,
         MAD_MV|              MAD_MY|MAD_ML,
                              MAD_MY|MAD_ML,
-        MAD_MV                            ,
+        MAD_MV|MAD_MX|MAD_MH|MAD_MY|MAD_ML,
                MAD_MX|MAD_MH              ,
-        MAD_MV|MAD_MX|MAD_MY|MAD_MH|MAD_ML,
+        MAD_MV                            ,
       };
       return madctl_table[r];
     }


### PR DESCRIPTION
Fix #711

The ILI9341_2 panel, which is the only mirrored one in  AutoDetect_ESP32_all.hpp, rotates anti-clockwise with successive values for setRotation().  Other non-mirrored LCD panels rotate clockwise.  The anti-clockwise rotation causes problems with touch at rotations 1 and 3, since the touch coordinate system rotates clockwise.  The fix is to exchange entries 5 and 7 in madctl_table[] thus swapping the orientations for mirrored rotations 1 and 3.  The change does not affect non-mirrored panels.