### PR TITLE
Fix arduino_default platform build (Teensy) and add Teensy CI

### DIFF
--- a/.github/workflows/PlatformioBuild.yml
+++ b/.github/workflows/PlatformioBuild.yml
@@ -63,6 +63,8 @@ jobs:
           - { board: seeed_wio_terminal, platform-version: default, ... }
           - { board: adafruit_pybadge_m4, platform-version: default, ... }
           - { board: pico, platform-version: default, ... }
+          - { board: teensy41, platform-version: default, ... }
+          - { board: teensy35, platform-version: default, ... }
           - { board: native, platform-version: portduino, ... }
 
       fail-fast: false

--- a/examples/Test/build_test/platformio.ini
+++ b/examples/Test/build_test/platformio.ini
@@ -9,6 +9,7 @@ extra_configs  = platformio_esp8266.ini
                  platformio_esp32.ini
                  platformio_atmelsam.ini
                  platformio_rpipico.ini
+                 platformio_teensy.ini
                  platformio_native.ini
 
 [env]

--- a/examples/Test/build_test/platformio_teensy.ini
+++ b/examples/Test/build_test/platformio_teensy.ini
@@ -1,0 +1,14 @@
+
+[teensy_default]
+platform = teensy
+framework = arduino
+build_flags       =
+  -DSKIP_I2C_TEST
+
+[env:teensy41-default]
+extends = teensy_default
+board = teensy41
+
+[env:teensy35-default]
+extends = teensy_default
+board = teensy35

--- a/src/lgfx/utility/lgfx_qoi.c
+++ b/src/lgfx/utility/lgfx_qoi.c
@@ -67,8 +67,6 @@ struct _qoi_t
   uint8_t read_buf[LGFX_QOI_READBUF_LEN];
 };
 
-#define QOI_DEBUG
-
 #ifdef QOI_DEBUG
 #define debug_printf(...) fprintf(stderr, __VA_ARGS__)
 #define QOI_ERROR(...) (fprintf(stderr, __VA_ARGS__), -2)

--- a/src/lgfx/v1/platforms/arduino_default/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_SPI.cpp
@@ -50,22 +50,23 @@ namespace lgfx
   {
     dc_h();
     pinMode(_cfg.pin_dc, pin_mode_t::output);
-    spi = new HardwareSPI(_cfg.spi_host);
+    spi = getSPIInstance(_cfg.spi_host);
     spi->begin();
     return true;
   }
 
   void Bus_SPI::release(void)
   {
+    if (spi == nullptr) { return; }
     spi->end();
+    spi = nullptr;
   }
 
 
   void Bus_SPI::beginTransaction(void)
   {
     dc_h();
-    //SPISettings setting(_cfg.freq_write, BitOrder::MSBFIRST, _cfg.spi_mode, true);
-    SPISettings setting(_cfg.freq_write, MSBFIRST, _cfg.spi_mode);
+    SPISettings setting(_cfg.freq_write, MSBFIRST, getSPIDataMode(_cfg.spi_mode));
     spi->beginTransaction(setting);
   }
 
@@ -78,8 +79,7 @@ namespace lgfx
   void Bus_SPI::beginRead(void)
   {
     spi->endTransaction();
-    //SPISettings setting(_cfg.freq_read, BitOrder::MSBFIRST, _cfg.spi_mode, false);
-    SPISettings setting(_cfg.freq_read, MSBFIRST, _cfg.spi_mode);
+    SPISettings setting(_cfg.freq_read, MSBFIRST, getSPIDataMode(_cfg.spi_mode));
     spi->beginTransaction(setting);
   }
 
@@ -162,7 +162,7 @@ namespace lgfx
   {
     if (dc) dc_h();
     else dc_l();
-    spi->transfer(const_cast<uint8_t*>(data), length);
+    spiWriteBytes(spi, data, length);
     if (!dc) dc_h();
   }
 

--- a/src/lgfx/v1/platforms/arduino_default/Bus_SPI.hpp
+++ b/src/lgfx/v1/platforms/arduino_default/Bus_SPI.hpp
@@ -87,7 +87,7 @@ namespace lgfx
       gpio_lo(_cfg.pin_dc);
     }
 
-    HardwareSPI *spi;
+    SPIClass* spi = nullptr;
     config_t _cfg;
     FlipBuffer _flip_buffer;
     bool _need_wait;

--- a/src/lgfx/v1/platforms/arduino_default/common.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.cpp
@@ -64,23 +64,45 @@ namespace lgfx
 
 //----------------------------------------------------------------------------
 
-  /// unimplemented.
   namespace spi
   {
-    HardwareSPI *spi;
-    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)  {
-      cpp::result<void, error_t> res = {};
-      spi = new HardwareSPI(spi_host);
-      spi->begin();
-      return res; }
-    void release(int spi_host) {}
-    void beginTransaction(int spi_host, uint32_t freq, int spi_mode) {
-      SPISettings setting(freq, MSBFIRST, SPI_MODE0);
-      spi->beginTransaction(setting);
+    /// ピン割り当ては Arduino の SPI ライブラリが持つ既定に従う。
+    static SPIClass* _spi_instance = nullptr;
+
+    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
+    {
+      _spi_instance = getSPIInstance(spi_host);
+      _spi_instance->begin();
+      return {};
     }
-    void endTransaction(int spi_host) {spi->endTransaction();}
-    void writeBytes(int spi_host, const uint8_t* data, size_t length) {}
-    void readBytes(int spi_host, uint8_t* data, size_t length) {spi->transfer(data, length);}  }
+    void release(int spi_host)
+    {
+      if (_spi_instance == nullptr) { return; }
+      _spi_instance->end();
+      _spi_instance = nullptr;
+    }
+    void beginTransaction(int spi_host, uint32_t freq, int spi_mode)
+    {
+      if (_spi_instance == nullptr) { return; }
+      SPISettings setting(freq, MSBFIRST, getSPIDataMode(spi_mode));
+      _spi_instance->beginTransaction(setting);
+    }
+    void endTransaction(int spi_host)
+    {
+      if (_spi_instance == nullptr) { return; }
+      _spi_instance->endTransaction();
+    }
+    void writeBytes(int spi_host, const uint8_t* data, size_t length)
+    {
+      if (_spi_instance == nullptr) { return; }
+      spiWriteBytes(_spi_instance, data, length);
+    }
+    void readBytes(int spi_host, uint8_t* data, size_t length)
+    {
+      if (_spi_instance == nullptr) { return; }
+      _spi_instance->transfer(data, length);
+    }
+  }
 
 //----------------------------------------------------------------------------
 

--- a/src/lgfx/v1/platforms/arduino_default/common.hpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.hpp
@@ -28,11 +28,61 @@ Contributors:
 #endif
 
 #include <Arduino.h>
+#include <SPI.h>
 
 namespace lgfx
 {
  inline namespace v1
  {
+//----------------------------------------------------------------------------
+
+  /// spi_host に対応する Arduino の SPIClass インスタンスを返す。
+  /// 複数の SPI を持たない環境では常に既定の SPI を返す。
+  __attribute__ ((unused))
+  static inline SPIClass* getSPIInstance(int spi_host)
+  {
+#if defined ( TEENSYDUINO )
+ #if defined (__MK64FX512__) || defined (__MK66FX1M0__) || defined (__IMXRT1062__)
+    if (spi_host == 1) { return &SPI1; }
+    if (spi_host == 2) { return &SPI2; }
+ #elif defined (__MKL26Z64__)
+    if (spi_host == 1) { return &SPI1; }
+ #endif
+#endif
+    (void)spi_host;
+    return &SPI;
+  }
+
+  /// SPI_MODE0~3 の実値は環境依存のため、spi_mode の生値を SPISettings に渡さず変換する。
+  __attribute__ ((unused))
+  static inline uint8_t getSPIDataMode(int spi_mode)
+  {
+    switch (spi_mode & 3)
+    {
+    default:
+    case 0: return SPI_MODE0;
+    case 1: return SPI_MODE1;
+    case 2: return SPI_MODE2;
+    case 3: return SPI_MODE3;
+    }
+  }
+
+  /// SPIClass::transfer(void*, size_t) は受信データでバッファを上書きするため、
+  /// 送信専用の転送は複製を経由して呼び出し元の入力を守る。
+  __attribute__ ((unused))
+  static inline void spiWriteBytes(SPIClass* spi, const uint8_t* data, size_t length)
+  {
+    uint8_t buf[64];
+    while (length)
+    {
+      size_t len = (length < sizeof(buf)) ? length : sizeof(buf);
+      memcpy(buf, data, len);
+      spi->transfer(buf, len);
+      data += len;
+      length -= len;
+    }
+  }
+
 //----------------------------------------------------------------------------
 
   __attribute__ ((unused))
@@ -133,45 +183,6 @@ namespace lgfx
 #endif
 
   };
-
-//----------------------------------------------------------------------------
-
-#if defined (ARDUINO) && defined (Stream_h)
-
-  struct StreamWrapper : public DataWrapper
-  {
-    void set(Stream* src, uint32_t length = ~0u) { _stream = src; _length = length; _index = 0; }
-
-    int read(uint8_t *buf, uint32_t len) override {
-      if (len > _length - _index) { len = _length - _index; }
-      _index += len;
-      return _stream->readBytes((char*)buf, len);
-    }
-    void skip(int32_t offset) override
-    {
-      if (0 >= offset) { return; }
-      _index += offset;
-      char dummy[64];
-      size_t len = ((offset - 1) & 63) + 1;
-      do
-      {
-        _stream->readBytes(dummy, len);
-        offset -= len;
-        len = 64;
-      } while (offset);
-    }
-    bool seek(uint32_t offset) override { if (offset < _index) { return false; } skip(offset - _index); return true; }
-    void close() override { }
-    int32_t tell(void) override { return _index; }
-
-  private:
-    Stream* _stream;
-    uint32_t _index;
-    uint32_t _length = 0;
-
-  };
-
-#endif
 
 //----------------------------------------------------------------------------
  }


### PR DESCRIPTION
## Summary

Make the generic Arduino fallback path (`platforms/arduino_default/`) actually buildable, using Teensy as the reference target. Until now this path could not compile anywhere, so it had quietly rotted:

- **Remove a stale `StreamWrapper` copy** from `arduino_default/common.hpp`. The canonical definition in `misc/DataWrapper.hpp` (which has the 3-arg `read()` and correct `_index` accounting) is enabled under the same condition, so the leftover copy always caused a redefinition error. Pure deletion — `DataWrapper.hpp` is untouched.
- **Replace the non-existent `HardwareSPI` with Arduino `SPIClass`**, with three small helpers:
  - `getSPIInstance()` maps `spi_host` to `SPI` / `SPI1` / `SPI2` (Teensy multi-bus support)
  - `getSPIDataMode()` converts raw `spi_mode` values to `SPI_MODEx` constants, whose actual values are environment-dependent
  - `spiWriteBytes()` protects the caller's input buffer from the destructive full-duplex `SPIClass::transfer(void*, size_t)`
- **Make `QOI_DEBUG` opt-in.** `lgfx_qoi.c` unconditionally defined it, so error paths always called `fprintf(stderr)`, pulling in newlib stdio and failing to link on cores without a `_write` syscall (e.g. Teensy 3.x). The png/jpg decoders reference no stdio; this aligns qoi with them. Define `QOI_DEBUG` externally to restore the debug output.
- **Add Teensy 4.1 / 3.5 to the PlatformIO CI matrix** as a build-only gate for this path (teensy41 covers gnu++17, teensy35 covers gnu++11). I2C is excluded via `SKIP_I2C_TEST`, same as rpipico — `Bus_I2C` does not exist on this platform and the `i2c` namespace remains the existing stub, so this is not a full Teensy support announcement.

## Scope

Build gate only: `LGFX_Sprite`, `Panel_Device`-derived panels and `Bus_SPI` become usable on Teensy. I2C-based features are out of scope for this PR.

## Checks

- `teensy41` / `teensy40` / `teensy36` / `teensy35` build SUCCESS (full library compile, firmware generated)
- ESP32 (arduino-esp32) regression build SUCCESS — all `arduino_default` translation units are empty on non-generic-Arduino platforms, so no behavior change there
- CI-equivalent local run of the new `teensy41-default` / `teensy35-default` envs (`pio pkg install --library file://` + `pio run`) SUCCESS
- `git diff --check`
