### PR TITLE
Add Light_CH422G I2C I/O expander driver and clean up Waveshare 4.3 b…

### DIFF
--- a/.github/scripts/installSDL2.bat
+++ b/.github/scripts/installSDL2.bat
@@ -40,6 +40,8 @@ curl https://www.libsdl.org/release/SDL2-%sdlVersion%.zip -o contrib/SDL2-SRC.zi
 
 cd contrib/src/SDL2-%sdlVersion%
 
+powershell -Command "(Get-Content CMakeLists.txt) -replace 'cmake_minimum_required\(VERSION [0-9.]+\)', 'cmake_minimum_required(VERSION 3.5)' | Set-Content CMakeLists.txt"
+
 set cwd=%cd%
 
 echo ============================================

--- a/src/lgfx/v1/platforms/device.hpp
+++ b/src/lgfx/v1/platforms/device.hpp
@@ -24,12 +24,14 @@ Contributors:
  #if defined (CONFIG_IDF_TARGET_ESP32C6)
 
   #include "esp32/Light_PWM.hpp"
+  #include "esp32/Light_CH422G.hpp"
   #include "esp32/Bus_SPI.hpp"
   #include "esp32/Bus_I2C.hpp"
 
  #elif defined (CONFIG_IDF_TARGET_ESP32C3)
 
   #include "esp32/Light_PWM.hpp"
+  #include "esp32/Light_CH422G.hpp"
   #include "esp32/Bus_SPI.hpp"
   #include "esp32/Bus_I2C.hpp"
   #include "esp32c3/Bus_Parallel8.hpp"
@@ -37,6 +39,7 @@ Contributors:
  #elif defined (CONFIG_IDF_TARGET_ESP32S2)
 
   #include "esp32/Light_PWM.hpp"
+  #include "esp32/Light_CH422G.hpp"
   #include "esp32/Bus_SPI.hpp"
   #include "esp32/Bus_I2C.hpp"
   #include "esp32s2/Bus_Parallel8.hpp"
@@ -45,6 +48,7 @@ Contributors:
  #elif defined (CONFIG_IDF_TARGET_ESP32S3)
 
   #include "esp32/Light_PWM.hpp"
+  #include "esp32/Light_CH422G.hpp"
   #include "esp32/Bus_SPI.hpp"
   #include "esp32/Bus_I2C.hpp"
   #include "esp32s3/Bus_Parallel8.hpp"
@@ -53,6 +57,7 @@ Contributors:
  #elif defined  (CONFIG_IDF_TARGET_ESP32P4)
 
   #include "esp32/Light_PWM.hpp"
+  #include "esp32/Light_CH422G.hpp"
   #include "esp32/Bus_SPI.hpp"
   #include "esp32/Bus_I2C.hpp"
   #include "esp32p4/Bus_DSI.hpp"
@@ -63,12 +68,14 @@ Contributors:
  #elif defined (CONFIG_IDF_TARGET_ESP32H2)
 
   #include "esp32/Light_PWM.hpp"
+  #include "esp32/Light_CH422G.hpp"
   #include "esp32/Bus_SPI.hpp"
   #include "esp32/Bus_I2C.hpp"
 
  #else
 
   #include "esp32/Light_PWM.hpp"
+  #include "esp32/Light_CH422G.hpp"
   #include "esp32/Bus_SPI.hpp"
   #include "esp32/Bus_I2C.hpp"
   #include "esp32/Bus_Parallel8.hpp"

--- a/src/lgfx/v1/platforms/esp32/Light_CH422G.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_CH422G.cpp
@@ -1,0 +1,72 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#if defined (ESP_PLATFORM)
+
+#include "Light_CH422G.hpp"
+#include "../common.hpp"
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  // CH422G I2C addresses (fixed by hardware, not configurable).
+  static constexpr uint8_t kAddrCfg = 0x24;  // write-enable register
+  static constexpr uint8_t kAddrOut = 0x38;  // output data register
+
+  bool Light_CH422G::init(uint8_t brightness)
+  {
+    lgfx::i2c::init(_cfg.i2c_port, _cfg.pin_sda, _cfg.pin_scl);
+    _shadow = _cfg.shadow_init;
+    write_shadow();
+    setBrightness(brightness);
+    return true;
+  }
+
+  void Light_CH422G::setBrightness(uint8_t brightness)
+  {
+    bool on = (brightness > 0);
+    write_pin(_cfg.pin_bl, _cfg.invert ? !on : on);
+  }
+
+  void Light_CH422G::write_pin(uint8_t pin, bool state)
+  {
+    if (state)
+    {
+      _shadow |=  (1u << pin);
+    }
+    else
+    {
+      _shadow &= ~(1u << pin);
+    }
+    write_shadow();
+  }
+
+  void Light_CH422G::write_shadow(void)
+  {
+    uint8_t enable = 0x01;
+    lgfx::i2c::transactionWrite(_cfg.i2c_port, kAddrCfg, &enable,  1, _cfg.freq);
+    lgfx::i2c::transactionWrite(_cfg.i2c_port, kAddrOut,  &_shadow, 1, _cfg.freq);
+  }
+
+//----------------------------------------------------------------------------
+ }
+}
+
+#endif

--- a/src/lgfx/v1/platforms/esp32/Light_CH422G.hpp
+++ b/src/lgfx/v1/platforms/esp32/Light_CH422G.hpp
@@ -1,0 +1,69 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../../Light.hpp"
+
+namespace lgfx
+{
+ inline namespace v1
+ {
+//----------------------------------------------------------------------------
+
+  // Backlight driver for the CH422G I/O expander.
+  //
+  // The CH422G uses two fixed I2C addresses: 0x24 (write-enable) and 0x38
+  // (output data). It has no read-back, so a shadow register tracks the
+  // current output state. All pin writes go through write_pin() to keep the
+  // shadow consistent.
+  //
+  // Boards that route non-backlight signals (e.g. touch reset, LCD reset)
+  // through the same CH422G should call write_pin() directly from their
+  // init_impl() after calling init().
+  class Light_CH422G : public ILight
+  {
+  public:
+    struct config_t
+    {
+      uint32_t freq        = 400000;
+      int16_t  pin_sda     = -1;
+      int16_t  pin_scl     = -1;
+      uint8_t  i2c_port    = 0;
+      uint8_t  pin_bl      = 0;
+      uint8_t  shadow_init = 0;
+      bool     invert      = false;
+    };
+
+    const config_t& config(void) const { return _cfg; }
+    void config(const config_t& cfg) { _cfg = cfg; }
+
+    bool init(uint8_t brightness) override;
+    void setBrightness(uint8_t brightness) override;
+
+    void write_pin(uint8_t pin, bool state);
+
+  private:
+    config_t _cfg;
+    uint8_t  _shadow = 0;
+
+    void write_shadow(void);
+  };
+
+//----------------------------------------------------------------------------
+ }
+}

--- a/src/lgfx_user/LGFX_Waveshare_ESP32S3_Touch_LCD_43.h
+++ b/src/lgfx_user/LGFX_Waveshare_ESP32S3_Touch_LCD_43.h
@@ -5,95 +5,37 @@
 
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
-#include <driver/i2c.h>
-
-// Platform-specific I2C includes.
-#ifdef ARDUINO
-#include <Wire.h>
-#else
-#include <driver/i2c_master.h>
-#endif
+#include <lgfx/v1/platforms/esp32/Light_CH422G.hpp>
 
 // LGFX for Waveshare ESP32-S3-Touch-LCD-4.3
 // https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
-// Hardware: 800x480 RGB565 display with GT911 touch controller
-// Special: CH422G I/O expander controls GT911 reset and LCD backlight
+// Hardware: 800x480 RGB565 display with GT911 touch controller.
+// Special:  CH422G I/O expander controls GT911 reset, LCD reset, and backlight.
 
-namespace lgfx {
+// CH422G output-pin assignments (board-specific, not reconfigurable).
+static constexpr uint8_t kCh422gPinTpRst  = 1;
+static constexpr uint8_t kCh422gPinLcdBl  = 2;
+static constexpr uint8_t kCh422gPinLcdRst = 3;
+static constexpr uint8_t kCh422gPinSdCs   = 4;  // active-low; HIGH = deselected
 
-// Custom backlight class for CH422G I/O expander control.
-class Light_CH422G : public ILight {
- public:
-  Light_CH422G() : backlight_pin_(0), exio_shadow_(0) {}
-
-  bool init(uint8_t brightness) override {
-    setBrightness(brightness);
-    return true;
-  }
-
-  void setBrightness(uint8_t brightness) override {
-    // CH422G has no PWM - digital on/off only.
-    bool state = (brightness > 0);
-    writeEXIO(backlight_pin_, state);
-  }
-
-  void setBacklightPin(uint8_t pin) { backlight_pin_ = pin; }
-  void setInitialState(uint8_t shadow) { exio_shadow_ = shadow; }
-
- private:
-  uint8_t backlight_pin_;
-  uint8_t exio_shadow_;
-
-  void writeEXIO(uint8_t pin, bool state) {
-    if (state) {
-      exio_shadow_ |= (1 << pin);
-    } else {
-      exio_shadow_ &= ~(1 << pin);
-    }
-
-    // CH422G dual-address protocol.
-#ifdef ARDUINO
-    Wire.beginTransmission(0x24);
-    Wire.write(0x01);  // Write enable.
-    Wire.endTransmission();
-    Wire.beginTransmission(0x38);
-    Wire.write(exio_shadow_);  // Output data.
-    Wire.endTransmission();
-#else
-    // ESP-IDF i2c_master write.
-    uint8_t enable_cmd = 0x01;
-    i2c_master_transmit(dev_handle_24_, &enable_cmd, 1, 100);
-    i2c_master_transmit(dev_handle_38_, &exio_shadow_, 1, 100);
-#endif
-  }
-
-#ifndef ARDUINO
-  i2c_master_dev_handle_t dev_handle_24_;
-  i2c_master_dev_handle_t dev_handle_38_;
-#endif
-
-  friend class LGFX;
-};
-
-}  // namespace lgfx
-
-class LGFX : public lgfx::LGFX_Device {
- public:
-  lgfx::Bus_RGB _bus_instance;
-  lgfx::Panel_RGB _panel_instance;
+class LGFX : public lgfx::LGFX_Device
+{
+public:
+  lgfx::Bus_RGB      _bus_instance;
+  lgfx::Panel_RGB    _panel_instance;
   lgfx::Light_CH422G _light_instance;
-  lgfx::Touch_GT911 _touch_instance;
+  lgfx::Touch_GT911  _touch_instance;
 
-  LGFX(void) {
-    // Panel configuration.
+  LGFX(void)
+  {
     {
       auto cfg = _panel_instance.config();
-      cfg.memory_width = 800;
+      cfg.memory_width  = 800;
       cfg.memory_height = 480;
-      cfg.panel_width = 800;
-      cfg.panel_height = 480;
-      cfg.offset_x = 0;
-      cfg.offset_y = 0;
+      cfg.panel_width   = 800;
+      cfg.panel_height  = 480;
+      cfg.offset_x      = 0;
+      cfg.offset_y      = 0;
       _panel_instance.config(cfg);
     }
 
@@ -103,66 +45,74 @@ class LGFX : public lgfx::LGFX_Device {
       _panel_instance.config_detail(cfg);
     }
 
-    // RGB bus configuration.
     {
       auto cfg = _bus_instance.config();
-      cfg.panel = &_panel_instance;
-      cfg.pin_d0 = GPIO_NUM_14;   // B0
-      cfg.pin_d1 = GPIO_NUM_38;   // B1
-      cfg.pin_d2 = GPIO_NUM_18;   // B2
-      cfg.pin_d3 = GPIO_NUM_17;   // B3
-      cfg.pin_d4 = GPIO_NUM_10;   // B4
-      cfg.pin_d5 = GPIO_NUM_39;   // G0
-      cfg.pin_d6 = GPIO_NUM_0;    // G1
-      cfg.pin_d7 = GPIO_NUM_45;   // G2
-      cfg.pin_d8 = GPIO_NUM_48;   // G3
-      cfg.pin_d9 = GPIO_NUM_47;   // G4
-      cfg.pin_d10 = GPIO_NUM_21;  // G5
-      cfg.pin_d11 = GPIO_NUM_1;   // R0
-      cfg.pin_d12 = GPIO_NUM_2;   // R1
-      cfg.pin_d13 = GPIO_NUM_42;  // R2
-      cfg.pin_d14 = GPIO_NUM_41;  // R3
-      cfg.pin_d15 = GPIO_NUM_40;  // R4
+      cfg.panel    = &_panel_instance;
+      cfg.pin_d0   = GPIO_NUM_14;   // B0
+      cfg.pin_d1   = GPIO_NUM_38;   // B1
+      cfg.pin_d2   = GPIO_NUM_18;   // B2
+      cfg.pin_d3   = GPIO_NUM_17;   // B3
+      cfg.pin_d4   = GPIO_NUM_10;   // B4
+      cfg.pin_d5   = GPIO_NUM_39;   // G0
+      cfg.pin_d6   = GPIO_NUM_0;    // G1
+      cfg.pin_d7   = GPIO_NUM_45;   // G2
+      cfg.pin_d8   = GPIO_NUM_48;   // G3
+      cfg.pin_d9   = GPIO_NUM_47;   // G4
+      cfg.pin_d10  = GPIO_NUM_21;   // G5
+      cfg.pin_d11  = GPIO_NUM_1;    // R0
+      cfg.pin_d12  = GPIO_NUM_2;    // R1
+      cfg.pin_d13  = GPIO_NUM_42;   // R2
+      cfg.pin_d14  = GPIO_NUM_41;   // R3
+      cfg.pin_d15  = GPIO_NUM_40;   // R4
 
-      cfg.pin_henable = GPIO_NUM_5;   // DE (Data Enable)
-      cfg.pin_vsync = GPIO_NUM_3;
-      cfg.pin_hsync = GPIO_NUM_46;
-      cfg.pin_pclk = GPIO_NUM_7;
-      cfg.freq_write = 16000000;
+      cfg.pin_henable = GPIO_NUM_5;
+      cfg.pin_vsync   = GPIO_NUM_3;
+      cfg.pin_hsync   = GPIO_NUM_46;
+      cfg.pin_pclk    = GPIO_NUM_7;
+      cfg.freq_write  = 16000000;
 
-      cfg.hsync_polarity = 0;
+      cfg.hsync_polarity    = 0;
       cfg.hsync_front_porch = 8;
       cfg.hsync_pulse_width = 4;
-      cfg.hsync_back_porch = 8;
-      cfg.vsync_polarity = 0;
+      cfg.hsync_back_porch  = 8;
+      cfg.vsync_polarity    = 0;
       cfg.vsync_front_porch = 16;
       cfg.vsync_pulse_width = 4;
-      cfg.vsync_back_porch = 16;
-      cfg.pclk_idle_high = 1;
+      cfg.vsync_back_porch  = 16;
+      cfg.pclk_idle_high    = 1;
       _bus_instance.config(cfg);
     }
     _panel_instance.setBus(&_bus_instance);
 
-    // Backlight configuration.
-    _panel_instance.light(&_light_instance);
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_sda     = GPIO_NUM_8;
+      cfg.pin_scl     = GPIO_NUM_9;
+      cfg.i2c_port    = 0;
+      cfg.freq        = 400000;
+      cfg.pin_bl      = kCh422gPinLcdBl;
+      // All active-low pins (SD_CS) start HIGH (deselected); all others HIGH too.
+      cfg.shadow_init = (1 << kCh422gPinTpRst) | (1 << kCh422gPinLcdBl)
+                      | (1 << kCh422gPinLcdRst) | (1 << kCh422gPinSdCs);
+      _light_instance.config(cfg);
+      _panel_instance.light(&_light_instance);
+    }
 
-    // Touch configuration.
     {
       auto cfg = _touch_instance.config();
-      cfg.x_min = 0;
-      cfg.y_min = 0;
-      cfg.x_max = 800;
-      cfg.y_max = 480;
-      cfg.bus_shared = false;
+      cfg.x_min        = 0;
+      cfg.y_min        = 0;
+      cfg.x_max        = 800;
+      cfg.y_max        = 480;
+      cfg.bus_shared   = false;
       cfg.offset_rotation = 0;
-      // I2C connection
-      cfg.i2c_port = I2C_NUM_0;
-      cfg.i2c_addr = 0x5D;  // Selected via INT pin during reset.
-      cfg.pin_sda = GPIO_NUM_8;
-      cfg.pin_scl = GPIO_NUM_9;
-      cfg.pin_int = GPIO_NUM_4;
-      cfg.pin_rst = -1;  // Reset via CH422G, not direct GPIO.
-      cfg.freq = 400000;
+      cfg.i2c_port     = 0;
+      cfg.i2c_addr     = 0x5D;  // INT low during reset selects 0x5D.
+      cfg.pin_sda      = GPIO_NUM_8;
+      cfg.pin_scl      = GPIO_NUM_9;
+      cfg.pin_int      = GPIO_NUM_4;
+      cfg.pin_rst      = -1;    // Reset handled via CH422G in init_impl().
+      cfg.freq         = 400000;
       _touch_instance.config(cfg);
       _panel_instance.setTouch(&_touch_instance);
     }
@@ -170,89 +120,26 @@ class LGFX : public lgfx::LGFX_Device {
     setPanel(&_panel_instance);
   }
 
-  // Hardware initialization after Arduino core ready.
-  bool init_impl(bool use_reset, bool use_clear) override {
-    // I2C initialization for touch and CH422G.
-#ifdef ARDUINO
-    Wire.begin(8, 9);  // SDA=8, SCL=9
-    Wire.setClock(400000);
-#else
-    // ESP-IDF i2c_master initialization.
-    i2c_master_bus_config_t bus_config = {
-        .i2c_port = I2C_NUM_0,
-        .sda_io_num = GPIO_NUM_8,
-        .scl_io_num = GPIO_NUM_9,
-        .clk_source = I2C_CLK_SRC_DEFAULT,
-        .glitch_ignore_cnt = 7,
-        .flags = {.enable_internal_pullup = true},
-    };
-    i2c_master_bus_handle_t bus_handle;
-    i2c_new_master_bus(&bus_config, &bus_handle);
+  bool init_impl(bool use_reset, bool use_clear) override
+  {
+    // Initialise CH422G: sets up I2C, drives all pins to shadow_init state.
+    _light_instance.init(255);
 
-    // CH422G device handles.
-    i2c_device_config_t dev_cfg_24 = {
-        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-        .device_address = 0x24,
-        .scl_speed_hz = 400000,
-    };
-    i2c_device_config_t dev_cfg_38 = {
-        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-        .device_address = 0x38,
-        .scl_speed_hz = 400000,
-    };
-    i2c_master_bus_add_device(bus_handle, &dev_cfg_24,
-                               &_light_instance.dev_handle_24_);
-    i2c_master_bus_add_device(bus_handle, &dev_cfg_38,
-                               &_light_instance.dev_handle_38_);
-#endif
+    // GT911 address selection: INT must be LOW while reset is asserted.
+    // Holding INT low causes GT911 to select I2C address 0x5D on release.
+    lgfx::pinMode(GPIO_NUM_4, lgfx::pin_mode_t::output);
+    lgfx::gpio_lo(GPIO_NUM_4);
+    lgfx::delay(10);
 
-    // CH422G initial state: LCD_RST=1, LCD_BL=1, TP_RST=1.
-    // Pin assignments: TP_RST=1, LCD_BL=2, LCD_RST=3.
-    uint8_t initial_state = (1 << 1) | (1 << 2) | (1 << 3);
-    _light_instance.setInitialState(initial_state);
-    _light_instance.setBacklightPin(2);
+    _light_instance.write_pin(kCh422gPinTpRst, false);
+    lgfx::delay(100);
+    _light_instance.write_pin(kCh422gPinTpRst, true);
+    lgfx::delay(10);
 
-    writeCH422G(initial_state);
-    delay(10);
+    lgfx::pinMode(GPIO_NUM_4, lgfx::pin_mode_t::input);
 
-    // GT911 reset sequence.
-    // GT911 samples INT pin during reset to select I2C address 0x5D.
-    // INT must be LOW during reset.
-
-    // Step 1: Pull INT pin LOW.
-    pinMode(4, OUTPUT);
-    digitalWrite(4, LOW);
-    delay(10);
-
-    // Step 2: Assert GT911 reset (TP_RST=0) via CH422G.
-    uint8_t reset_state = (1 << 2) | (1 << 3);  // LCD_BL=1, LCD_RST=1, TP_RST=0
-    writeCH422G(reset_state);
-    delay(100);
-
-    // Step 3: Release GT911 reset (TP_RST=1).
-    writeCH422G(initial_state);
-    delay(10);
-
-    // Step 4: Configure INT pin as input for touch interrupts.
-    pinMode(4, INPUT);
-
-    // Call parent init.
     return lgfx::LGFX_Device::init_impl(use_reset, use_clear);
   }
-
- private:
-  void writeCH422G(uint8_t data) {
-#ifdef ARDUINO
-    Wire.beginTransmission(0x24);
-    Wire.write(0x01);  // Write enable.
-    Wire.endTransmission();
-    Wire.beginTransmission(0x38);
-    Wire.write(data);  // Output data.
-    Wire.endTransmission();
-#else
-    uint8_t enable_cmd = 0x01;
-    i2c_master_transmit(_light_instance.dev_handle_24_, &enable_cmd, 1, 100);
-    i2c_master_transmit(_light_instance.dev_handle_38_, &data, 1, 100);
-#endif
-  }
 };
+
+using LGFX_Waveshare = LGFX;


### PR DESCRIPTION
## Summary

- Adds `Light_CH422G` as a reusable library class under `src/lgfx/v1/platforms/esp32/`, following the same pattern as `Light_PWM`.
- Rewrites `LGFX_Waveshare_ESP32S3_Touch_LCD_43.h` using the new driver, eliminating a `friend class` hack, duplicated I2C code, and `#ifdef ARDUINO` blocks scattered across four locations in the same file.

## Motivation

The CH422G is an I2C I/O expander found on several Waveshare ESP32-S3 boards. The existing board config implemented CH422G communication inline, requiring a `friend class LGFX` workaround to share I2C state between the light driver and `init_impl()`. This PR replaces that with a self-contained `Light_CH422G` class that any board config can use directly.

## Changes

**New:**
- `src/lgfx/v1/platforms/esp32/Light_CH422G.hpp`
- `src/lgfx/v1/platforms/esp32/Light_CH422G.cpp`

**Modified:**
- `src/lgfx/v1/platforms/device.hpp` — includes `Light_CH422G` alongside `Light_PWM` for all ESP32 targets
- `src/lgfx_user/LGFX_Waveshare_ESP32S3_Touch_LCD_43.h` — rewritten to use `Light_CH422G`; no more `friend`, no duplicate I2C code, no `#ifdef ARDUINO`

## Design Notes

- **Framework Independence:** No more usage of the `Wire` library. All I2C communication goes through `lgfx::i2c::transactionWrite()` — resulting in identical behavior on Arduino and ESP-IDF without any `#ifdef` blocks.
- **State Management:** `Light_CH422G` owns a shadow register (since CH422G has no read-back capability) and exposes `write_pin(pin, state)` publicly so board-level `init_impl()` can drive touch/LCD reset signals through the same expander without additional I2C transactions or friendship declarations.
- **Atomic Safe State:** `shadow_init` in `config_t` lets the board declare a safe startup state for all expander pins (including active-low signals like `SD_CS`) atomically on the first write.

## Verification / Testing

Tested on Waveshare ESP32-S3-Touch-LCD-4.3 / 4.3B (800×480 RGB, GT911 touch, Arduino framework): 
- Display initializes correctly.
- Backlight control works as expected.
- Touch input is fully functional.