### PR TITLE
Fix -Wsign-compare warning in Touch_CST226::getTouchRaw

### DIFF
--- a/src/lgfx/v1/touch/Touch_CSTxxx.cpp
+++ b/src/lgfx/v1/touch/Touch_CSTxxx.cpp
@@ -315,7 +315,7 @@ namespace lgfx
         if( requested_count > 1 ) // an array of touch_point_t was provided
         {
           int pIdx = 0; // points index with corrected offset
-          for (int i=0; i<count; i++) {
+          for (uint_fast8_t i=0; i<count; i++) {
             tp[i].id = i;
             tp[i].size = readdata[pIdx+4]; // pressure
             tp[i].x = (uint16_t)((readdata[pIdx+1] << 4) | ((readdata[pIdx+3] >> 4) & 0xf));


### PR DESCRIPTION
## Summary

Fix a `-Wsign-compare` warning in `Touch_CST226::getTouchRaw()` reported from a Teensy build: the loop counter was `int` while `count` is `uint_fast8_t`.

On ARM cores `uint_fast8_t` is `unsigned int`, so the comparison is signed-vs-unsigned and warns. On xtensa/riscv it is `unsigned char`, which gets promoted to `int`, so ESP32 builds never surfaced this. Harmless at runtime (`count` is already range-checked against `max_touch_points`), but it pollutes user build logs on ARM targets. The loop counter now uses the same type as `count`.

## Checks

- teensy41 build: warning gone, SUCCESS
- ESP32 (arduino-esp32) regression build SUCCESS
- `git diff --check`
