### PR TITLE
Support AMOLED NV3031B driver

### DIFF
--- a/src/lgfx/v1/panel/Panel_NV3031B.cpp
+++ b/src/lgfx/v1/panel/Panel_NV3031B.cpp
@@ -1,0 +1,472 @@
+/*----------------------------------------------------------------------------/
+ *  Lovyan GFX - Graphics library for embedded devices.
+ *
+ * Original Source:
+ * https://github.com/lovyan03/LovyanGFX/
+ *
+ * Licence:
+ * [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+ *
+ * Authors:
+ * [lovyan03](https://twitter.com/lovyan03)
+ *
+ * Contributors:
+ * [ciniml](https://github.com/ciniml)
+ * [mongonta0716](https://github.com/mongonta0716)
+ * [tobozo](https://github.com/tobozo)
+ * [mverch67](https://github.com/mverch67)
+ * /----------------------------------------------------------------------------*/
+
+#if defined (ESP_PLATFORM)
+
+#include "Panel_NV3031B.hpp"
+#include <lgfx/v1/Bus.hpp>
+#include <lgfx/v1/platforms/common.hpp>
+#include <lgfx/v1/misc/pixelcopy.hpp>
+#include <lgfx/v1/misc/colortype.hpp>
+#include "driver/spi_master.h"
+#include "esp_log.h"
+
+
+namespace lgfx
+{
+    inline namespace v1
+    {
+        //----------------------------------------------------------------------------
+
+        bool Panel_NV3031B::init(bool use_reset)
+        {
+            //ESP_LOGD("NV3031B","panel init %d", use_reset);
+            if (!Panel_Device::init(use_reset)) {
+                return false;
+            }
+
+            startWrite();
+
+            // Flush QSPI bus with a NOP before sending real commands.
+            cs_control(false);
+            write_cmd(0x00);  // {0x02, 0x00, 0x00, 0x00} — 4-byte NOP frame only
+            _bus->wait();
+            cs_control(true);
+
+            // Send the full init table (variable-length data per command).
+            constexpr int n = sizeof(init_cmds) / sizeof(init_cmds[0]);
+            for (int i = 0; i < n; i++)
+            {
+                cs_control(false);
+                write_cmd(init_cmds[i].cmd);
+                for (int j = 0; j < init_cmds[i].len; j++) {
+                    _bus->writeCommand(init_cmds[i].data[j], 8);
+                }
+                _bus->wait();
+                cs_control(true);
+                if (init_cmds[i].delay_ms) {
+                    delay(init_cmds[i].delay_ms);
+                }
+            }
+
+            endWrite();
+
+            // Display on — send DISPON with one dummy 0x00 parameter byte as required by NV303x.
+            startWrite();
+            cs_control(false);
+            write_cmd(CMD_DISPON);
+            _bus->writeCommand(0x00, 8);
+            _bus->wait();
+            cs_control(true);
+            endWrite();
+
+            return true;
+        }
+
+
+        void Panel_NV3031B::update_madctl(void)
+        {
+            uint8_t r = _internal_rotation;
+            uint8_t rgb_order = (_cfg.rgb_order ? CMD_MADCTL_RGB : CMD_MADCTL_BGR);
+            switch (r)
+            {
+                case 1:
+                    r = CMD_MADCTL_MY | CMD_MADCTL_MV | rgb_order;
+                    break;
+                case 2:
+                    r = rgb_order;
+                    break;
+                case 3:
+                    r = CMD_MADCTL_MX | CMD_MADCTL_MV | rgb_order;
+                    break;
+                default: // case 0:
+                    r = CMD_MADCTL_MX | CMD_MADCTL_MY | rgb_order;
+                    break;
+            }
+
+            startWrite();
+            cs_control(false);
+            this->write_cmd(CMD_MADCTL);
+            _bus->writeCommand(r, 8);
+            _bus->wait();
+            cs_control(true);
+            endWrite();
+        }
+
+
+        void Panel_NV3031B::setInvert(bool invert)
+        {
+            startWrite();
+            cs_control(false);
+            write_cmd(invert ? CMD_INVON : CMD_INVOFF);
+            _bus->wait();
+            cs_control(true);
+            endWrite();
+        }
+
+
+        void Panel_NV3031B::setSleep(bool flg)
+        {
+            startWrite();
+            cs_control(false);
+            if (flg) {
+                write_cmd(CMD_SLPIN);
+            } else {
+                write_cmd(CMD_SLPOUT);
+                delay(150);
+            }
+            _bus->wait();
+            cs_control(true);
+            endWrite();
+        }
+
+
+        void Panel_NV3031B::setPowerSave(bool flg)
+        {
+            startWrite();
+            cs_control(false);
+            write_cmd(flg ? CMD_DISPOFF : CMD_DISPON);
+            _bus->wait();
+            cs_control(true);
+            endWrite();
+        }
+
+
+        void Panel_NV3031B::waitDisplay(void)
+        {
+        }
+
+
+        bool Panel_NV3031B::displayBusy(void)
+        {
+            return false;
+        }
+
+
+        color_depth_t Panel_NV3031B::setColorDepth(color_depth_t depth)
+        {
+            // MIPI DCS COLMOD values: 0x55 = RGB565 (16bpp), 0x66 = RGB666 (18bpp)
+            uint8_t cmd_send = 0;
+            if (depth == rgb565_2Byte) {
+                cmd_send = 0x55;
+            } else if (depth == rgb666_3Byte) {
+                cmd_send = 0x66;
+            } else {
+                return _write_depth;
+            }
+            _write_depth = depth;
+
+            startWrite();
+            cs_control(false);
+            write_cmd(CMD_COLMOD);
+            _bus->writeCommand(cmd_send, 8);
+            _bus->wait();
+            cs_control(true);
+            endWrite();
+
+            return _write_depth;
+        }
+
+
+        void Panel_NV3031B::write_cmd(uint8_t cmd)
+        {
+            uint8_t cmd_buffer[4] = {0x02, 0x00, 0x00, 0x00};
+            cmd_buffer[2] = cmd;
+            for (int i = 0; i < 4; i++) {
+                _bus->writeCommand(cmd_buffer[i], 8);
+            }
+        }
+
+
+        void Panel_NV3031B::start_qspi()
+        {
+            cs_control(false);
+            _bus->writeCommand(0x32, 8);
+            _bus->writeCommand(0x00, 8);
+            _bus->writeCommand(0x2C, 8);
+            _bus->writeCommand(0x00, 8);
+            _bus->wait();
+        }
+
+        void Panel_NV3031B::end_qspi()
+        {
+            cs_control(true);
+        }
+
+
+        void Panel_NV3031B::beginTransaction(void)
+        {
+            //ESP_LOGD("NV3031B","beginTransaction");
+            if (_in_transaction) return;
+            _in_transaction = true;
+            _bus->beginTransaction();
+        }
+
+
+        void Panel_NV3031B::endTransaction(void)
+        {
+            //ESP_LOGD("NV3031B","endTransaction");
+            if (!_in_transaction) return;
+            _in_transaction = false;
+
+            if (_has_align_data)
+            {
+                _has_align_data = false;
+                _bus->writeData(0, 8);
+            }
+
+            _bus->endTransaction();
+        }
+
+
+        void Panel_NV3031B::write_bytes(const uint8_t* data, uint32_t len, bool use_dma)
+        {
+            start_qspi();
+            _bus->writeBytes(data, len, true, use_dma);
+            _bus->wait();
+            end_qspi();
+        }
+
+
+        void Panel_NV3031B::setWindow(uint_fast16_t xs, uint_fast16_t ys, uint_fast16_t xe, uint_fast16_t ye)
+        {
+            //ESP_LOGD("NV3031B","setWindow %d %d %d %d", xs, ys, xe, ye);
+            if ((xe - xs) >= _width)  { xs = 0; xe = _width  - 1; }
+            if ((ye - ys) >= _height) { ys = 0; ye = _height - 1; }
+
+            cs_control(false);
+            write_cmd(CMD_CASET);
+            _bus->writeCommand(xs >> 8, 8);
+            _bus->writeCommand(xs & 0xFF, 8);
+            _bus->writeCommand(xe >> 8, 8);
+            _bus->writeCommand(xe & 0xFF, 8);
+            _bus->wait();
+            cs_control(true);
+
+            cs_control(false);
+            write_cmd(CMD_RASET);
+            _bus->writeCommand(ys >> 8, 8);
+            _bus->writeCommand(ys & 0xFF, 8);
+            _bus->writeCommand(ye >> 8, 8);
+            _bus->writeCommand(ye & 0xFF, 8);
+            _bus->wait();
+            cs_control(true);
+
+            cs_control(false);
+            write_cmd(CMD_RAMWR);
+            _bus->wait();
+            cs_control(true);
+        }
+
+
+        void Panel_NV3031B::writeBlock(uint32_t rawcolor, uint32_t len)
+        {
+            start_qspi();
+            _bus->writeDataRepeat(rawcolor, _write_bits, len);
+            _bus->wait();
+            end_qspi();
+        }
+
+
+        void Panel_NV3031B::writePixels(pixelcopy_t* param, uint32_t len, bool use_dma)
+        {
+            //ESP_LOGD("NV3031B","writePixels %ld %d", len, use_dma);
+            start_qspi();
+
+            if (param->no_convert) {
+                _bus->writeBytes(reinterpret_cast<const uint8_t*>(param->src_data), len * _write_bits >> 3, true, use_dma);
+            } else {
+                _bus->writePixels(param, len);
+            }
+            if (_cfg.dlen_16bit && (_write_bits & 15) && (len & 1)) {
+                _has_align_data = !_has_align_data;
+            }
+
+            _bus->wait();
+            end_qspi();
+        }
+
+
+        void Panel_NV3031B::drawPixelPreclipped(uint_fast16_t x, uint_fast16_t y, uint32_t rawcolor)
+        {
+            //ESP_LOGD("NV3031B","drawPixelPreclipped %d %d 0x%lX", x, y, rawcolor);
+            setWindow(x, y, x, y);
+            if (_cfg.dlen_16bit) { _has_align_data = (_write_bits & 15); }
+
+            start_qspi();
+            _bus->writeData(rawcolor, _write_bits);
+            _bus->wait();
+            end_qspi();
+        }
+
+
+        void Panel_NV3031B::writeFillRectPreclipped(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, uint32_t rawcolor)
+        {
+            //ESP_LOGD("NV3031B","writeFillRectPreclipped %d %d %d %d 0x%lX", x, y, w, h, rawcolor);
+            uint32_t len = w * h;
+            uint_fast16_t xe = w + x - 1;
+            uint_fast16_t ye = y + h - 1;
+
+            setWindow(x, y, xe, ye);
+
+            start_qspi();
+            _bus->writeDataRepeat(rawcolor, _write_bits, len);
+            _bus->wait();
+            end_qspi();
+        }
+
+
+        void Panel_NV3031B::writeImage(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param, bool use_dma)
+        {
+            //ESP_LOGD("NV3031B","writeImage %d %d %d %d %d", x, y, w, h, use_dma);
+            auto bytes = param->dst_bits >> 3;
+            auto src_x = param->src_x;
+
+            if (param->transp == pixelcopy_t::NON_TRANSP)
+            {
+                if (param->no_convert)
+                {
+                    auto wb = w * bytes;
+                    uint32_t i = (src_x + param->src_y * param->src_bitwidth) * bytes;
+                    auto src = &((const uint8_t*)param->src_data)[i];
+                    setWindow(x, y, x + w - 1, y + h - 1);
+                    if (param->src_bitwidth == w || h == 1)
+                    {
+                        write_bytes(src, wb * h, use_dma);
+                    }
+                    else
+                    {
+                        auto add = param->src_bitwidth * bytes;
+                        if (use_dma)
+                        {
+                            if (_cfg.dlen_16bit && ((wb * h) & 1))
+                            {
+                                _has_align_data = !_has_align_data;
+                            }
+                            do
+                            {
+                                _bus->addDMAQueue(src, wb);
+                                src += add;
+                            } while (--h);
+                            _bus->execDMAQueue();
+                        }
+                        else
+                        {
+                            do
+                            {
+                                write_bytes(src, wb, false);
+                                src += add;
+                            } while (--h);
+                        }
+                    }
+                }
+                else
+                {
+                    if (!_bus->busy())
+                    {
+                        static constexpr uint32_t WRITEPIXELS_MAXLEN = 32767;
+
+                        setWindow(x, y, x + w - 1, y + h - 1);
+                        bool nogap = (h == 1) || (param->src_y32_add == 0 && ((param->src_bitwidth << pixelcopy_t::FP_SCALE) == (w * param->src_x32_add)));
+                        if (nogap && (w * h <= WRITEPIXELS_MAXLEN))
+                        {
+                            writePixels(param, w * h, use_dma);
+                        }
+                        else
+                        {
+                            uint_fast16_t h_step = nogap ? WRITEPIXELS_MAXLEN / w : 1;
+                            uint_fast16_t h_len = (h_step > 1) ? ((h - 1) % h_step) + 1 : 1;
+                            writePixels(param, w * h_len, use_dma);
+                            if (h -= h_len)
+                            {
+                                param->src_y += h_len;
+                                do
+                                {
+                                    param->src_x = src_x;
+                                    writePixels(param, w * h_step, use_dma);
+                                    param->src_y += h_step;
+                                } while (h -= h_step);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        size_t wb = w * bytes;
+                        auto buf = _bus->getDMABuffer(wb);
+                        param->fp_copy(buf, 0, w, param);
+                        setWindow(x, y, x + w - 1, y + h - 1);
+                        write_bytes(buf, wb, true);
+                        _has_align_data = (_cfg.dlen_16bit && (_write_bits & 15) && (w & h & 1));
+                        while (--h)
+                        {
+                            param->src_x = src_x;
+                            param->src_y++;
+                            buf = _bus->getDMABuffer(wb);
+                            param->fp_copy(buf, 0, w, param);
+                            write_bytes(buf, wb, true);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                h += y;
+                uint32_t wb = w * bytes;
+                do
+                {
+                    uint32_t i = 0;
+                    while (w != (i = param->fp_skip(i, w, param)))
+                    {
+                        auto buf = _bus->getDMABuffer(wb);
+                        int32_t len = param->fp_copy(buf, 0, w - i, param);
+                        setWindow(x + i, y, x + i + len - 1, y);
+                        write_bytes(buf, len * bytes, true);
+                        if (w == (i += len)) break;
+                    }
+                    param->src_x = src_x;
+                    param->src_y++;
+                } while (++y != (int)h);
+            }
+        }
+
+
+        uint32_t Panel_NV3031B::readCommand(uint_fast16_t cmd, uint_fast8_t index, uint_fast8_t len)
+        {
+            (void)cmd; (void)index; (void)len;
+            return 0;
+        }
+
+        uint32_t Panel_NV3031B::readData(uint_fast8_t index, uint_fast8_t len)
+        {
+            (void)index; (void)len;
+            return 0;
+        }
+
+        void Panel_NV3031B::readRect(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, void* dst, pixelcopy_t* param)
+        {
+            (void)x; (void)y; (void)w; (void)h; (void)dst; (void)param;
+        }
+
+
+        //----------------------------------------------------------------------------
+    }
+}
+
+
+#endif

--- a/src/lgfx/v1/panel/Panel_NV3031B.cpp
+++ b/src/lgfx/v1/panel/Panel_NV3031B.cpp
@@ -49,19 +49,24 @@ namespace lgfx
             _bus->wait();
             cs_control(true);
 
-            // Send the full init table (variable-length data per command).
-            constexpr int n = sizeof(init_cmds) / sizeof(init_cmds[0]);
-            for (int i = 0; i < n; i++)
+            // Send the full init table (flat: cmd, len[|CMD_INIT_DELAY], data...[, delay_ms], 0xFF 0xFF).
+            const uint8_t* p = init_cmds;
+            while (p[0] != 0xFF || p[1] != 0xFF)
             {
+                uint8_t cmd      = p[0];
+                uint8_t len      = p[1] & ~CMD_INIT_DELAY;
+                bool    has_delay = (p[1] & CMD_INIT_DELAY) != 0;
+                p += 2;
                 cs_control(false);
-                write_cmd(init_cmds[i].cmd);
-                for (int j = 0; j < init_cmds[i].len; j++) {
-                    _bus->writeCommand(init_cmds[i].data[j], 8);
+                write_cmd(cmd);
+                for (uint8_t i = 0; i < len; i++) {
+                    _bus->writeCommand(p[i], 8);
                 }
                 _bus->wait();
                 cs_control(true);
-                if (init_cmds[i].delay_ms) {
-                    delay(init_cmds[i].delay_ms);
+                p += len;
+                if (has_delay) {
+                    delay(*p++);
                 }
             }
 

--- a/src/lgfx/v1/panel/Panel_NV3031B.hpp
+++ b/src/lgfx/v1/panel/Panel_NV3031B.hpp
@@ -1,0 +1,166 @@
+/*----------------------------------------------------------------------------/
+ *  Lovyan GFX - Graphics library for embedded devices.
+ *
+ * Original Source:
+ * https://github.com/lovyan03/LovyanGFX/
+ *
+ * Licence:
+ * [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+ *
+ * Author:
+ * [lovyan03](https://twitter.com/lovyan03)
+ *
+ * Contributors:
+ * [ciniml](https://github.com/ciniml)
+ * [mongonta0716](https://github.com/mongonta0716)
+ * [tobozo](https://github.com/tobozo)
+ * [mverch67](https://github.com/mverch67)
+ * /----------------------------------------------------------------------------*/
+#pragma once
+
+#if defined (ESP_PLATFORM)
+
+#include <lgfx/v1/panel/Panel_LCD.hpp>
+
+
+namespace lgfx
+{
+    inline namespace v1
+    {
+        //----------------------------------------------------------------------------
+
+        struct Panel_NV3031B : public Panel_LCD
+        {
+        protected:
+
+            static constexpr uint8_t CMD_RST_DELAY    = 120 ;   ///< delay ms wait for reset finish
+            static constexpr uint8_t CMD_SLPIN_DELAY  = 120 ;   ///< delay ms wait for sleep in finish
+            static constexpr uint8_t CMD_SLPOUT_DELAY = 120 ;   ///< delay ms wait for sleep out finish
+            static constexpr uint8_t CMD_NOP          = 0x00;
+            static constexpr uint8_t CMD_SWRESET      = 0x01;
+            static constexpr uint8_t CMD_SLPIN        = 0x10;
+            static constexpr uint8_t CMD_SLPOUT       = 0x11;
+            static constexpr uint8_t CMD_INVOFF       = 0x20;
+            static constexpr uint8_t CMD_INVON        = 0x21;
+            static constexpr uint8_t CMD_DISPOFF      = 0x28;
+            static constexpr uint8_t CMD_DISPON       = 0x29;
+            static constexpr uint8_t CMD_CASET        = 0x2A;
+            static constexpr uint8_t CMD_RASET        = 0x2B;
+            static constexpr uint8_t CMD_RAMWR        = 0x2C;
+            static constexpr uint8_t CMD_MADCTL       = 0x36;
+            static constexpr uint8_t CMD_COLMOD       = 0x3A;
+            static constexpr uint8_t CMD_GATEON       = 0x51;
+            static constexpr uint8_t CMD_MADCTL_MY    = 0x80;
+            static constexpr uint8_t CMD_MADCTL_MX    = 0x40;
+            static constexpr uint8_t CMD_MADCTL_MV    = 0x20;
+            static constexpr uint8_t CMD_MADCTL_ML    = 0x10;
+            static constexpr uint8_t CMD_MADCTL_RGB   = 0x0 ;
+            static constexpr uint8_t CMD_MADCTL_BGR   = 0x08;
+
+
+            // Init sequence derived from esp_lcd_nv3031b.c vendor_specific_init_default.
+            // Commands have variable-length data; see Panel_NV3031B::init() for the send loop.
+            struct InitCmd {
+                uint8_t  cmd;
+                uint8_t  data[8];
+                uint8_t  len;       // number of data bytes (0 = command only)
+                uint16_t delay_ms;
+            };
+
+            static constexpr InitCmd init_cmds[] =
+            {
+                // 0xFD — Cmd2 Enable: password bytes 0x06,0x08 unlock factory register set (Cmd2)
+                { 0xFD, { 0x06, 0x08 },                         2, 0   },
+                // 0x60 — Source timing adjust: SDNL timing control value 0x0C
+                { 0x60, { 0x0C },                                1, 0   },
+                // 0x61 — Gate timing control: gate on/off timing (0x07 = rise, 0x04 = fall)
+                { 0x61, { 0x07, 0x04 },                         2, 0   },
+                // 0xB4 — Display inversion control: 0x01 = 1-dot inversion (column)
+                { 0xB4, { 0x01 },                                1, 0   },
+                // 0xB1 — Frame rate control (normal mode): DIVA=0x0F (osc divisor), RTNA=0x02 (line period), FPA=0x03 (front porch)
+                { 0xB1, { 0x0F, 0x02, 0x03 },                   3, 0   },
+                // 0xB5 — Blanking porch control: VFP=0x02, VBP=0x02, HBP_even=0x0A, HBP_odd=0x14
+                { 0xB5, { 0x02, 0x02, 0x0A, 0x14 },             4, 0   },
+                // 0xB6 — Display function control: ISC=0x44, SM=0x01, SS=0x9F, GS=0x00, REV=0x02
+                { 0xB6, { 0x44, 0x01, 0x9F, 0x00, 0x02 },       5, 0   },
+                // 0xDF — Vendor-specific (bias/oscillator trim): value 0x11
+                { 0xDF, { 0x11 },                                1, 0   },
+                // 0x67 — Vendor-specific (bias current control): value 0x21
+                { 0x67, { 0x21 },                                1, 0   },
+                // 0x68 — VCOM / power control: VCOM_H=0x90, VDV=0x4F, VCM_offset=0x27, VCOM_L=0x21
+                { 0x68, { 0x90, 0x4F, 0x27, 0x21 },             4, 0   },
+                // 0xE1 — Positive gamma voltage control: V63P=0x20, V0P=0x69
+                { 0xE1, { 0x20, 0x69 },                         2, 0   },
+                // 0xE4 — Negative gamma voltage control: V63N=0x69, V0N=0x20
+                { 0xE4, { 0x69, 0x20 },                         2, 0   },
+                // 0xE2 — Positive gamma correction (mid-tones): VP20,VP36,VP44,VP52,VP59,VP63
+                { 0xE2, { 0x10, 0x12, 0x12, 0x30, 0x39, 0x3F }, 6, 0   },
+                // 0xE5 — Negative gamma correction (mid-tones): VN20,VN36,VN44,VN52,VN59,VN63
+                { 0xE5, { 0x3F, 0x33, 0x2D, 0x12, 0x12, 0x10 }, 6, 0   },
+                // 0xE0 — Positive gamma curve (shadow/highlight): VP1..VP8
+                { 0xE0, { 0x06, 0x06, 0x0B, 0x12, 0x11, 0x11, 0x0E, 0x19 }, 8, 0 },
+                // 0xE3 — Negative gamma curve (shadow/highlight): VN1..VN8
+                { 0xE3, { 0x19, 0x13, 0x14, 0x14, 0x14, 0x12, 0x08, 0x05 }, 8, 0 },
+                // 0xE6 — Vendor-specific (power / AVDD/AVCL slope control): 0x00, 0xFF
+                { 0xE6, { 0x00, 0xFF },                         2, 0   },
+                // 0xE7 — Vendor-specific (source output / EQ timing): 6 bytes
+                { 0xE7, { 0x01, 0x04, 0x03, 0x03, 0x00, 0x12 }, 6, 0   },
+                // 0xE8 — Source driver output level / pre-charge control: 3 bytes
+                { 0xE8, { 0x00, 0x70, 0x00 },                   3, 0   },
+                // 0xEC — Vendor-specific (gate EQ / charge-pump timing): value 0x54
+                { 0xEC, { 0x54 },                                1, 0   },
+                // 0xFD — Cmd2 Enable: password bytes 0xFA,0xFC lock factory register set (Cmd2)
+                { 0xFD, { 0xFA, 0xFC },                         2, 0   },
+                // 0x3A — COLMOD (interface pixel format): 0x55 = 16 bpp RGB565
+                { 0x3A, { 0x55 },                                1, 0   },
+                // 0x11 — Sleep Out: exits sleep mode; 100 ms delay required before display on
+                { 0x11, { },                                     0, 100 },
+            };
+
+        public:
+            Panel_NV3031B(void)
+            {
+                _cfg.memory_width  = _cfg.panel_width  = 240;
+                _cfg.memory_height = _cfg.panel_height = 320;
+            }
+
+            bool init(bool use_reset) override;
+            void beginTransaction(void) override;
+            void endTransaction(void) override;
+
+            color_depth_t setColorDepth(color_depth_t depth) override;
+            void setInvert(bool invert) override;
+            void setSleep(bool flg) override;
+            void setPowerSave(bool flg) override;
+
+            void waitDisplay(void) override;
+            bool displayBusy(void) override;
+
+            void writePixels(pixelcopy_t* param, uint32_t len, bool use_dma) override;
+            void writeBlock(uint32_t rawcolor, uint32_t len) override;
+
+            void setWindow(uint_fast16_t xs, uint_fast16_t ys, uint_fast16_t xe, uint_fast16_t ye) override;
+            void drawPixelPreclipped(uint_fast16_t x, uint_fast16_t y, uint32_t rawcolor) override;
+            void writeFillRectPreclipped(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, uint32_t rawcolor) override;
+            void writeImage(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, pixelcopy_t* param, bool use_dma) override;
+
+            uint32_t readCommand(uint_fast16_t cmd, uint_fast8_t index, uint_fast8_t len) override;
+            uint32_t readData(uint_fast8_t index, uint_fast8_t len) override;
+            void readRect(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h, void* dst, pixelcopy_t* param) override;
+
+        protected:
+            bool _in_transaction = false;
+
+            void update_madctl(void) override;
+            void write_cmd(uint8_t cmd);
+            void start_qspi();
+            void end_qspi();
+            void write_bytes(const uint8_t* data, uint32_t len, bool use_dma);
+        };
+
+        //----------------------------------------------------------------------------
+    }
+}
+
+
+#endif

--- a/src/lgfx/v1/panel/Panel_NV3031B.hpp
+++ b/src/lgfx/v1/panel/Panel_NV3031B.hpp
@@ -58,63 +58,36 @@ namespace lgfx
             static constexpr uint8_t CMD_MADCTL_BGR   = 0x08;
 
 
-            // Init sequence derived from esp_lcd_nv3031b.c vendor_specific_init_default.
-            // Commands have variable-length data; see Panel_NV3031B::init() for the send loop.
-            struct InitCmd {
-                uint8_t  cmd;
-                uint8_t  data[8];
-                uint8_t  len;       // number of data bytes (0 = command only)
-                uint16_t delay_ms;
-            };
+            // Flat init table: cmd, len[|CMD_INIT_DELAY], data...[, delay_ms], ..., 0xFF, 0xFF
+            // CMD_INIT_DELAY ORed into len means a delay_ms byte follows the data bytes.
+            static constexpr uint8_t CMD_INIT_DELAY = 0x80;
 
-            static constexpr InitCmd init_cmds[] =
+            static constexpr uint8_t init_cmds[] =
             {
-                // 0xFD — Cmd2 Enable: password bytes 0x06,0x08 unlock factory register set (Cmd2)
-                { 0xFD, { 0x06, 0x08 },                         2, 0   },
-                // 0x60 — Source timing adjust: SDNL timing control value 0x0C
-                { 0x60, { 0x0C },                                1, 0   },
-                // 0x61 — Gate timing control: gate on/off timing (0x07 = rise, 0x04 = fall)
-                { 0x61, { 0x07, 0x04 },                         2, 0   },
-                // 0xB4 — Display inversion control: 0x01 = 1-dot inversion (column)
-                { 0xB4, { 0x01 },                                1, 0   },
-                // 0xB1 — Frame rate control (normal mode): DIVA=0x0F (osc divisor), RTNA=0x02 (line period), FPA=0x03 (front porch)
-                { 0xB1, { 0x0F, 0x02, 0x03 },                   3, 0   },
-                // 0xB5 — Blanking porch control: VFP=0x02, VBP=0x02, HBP_even=0x0A, HBP_odd=0x14
-                { 0xB5, { 0x02, 0x02, 0x0A, 0x14 },             4, 0   },
-                // 0xB6 — Display function control: ISC=0x44, SM=0x01, SS=0x9F, GS=0x00, REV=0x02
-                { 0xB6, { 0x44, 0x01, 0x9F, 0x00, 0x02 },       5, 0   },
-                // 0xDF — Vendor-specific (bias/oscillator trim): value 0x11
-                { 0xDF, { 0x11 },                                1, 0   },
-                // 0x67 — Vendor-specific (bias current control): value 0x21
-                { 0x67, { 0x21 },                                1, 0   },
-                // 0x68 — VCOM / power control: VCOM_H=0x90, VDV=0x4F, VCM_offset=0x27, VCOM_L=0x21
-                { 0x68, { 0x90, 0x4F, 0x27, 0x21 },             4, 0   },
-                // 0xE1 — Positive gamma voltage control: V63P=0x20, V0P=0x69
-                { 0xE1, { 0x20, 0x69 },                         2, 0   },
-                // 0xE4 — Negative gamma voltage control: V63N=0x69, V0N=0x20
-                { 0xE4, { 0x69, 0x20 },                         2, 0   },
-                // 0xE2 — Positive gamma correction (mid-tones): VP20,VP36,VP44,VP52,VP59,VP63
-                { 0xE2, { 0x10, 0x12, 0x12, 0x30, 0x39, 0x3F }, 6, 0   },
-                // 0xE5 — Negative gamma correction (mid-tones): VN20,VN36,VN44,VN52,VN59,VN63
-                { 0xE5, { 0x3F, 0x33, 0x2D, 0x12, 0x12, 0x10 }, 6, 0   },
-                // 0xE0 — Positive gamma curve (shadow/highlight): VP1..VP8
-                { 0xE0, { 0x06, 0x06, 0x0B, 0x12, 0x11, 0x11, 0x0E, 0x19 }, 8, 0 },
-                // 0xE3 — Negative gamma curve (shadow/highlight): VN1..VN8
-                { 0xE3, { 0x19, 0x13, 0x14, 0x14, 0x14, 0x12, 0x08, 0x05 }, 8, 0 },
-                // 0xE6 — Vendor-specific (power / AVDD/AVCL slope control): 0x00, 0xFF
-                { 0xE6, { 0x00, 0xFF },                         2, 0   },
-                // 0xE7 — Vendor-specific (source output / EQ timing): 6 bytes
-                { 0xE7, { 0x01, 0x04, 0x03, 0x03, 0x00, 0x12 }, 6, 0   },
-                // 0xE8 — Source driver output level / pre-charge control: 3 bytes
-                { 0xE8, { 0x00, 0x70, 0x00 },                   3, 0   },
-                // 0xEC — Vendor-specific (gate EQ / charge-pump timing): value 0x54
-                { 0xEC, { 0x54 },                                1, 0   },
-                // 0xFD — Cmd2 Enable: password bytes 0xFA,0xFC lock factory register set (Cmd2)
-                { 0xFD, { 0xFA, 0xFC },                         2, 0   },
-                // 0x3A — COLMOD (interface pixel format): 0x55 = 16 bpp RGB565
-                { 0x3A, { 0x55 },                                1, 0   },
-                // 0x11 — Sleep Out: exits sleep mode; 100 ms delay required before display on
-                { 0x11, { },                                     0, 100 },
+                0xFD, 2, 0x06, 0x08,                             // Cmd2 Enable: unlock factory registers
+                0x60, 1, 0x0C,                                   // Source timing adjust
+                0x61, 2, 0x07, 0x04,                             // Gate timing control
+                0xB4, 1, 0x01,                                   // Display inversion: 1-dot column
+                0xB1, 3, 0x0F, 0x02, 0x03,                       // Frame rate control
+                0xB5, 4, 0x02, 0x02, 0x0A, 0x14,                 // Blanking porch control
+                0xB6, 5, 0x44, 0x01, 0x9F, 0x00, 0x02,           // Display function control
+                0xDF, 1, 0x11,                                   // Bias/oscillator trim
+                0x67, 1, 0x21,                                   // Bias current control
+                0x68, 4, 0x90, 0x4F, 0x27, 0x21,                 // VCOM / power control
+                0xE1, 2, 0x20, 0x69,                             // Positive gamma voltage
+                0xE4, 2, 0x69, 0x20,                             // Negative gamma voltage
+                0xE2, 6, 0x10, 0x12, 0x12, 0x30, 0x39, 0x3F,     // Positive gamma mid-tones
+                0xE5, 6, 0x3F, 0x33, 0x2D, 0x12, 0x12, 0x10,     // Negative gamma mid-tones
+                0xE0, 8, 0x06, 0x06, 0x0B, 0x12, 0x11, 0x11, 0x0E, 0x19, // Positive gamma curve
+                0xE3, 8, 0x19, 0x13, 0x14, 0x14, 0x14, 0x12, 0x08, 0x05, // Negative gamma curve
+                0xE6, 2, 0x00, 0xFF,                             // AVDD/AVCL slope control
+                0xE7, 6, 0x01, 0x04, 0x03, 0x03, 0x00, 0x12,     // Source output / EQ timing
+                0xE8, 3, 0x00, 0x70, 0x00,                       // Source driver output level
+                0xEC, 1, 0x54,                                   // Gate EQ / charge-pump timing
+                0xFD, 2, 0xFA, 0xFC,                             // Cmd2 Enable: lock factory registers
+                0x3A, 1, 0x55,                                   // COLMOD: 16 bpp RGB565
+                0x11, 0|CMD_INIT_DELAY, 100,                     // Sleep Out + 100 ms delay
+                0xFF, 0xFF                                       // end of table
             };
 
         public:

--- a/src/lgfx/v1_init.hpp
+++ b/src/lgfx/v1_init.hpp
@@ -56,6 +56,7 @@ Contributors:
 
 // AMOLED
 #include "v1/panel/Panel_SH8601Z.hpp"
+#include "v1/panel/Panel_NV3031B.hpp"
 #include "v1/panel/Panel_NV3041A.hpp"
 #include "v1/panel/Panel_RM690B0.hpp"
 #include "v1/panel/Panel_RM67162.hpp"


### PR DESCRIPTION
NV3031B is used for AMOLED displays with lower resolution, e.g. 320x240.

For this PR the existing NV3041A.cpp implementation served as a template.

**NV3031B vs NV3041A — key driver differences**

- COLMOD pixel format encoding: NV3031B uses standard MIPI DCS values 0x55 (RGB565) / 0x66 (RGB666). NV3041A uses non-standard values 0x00 / 0x01.
- end_qspi() fix: NV3031B simply deasserts CS to terminate a color write. NV3041A sends a 4-byte terminator sequence {0x32, 0x00, 0x00, 0x00} before CS-high, which writes 2 rogue pixels at the start of every draw region — a latent corruption bug.
- setPowerSave() implemented: NV3031B sends DISPOFF (0x28) / DISPON (0x29) for a fast, low-power display-off state with immediate resume. NV3041A's setPowerSave() is a no-op.
- startWrite()/endWrite() around all command methods: NV3031B wraps setInvert(), setSleep(), and setPowerSave() in startWrite()/endWrite(), ensuring the SPI bus is correctly claimed and the peripheral clock/mode configured before sending commands on a shared bus. NV3041A omits these guards in setInvert() and setSleep().

<img width="955" height="725" alt="image" src="https://github.com/user-attachments/assets/6c8d0ec5-ae9f-4eb9-aebf-044418fa9eb5" />
