### PR TITLE
Fix createFromBmp for top-down BMPs

### DIFF
--- a/src/lgfx/v1/LGFX_Sprite.cpp
+++ b/src/lgfx/v1/LGFX_Sprite.cpp
@@ -709,14 +709,15 @@ namespace lgfx
     setColorDepth(bpp < 32 ? bpp : 24);
     uint32_t w = bmpdata.biWidth;
     int32_t h = bmpdata.biHeight;  // bcHeight Image height (pixels)
-    if (!createSprite(w, h)) return false;
 
       //If the value of Height is positive, the image data is from bottom to top
       //If the value of Height is negative, the image data is from top to bottom.
-    int32_t flow = (h < 0) ? 1 : -1;
-    int32_t y = 0;
-    if (h < 0) h = -h;
-    else y = h - 1;
+    if (h == INT32_MIN) return false;
+    bool top_down = h < 0;
+    if (top_down) h = -h;
+    if (!createSprite(w, h)) return false;
+    int32_t flow = top_down ? 1 : -1;
+    int32_t y = top_down ? 0 : h - 1;
 
     if (bpp <= 8) {
       if (!_palette) createPalette();


### PR DESCRIPTION
## Problem

`LGFX_Sprite::createFromBmp()` reads `biHeight` as a signed value and already has row-order logic for negative heights. However, it passes that negative value to `createSprite()` before normalizing it. Since `createSprite()` rejects heights below 1, every valid top-down BMP fails before the intended row-order branch can run.

The Windows `BITMAPINFOHEADER` documentation defines a negative `biHeight` for uncompressed RGB data as a top-down DIB with its origin at the upper-left: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader

## Fix

Record the row direction and normalize the height before allocating the sprite. `INT32_MIN` is rejected explicitly because its positive magnitude cannot be represented by `int32_t`. Positive-height BMPs keep their existing bottom-up row reversal.

## Verification

Built the library's full SDL host source set with GCC 13.3, including the real `LGFX_Sprite.cpp`, and ran a 2x2 24-bit BMP test through the public `createFromBmp()` API:

- Before: the bottom-up fixture imports correctly, while the equivalent top-down fixture returns `false` with an empty 0x0 sprite.
- After: both fixtures import as 2x2 sprites and produce the same logical RGB pixels (red/green top row, blue/white bottom row).
- An `INT32_MIN` height is rejected without allocating a buffer.
- The behavior test passes under AddressSanitizer and UndefinedBehaviorSanitizer.
- The affected translation unit compiles under `-Wall -Wextra -Werror`, exempting only pre-existing unused-parameter diagnostics from shared SDL headers.
