### PR TITLE
Fix panel transaction shutdown order

### DIFF
--- a/src/lgfx/v1/LGFXBase.cpp
+++ b/src/lgfx/v1/LGFXBase.cpp
@@ -2129,6 +2129,7 @@ namespace lgfx
     int32_t right = 0;
     auto str = string;
     do {
+      auto char_start = string;
       uint32_t uniCode = *string;
       if (_text_style.utf8) {
         do {
@@ -2160,7 +2161,7 @@ namespace lgfx
       right = left + std::max<int>(sxadvance, ((_font_metrics.width * sx) >> 16) + ((_font_metrics.x_offset * sx) >> 16));
       //right = left + (int)(std::max<int>(_font_metrics.x_advance, _font_metrics.width + _font_metrics.x_offset) * sx);
       left += sxadvance;
-      if (width <= right) return string - str;
+      if (width <= right) return char_start - str;
     } while (*(++string));
     return string - str;
   }

--- a/src/lgfx/v1/panel/Panel_HasBuffer.cpp
+++ b/src/lgfx/v1/panel/Panel_HasBuffer.cpp
@@ -67,8 +67,9 @@ namespace lgfx
   {
     if (!_in_transaction) return;
     _in_transaction = false;
-    _bus->endTransaction();
+    _bus->wait();
     cs_control(true);
+    _bus->endTransaction();
   }
 
   void Panel_HasBuffer::setRotation(uint_fast8_t r)

--- a/src/lgfx/v1/panel/Panel_IT8951.cpp
+++ b/src/lgfx/v1/panel/Panel_IT8951.cpp
@@ -236,8 +236,9 @@ IT8951 Registers defines
   {
     if (!_in_transaction) return;
     _in_transaction = false;
-    _bus->endTransaction();
+    _bus->wait();
     cs_control(true);
+    _bus->endTransaction();
   }
 
   bool Panel_IT8951::_wait_busy(uint32_t timeout)

--- a/src/lgfx/v1/panel/Panel_M5UnitLCD.cpp
+++ b/src/lgfx/v1/panel/Panel_M5UnitLCD.cpp
@@ -78,8 +78,9 @@ namespace lgfx
   {
     if (!_in_transaction) return;
     _in_transaction = false;
-    _bus->endTransaction();
+    _bus->wait();
     cs_control(true);
+    _bus->endTransaction();
     _last_cmd = 0;
   }
 
@@ -96,8 +97,9 @@ namespace lgfx
         --_buff_free_count;
         return true;
       }
-      _bus->endTransaction();
+      _bus->wait();
       cs_control(true);
+      _bus->endTransaction();
       _bus->beginTransaction();
       cs_control(false);
       break;

--- a/src/lgfx/v1/panel/Panel_NV3031B.cpp
+++ b/src/lgfx/v1/panel/Panel_NV3031B.cpp
@@ -263,6 +263,8 @@ namespace lgfx
                 _bus->writeData(0, 8);
             }
 
+            _bus->wait();
+            cs_control(true);
             _bus->endTransaction();
         }
 

--- a/src/lgfx/v1/panel/Panel_NV3041A.cpp
+++ b/src/lgfx/v1/panel/Panel_NV3041A.cpp
@@ -270,6 +270,8 @@ namespace lgfx
                 _bus->writeData(0, 8);
             }
 
+            _bus->wait();
+            cs_control(true);
             _bus->endTransaction();
         }
 

--- a/src/lgfx/v1/panel/Panel_RA8875.cpp
+++ b/src/lgfx/v1/panel/Panel_RA8875.cpp
@@ -157,8 +157,9 @@ namespace lgfx
     if (!_in_transaction) return;
     _in_transaction = false;
 
-    _bus->endTransaction();
+    _bus->wait();
     cs_control(true);
+    _bus->endTransaction();
   }
 
   color_depth_t Panel_RA8875::setColorDepth(color_depth_t depth)

--- a/src/lgfx/v1/panel/Panel_SH8601Z.cpp
+++ b/src/lgfx/v1/panel/Panel_SH8601Z.cpp
@@ -320,6 +320,8 @@ namespace lgfx
                 _bus->writeData(0, 8);
             }
 
+            _bus->wait();
+            cs_control(true);
             _bus->endTransaction();
         }
 

--- a/src/lgfx/v1/platforms/esp32/Panel_EPD.cpp
+++ b/src/lgfx/v1/platforms/esp32/Panel_EPD.cpp
@@ -554,6 +554,14 @@ namespace lgfx
   {
     if (0 < w && 0 < h)
     {
+      uint_fast8_t r = _internal_rotation;
+      if (r)
+      {
+        if (r & 1) { std::swap(x, y); std::swap(w, h); }
+        uint_fast8_t rb = 1 << r;
+        if (rb & 0b11000110) { x = _cfg.panel_width  - x - w; }
+        if (rb & 0b10011100) { y = _cfg.panel_height - y - h; }
+      }
       _range_mod.left   = std::min<int16_t>(_range_mod.left  , x        );
       _range_mod.right  = std::max<int16_t>(_range_mod.right , x + w - 1);
       _range_mod.top    = std::min<int16_t>(_range_mod.top   , y        );
@@ -923,6 +931,7 @@ __asm__ __volatile(
 
           do {
             size_t w = new_data.w >> 1;
+            w &= ~1u;
             auto s = src;
             auto d = dst;
             src += panel_w >> 1;


### PR DESCRIPTION
## Summary
- Wait for pending bus transfers before releasing CS in panel transaction shutdown paths.
- Keep the bus endTransaction call after CS has been deasserted.
- Apply the ordering to Panel_HasBuffer, Panel_IT8951, Panel_M5UnitLCD, Panel_NV3031B, Panel_NV3041A, Panel_RA8875, and Panel_SH8601Z.
- Include the pending EPD range/update fixes and UTF-8 text clipping fix from the local develop branch.