### PR TITLE
Make 24-bit sprite reads alignment-safe

### DIFF
--- a/src/lgfx/utility/pgmspace.h
+++ b/src/lgfx/utility/pgmspace.h
@@ -61,7 +61,14 @@ Contributors:
 #endif
 
 #if !defined ( pgm_read_3byte_unaligned )
- #define pgm_read_3byte_unaligned(addr) (pgm_read_dword_unaligned(addr) & 0xFFFFFFu)
+ #if defined ( pgm_read_dword_with_offset )
+  #define pgm_read_3byte_unaligned(addr) (pgm_read_dword_unaligned(addr) & 0xFFFFFFu)
+ #else
+  #define pgm_read_3byte_unaligned(addr) (uint32_t) \
+    ( (uint32_t)pgm_read_byte((const uint8_t *)(addr)    )       \
+    | (uint32_t)pgm_read_byte((const uint8_t *)(addr) + 1) << 8  \
+    | (uint32_t)pgm_read_byte((const uint8_t *)(addr) + 2) << 16 )
+ #endif
 #endif
 
 #if defined ( ESP8266 ) || defined (__SAMD21__) || defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__) || defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040) || defined(USE_PICO_SDK)


### PR DESCRIPTION
## Problem

`pgm_read_3byte_unaligned()` falls back to reading a `uint32_t` and masking off the high byte. Packed 24-bit pixels advance in three-byte steps, so the second pixel in a normally aligned sprite starts at `buffer + 3`. Reading that address through a `uint32_t *` requires alignment the pixel cannot provide.

A 3x1 24-bit `LGFX_Sprite` fixture built from the real SDL source set reproduces this through both public read paths:

- `readPixel(1, 0)` reports a misaligned load in `bgr888_t::get()`, called by `pixelcopy_t::copy_rgb_affine()` and `Panel_Sprite::readRect()`.
- `readPixelValue(1, 0)` reports the same load in `bgr888_t::operator uint32_t()`.

ESP32 cross-compilation also turns the fallback into an aligned-width instruction (`l32i` on Xtensa and `lw` on RISC-V), rather than an unaligned-safe sequence.

## Fix

When a platform provides `pgm_read_dword_with_offset`, retain its existing optimized unaligned dword path. Otherwise, assemble the 24-bit value from exactly three `pgm_read_byte()` calls. This preserves platform PROGMEM access semantics and avoids reading through an incorrectly aligned wider pointer.

Platforms that already define their own `pgm_read_3byte_unaligned()` remain unchanged.

## Verification

- Built the repository's full SDL host source set with GCC 13.3, AddressSanitizer, and UndefinedBehaviorSanitizer.
- Before: both public read paths stop on the misaligned load at `buffer + 3`.
- After: both paths exit cleanly and preserve their previous values (`readPixel=0x428c`, `readPixelValue=0x605040`).
- Repeated the two sanitized behavior tests 100 times each.
- Cross-compiled the helper with `-Wall -Wextra -Werror` for ESP32/ESP32-S3 Xtensa, ESP32-C3-class RISC-V, and ESP8266.
- Confirmed ESP32 code generation uses byte loads after the change, while ESP8266 retains its existing offset-aware dword sequence.
- Compiled the header from both C11 and C++17 translation units with warnings as errors.