### PR TITLE
Support the low power I2C port on the ESP32-C5 / C6 / P4

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -938,6 +938,83 @@ namespace lgfx
  #define I2C_ACK_ERR_INT_RAW_M I2C_NACK_INT_RAW_M
 #endif
 
+// From the ESP32-C6 on, some chips carry a low power I2C in addition to the normal ones,
+// and SOC_I2C_NUM counts both of them. SOC_HP_I2C_NUM / SOC_LP_I2C_NUM tell them apart,
+// but they only exist in recent ESP-IDF, so the chips with a single high power port have
+// to be named when they are missing.
+#if defined ( SOC_HP_I2C_NUM )
+ #define LGFX_HP_I2C_NUM SOC_HP_I2C_NUM
+#elif defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 )
+ #define LGFX_HP_I2C_NUM 1
+#else
+ #define LGFX_HP_I2C_NUM SOC_I2C_NUM
+#endif
+
+// ESP-IDF numbers the low power ports after all the high power ones, so the first low
+// power port index is the number of high power ports. ( see i2c_port_t in hal/i2c_types.h )
+#if defined ( SOC_LP_I2C_NUM ) && ( SOC_LP_I2C_NUM > 0 )
+ #define LGFX_LP_I2C_NUM SOC_LP_I2C_NUM
+ #define LGFX_LP_I2C_PORT LGFX_HP_I2C_NUM
+#else
+ #define LGFX_LP_I2C_NUM 0
+#endif
+
+    /// True if this port index belongs to the low power I2C.
+    static inline bool isLpPort(int i2c_port)
+    {
+#if LGFX_LP_I2C_NUM > 0
+      return i2c_port >= LGFX_LP_I2C_PORT;
+#else
+      (void)i2c_port;
+      return false;
+#endif
+    }
+
+    /// Hardware FIFO depth of this port. The low power I2C has a shallower FIFO than the
+    /// normal one, so this cannot be a single constant for the whole chip.
+    static inline uint32_t getFifoLen(int i2c_port)
+    {
+#if LGFX_LP_I2C_NUM > 0 && defined ( SOC_LP_I2C_FIFO_LEN )
+      if (isLpPort(i2c_port)) { return SOC_LP_I2C_FIFO_LEN; }
+#else
+      (void)i2c_port;
+#endif
+#if defined ( SOC_I2C_FIFO_LEN )
+      return SOC_I2C_FIFO_LEN;
+#else
+      return 32;
+#endif
+    }
+
+    /// Clock feeding the SCL divider of this port [Hz].
+    /// This is not a property of the chip alone: the low power I2C runs from its own
+    /// clock, and on the older chips the normal one follows the CPU frequency.
+    static inline uint32_t getSourceClock(int i2c_port)
+    {
+#if LGFX_LP_I2C_NUM > 0
+      if (isLpPort(i2c_port))
+      { // Both selectable sources of the low power I2C are 20MHz:
+        // LP_FAST ( RC fast, nominal 20MHz ) and XTAL_D2 ( 40MHz crystal divided by 2 ).
+        return 20 * 1000 * 1000;
+      }
+#else
+      (void)i2c_port;
+#endif
+
+#if defined (CONFIG_IDF_TARGET_ESP32C2) || defined (CONFIG_IDF_TARGET_ESP32C3) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32S3) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+      return 40 * 1000 * 1000; // XTAL clock
+#else
+      rtc_cpu_freq_config_t cpu_freq_conf;
+      rtc_clk_cpu_freq_get_config(&cpu_freq_conf);
+      if (cpu_freq_conf.freq_mhz < 80)
+      { // The source follows the CPU frequency here, so it has to be read every time
+        // rather than cached when the port is initialized.
+        return (cpu_freq_conf.source_freq_mhz * 1000000) / cpu_freq_conf.div;
+      }
+      return 80 * 1000 * 1000;
+#endif
+    }
+
 #if !defined ( I2C_CLOCK_SRC_ATOMIC )
   #if __cplusplus <= 201103L
     #define LGFX_PERIPH_MODULE_T periph_module_t
@@ -948,7 +1025,7 @@ namespace lgfx
     __attribute__ ((unused))
         static LGFX_PERIPH_MODULE_T getPeriphModule(int num)
     {
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       return PERIPH_I2C0_MODULE;
 #else
       return num == 0 ? PERIPH_I2C0_MODULE : PERIPH_I2C1_MODULE;
@@ -960,7 +1037,7 @@ namespace lgfx
 
     static i2c_dev_t* getDev(int num)
     {
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       return &I2C0;
 #else
       return num == 0 ? &I2C0 : &I2C1;
@@ -1144,7 +1221,7 @@ namespace lgfx
   #endif
  #endif
 
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
         auto twowire = &Wire;
 #else
         auto twowire = ((dev == &I2C0) ? &Wire : &Wire1);
@@ -1378,7 +1455,7 @@ namespace lgfx
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
   #if defined ARDUINO_ESP32_GIT_VER
     #if ARDUINO_ESP32_GIT_VER != 0x44c11981
-      #if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+      #if LGFX_HP_I2C_NUM == 1
         auto twowire = &Wire;
       #else
         auto twowire = ((i2c_port == 0) ? &Wire : &Wire1);
@@ -1437,7 +1514,7 @@ namespace lgfx
  #endif
  #if defined ( USE_TWOWIRE_SETPINS )
 
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       auto twowire = &Wire;
 #else
       auto twowire = ((i2c_port == 0) ? &Wire : &Wire1);
@@ -1477,7 +1554,7 @@ namespace lgfx
       i2c_stop(i2c_port);
 
 #if defined ( ARDUINO ) && __has_include (<Wire.h>)
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       auto twowire = &Wire;
 #else
       auto twowire = ((i2c_port == 0) ? &Wire : &Wire1);
@@ -1561,22 +1638,7 @@ namespace lgfx
       {
         i2c_context[i2c_port].freq = freq;
         static constexpr uint32_t MIN_I2C_CYCLE = 35;
-#if defined (CONFIG_IDF_TARGET_ESP32C2) || defined (CONFIG_IDF_TARGET_ESP32C3) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32S3) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
-        uint32_t src_clock = 40 * 1000 * 1000; // XTAL clock
-#else
-        rtc_cpu_freq_config_t cpu_freq_conf;
-        rtc_clk_cpu_freq_get_config(&cpu_freq_conf);
-        uint32_t src_clock = 80 * 1000 * 1000;
-        if (cpu_freq_conf.freq_mhz < 80)
-        {
-          src_clock = (cpu_freq_conf.source_freq_mhz * 1000000) / cpu_freq_conf.div;
-        }
-// ESP_LOGI("LGFX", "i2c::restart : port:%d / addr:%02x / freq:%d / rw:%d", i2c_port, i2c_addr, freq, read);
-// ESP_LOGI("LGFX", "cpu_freq_conf.div             :%d", cpu_freq_conf.div);
-// ESP_LOGI("LGFX", "cpu_freq_conf.freq_mhz        :%d", cpu_freq_conf.freq_mhz);
-// ESP_LOGI("LGFX", "cpu_freq_conf.source          :%d", cpu_freq_conf.source);
-// ESP_LOGI("LGFX", "cpu_freq_conf.source_freq_mhz :%d", cpu_freq_conf.source_freq_mhz);
-#endif
+        uint32_t src_clock = getSourceClock(i2c_port);
 
         auto cycle = std::min<uint32_t>(32767u, std::max(MIN_I2C_CYCLE, (src_clock / (freq + 1) + 1)));
         freq = src_clock / cycle;
@@ -1752,10 +1814,10 @@ namespace lgfx
       cpp::result<void, error_t> res {};
       if (!length) return res;
 
-      static constexpr int txfifo_limit = 32;
+      const uint32_t txfifo_limit = getFifoLen(i2c_port);
       auto dev = getDev(i2c_port);
       auto fifo_addr = getFifoAddr(i2c_port);
-      size_t len = ((length - 1) & (txfifo_limit-1)) + 1;
+      size_t len = ((length - 1) % txfifo_limit) + 1;
       do
       {
         res = i2c_wait(i2c_port);
@@ -1791,6 +1853,7 @@ namespace lgfx
       if (!length) return res;
 
       static constexpr uint32_t intmask = I2C_ACK_ERR_INT_RAW_M | I2C_TIME_OUT_INT_RAW_M | I2C_END_DETECT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M;
+      const uint32_t rxfifo_limit = getFifoLen(i2c_port);
       auto fifo_addr = getFifoAddr(i2c_port);
       auto dev = getDev(i2c_port);
 
@@ -1811,7 +1874,7 @@ namespace lgfx
           break;
         }
 
-        len = length < 32 ? length : 32;
+        len = length < rxfifo_limit ? length : rxfifo_limit;
 #if defined ( CONFIG_IDF_TARGET_ESP32 ) || !defined ( CONFIG_IDF_TARGET )
         // workaround for ESP32 i2c bug.
         if (last_nack && len == length && len > 1) { len -= 1; }

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -952,9 +952,20 @@ namespace lgfx
 
 // ESP-IDF numbers the low power ports after all the high power ones, so the first low
 // power port index is the number of high power ports. ( see i2c_port_t in hal/i2c_types.h )
-#if defined ( SOC_LP_I2C_NUM ) && ( SOC_LP_I2C_NUM > 0 )
+//
+// Bringing a low power port up is left to the ESP-IDF driver: there is no TwoWire for it,
+// and the pads reach the peripheral differently depending on the chip ( a fixed LP IO MUX
+// function on some, the LP GPIO matrix on others ). The driver already knows which, so it
+// is asked to open the bus and the registers are taken over afterwards, exactly as this
+// code does for the normal ports.
+#if defined ( SOC_LP_I2C_NUM ) && ( SOC_LP_I2C_NUM > 0 ) && __has_include ( <driver/i2c_master.h> ) \
+ && defined ( ESP_IDF_VERSION_VAL ) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
  #define LGFX_LP_I2C_NUM SOC_LP_I2C_NUM
  #define LGFX_LP_I2C_PORT LGFX_HP_I2C_NUM
+ // The default source is the RC oscillator, which drifts with temperature. XTAL_D2 is a
+ // divided crystal, so the SCL frequency comes out as asked.
+ #define LGFX_LP_I2C_SCLK LP_I2C_SCLK_XTAL_D2
+ #include <esp_clk_tree.h>
 #else
  #define LGFX_LP_I2C_NUM 0
 #endif
@@ -993,8 +1004,15 @@ namespace lgfx
     {
 #if LGFX_LP_I2C_NUM > 0
       if (isLpPort(i2c_port))
-      { // Both selectable sources of the low power I2C are 20MHz:
-        // LP_FAST ( RC fast, nominal 20MHz ) and XTAL_D2 ( 40MHz crystal divided by 2 ).
+      { // Ask the clock tree rather than assuming a figure: which source the low power
+        // port runs from is a choice made when the bus is opened, and the two are not
+        // the same clock even where they happen to share a nominal frequency.
+        uint32_t hz = 0;
+        if (ESP_OK == esp_clk_tree_src_get_freq_hz((soc_module_clk_t)LGFX_LP_I2C_SCLK
+                    , ESP_CLK_TREE_SRC_FREQ_PRECISION_APPROX, &hz) && hz)
+        {
+          return hz;
+        }
         return 20 * 1000 * 1000;
       }
 #else
@@ -1037,6 +1055,12 @@ namespace lgfx
 
     static i2c_dev_t* getDev(int num)
     {
+#if LGFX_LP_I2C_NUM > 0
+      // The register layout of the low power I2C matches the normal one, which is why
+      // ESP-IDF publishes it as an i2c_dev_t as well. Everything below the port lookup
+      // therefore works on it unchanged.
+      if (isLpPort(num)) { return &LP_I2C; }
+#endif
 #if LGFX_HP_I2C_NUM == 1
       return &I2C0;
 #else
@@ -1235,8 +1259,10 @@ namespace lgfx
 #endif
       }
 
-#if defined ( ARDUINO ) && __has_include (<Wire.h>)
-#elif __has_include(<driver/i2c_master.h>)
+// A low power port is opened through the ESP-IDF driver even in an Arduino build, where
+// the normal ports go through TwoWire, so the handle is needed in both cases.
+#if __has_include(<driver/i2c_master.h>) \
+ && ( LGFX_LP_I2C_NUM > 0 || !( defined ( ARDUINO ) && __has_include (<Wire.h>) ) )
       i2c_master_bus_handle_t i2c_bus_handle = nullptr;
 #endif
     private:
@@ -1244,8 +1270,32 @@ namespace lgfx
     };
     i2c_context_t i2c_context[I2C_NUM_MAX];
 
+#if LGFX_LP_I2C_NUM > 0 && SOC_RTCIO_PIN_COUNT > 0
+    /// Hand a pin back from the low power IO domain.
+    /// A pin routed to the low power I2C keeps that routing across a reset, because it is
+    /// held in the low power domain rather than by the CPU. Any later attempt to drive it
+    /// from a normal port then finds a pad that no longer reaches the peripheral, and the
+    /// bus looks dead for reasons nothing in the running program explains. Releasing it
+    /// here makes taking a pin over idempotent, whether or not the previous user shut
+    /// down in an orderly way.
+    static void releaseLpPad(gpio_num_t pin)
+    {
+      if ((int)pin >= 0 && rtc_gpio_is_valid_gpio(pin))
+      {
+        rtc_gpio_deinit(pin);
+      }
+    }
+#endif
+
     static void set_pin(i2c_port_t i2c_num, gpio_num_t pin_sda, gpio_num_t pin_scl)
     {
+#if LGFX_LP_I2C_NUM > 0 && SOC_RTCIO_PIN_COUNT > 0
+      // Callers keep the low power ports away from here, so reaching this point means the
+      // pins are wanted for a normal port and any low power routing left on them, possibly
+      // by a previous run, has to go. ( see releaseLpPad )
+      releaseLpPad(pin_sda);
+      releaseLpPad(pin_scl);
+#endif
 #if __has_include(<driver/i2c_master.h>)
       if ((int8_t)pin_sda >= 0) {
         gpio_set_level(pin_sda, true);
@@ -1451,6 +1501,25 @@ namespace lgfx
       if (i2c_context[i2c_port].initialized)
       {
         i2c_context[i2c_port].initialized = false;
+#if LGFX_LP_I2C_NUM > 0
+        if (isLpPort(i2c_port))
+        { // Opened through the ESP-IDF driver in init(), so it is closed the same way.
+          auto bus_handle = i2c_context[i2c_port].i2c_bus_handle;
+          if (bus_handle) {
+            i2c_context[i2c_port].i2c_bus_handle = nullptr;
+            i2c_del_master_bus(bus_handle);
+          }
+ #if SOC_RTCIO_PIN_COUNT > 0
+          // The pins have to be handed back explicitly: their routing lives in the low
+          // power domain and would otherwise outlive this program, leaving them unusable
+          // from a normal port even after a reset. ( see releaseLpPad )
+          releaseLpPad(i2c_context[i2c_port].pin_sda);
+          releaseLpPad(i2c_context[i2c_port].pin_scl);
+ #endif
+        }
+        else
+#endif
+        {
 #if defined ( ARDUINO ) && __has_include (<Wire.h>) && defined ( ESP_IDF_VERSION_VAL )
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
   #if defined ARDUINO_ESP32_GIT_VER
@@ -1473,6 +1542,7 @@ namespace lgfx
 #else
         i2c_periph_disable(i2c_port);
 #endif
+        }
         if ((int)i2c_context[i2c_port].pin_scl >= 0)
         {
           pinMode(i2c_context[i2c_port].pin_scl, pin_mode_t::input_pullup);
@@ -1506,6 +1576,11 @@ namespace lgfx
       release(i2c_port).has_value();
       i2c_context[i2c_port].pin_scl = (gpio_num_t)pin_scl;
       i2c_context[i2c_port].pin_sda = (gpio_num_t)pin_sda;
+#if LGFX_LP_I2C_NUM > 0
+      // The TwoWire instances belong to the normal ports; a low power port has none,
+      // and handing these pins to one would redirect that port to them.
+      if (isLpPort(i2c_port)) { return {}; }
+#endif
 #if defined ( ARDUINO ) && __has_include (<Wire.h>)
  #if defined ( ESP_IDF_VERSION_VAL )
   #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(3, 3, 0)
@@ -1552,6 +1627,35 @@ namespace lgfx
       }
 
       i2c_stop(i2c_port);
+
+#if LGFX_LP_I2C_NUM > 0
+      if (isLpPort(i2c_port))
+      {
+        i2c_master_bus_config_t bus_config;
+        memset(&bus_config, 0, sizeof(i2c_master_bus_config_t));
+        bus_config.i2c_port = i2c_port;
+        bus_config.sda_io_num = pin_sda;
+        bus_config.scl_io_num = pin_scl;
+        bus_config.lp_source_clk = LGFX_LP_I2C_SCLK;
+        bus_config.glitch_ignore_cnt = 7;
+        bus_config.flags.enable_internal_pullup = true;
+        bus_config.intr_priority = 1;
+
+        i2c_master_bus_handle_t bus_handle = nullptr;
+        if (ESP_OK != i2c_new_master_bus(&bus_config, &bus_handle))
+        { // The pins of the low power port are constrained: they have to be LP IO, and on
+          // the chips without an LP GPIO matrix they are a fixed pair.
+          return cpp::fail(error_t::invalid_arg);
+        }
+        i2c_context[i2c_port].i2c_bus_handle = bus_handle;
+        i2c_context[i2c_port].initialized = true;
+
+        // The pads are already routed to the peripheral by the call above, and they do not
+        // go through the normal GPIO matrix that set_pin() drives, so it is not called.
+        i2c_context[i2c_port].save_reg(getDev(i2c_port));
+        return {};
+      }
+#endif
 
 #if defined ( ARDUINO ) && __has_include (<Wire.h>)
 #if LGFX_HP_I2C_NUM == 1
@@ -1757,7 +1861,15 @@ namespace lgfx
       }
       i2c_context[i2c_port].save_reg(dev);
 
-      set_pin((i2c_port_t)i2c_port, i2c_context[i2c_port].pin_sda, i2c_context[i2c_port].pin_scl);
+#if LGFX_LP_I2C_NUM > 0
+      // A low power port reaches its pads through the low power IO domain, which set_pin()
+      // knows nothing about: routing them through the normal GPIO matrix here would
+      // disconnect the port from its own pins on every transaction.
+      if (!isLpPort(i2c_port))
+#endif
+      {
+        set_pin((i2c_port_t)i2c_port, i2c_context[i2c_port].pin_sda, i2c_context[i2c_port].pin_scl);
+      }
 
 #if SOC_I2C_SUPPORT_HW_FSM_RST
       dev->ctr.fsm_rst = 1;
@@ -1778,8 +1890,16 @@ namespace lgfx
       ctrl_reg.val = 0;
       ctrl_reg.ms_mode = 1;       // master mode
       ctrl_reg.clk_en = 1;
-      ctrl_reg.sda_force_out = 1;
-      ctrl_reg.scl_force_out = 1;
+#if LGFX_LP_I2C_NUM > 0
+      // The low power controller reaches the bus only through its internal open drain
+      // mode ( sda_force_out = 0 ): with the outputs forced, the state machine runs to
+      // completion without ever driving the lines, so no device can respond.
+      if (!isLpPort(i2c_port))
+#endif
+      {
+        ctrl_reg.sda_force_out = 1;
+        ctrl_reg.scl_force_out = 1;
+      }
       dev->ctr.val = ctrl_reg.val;
 // ---------- i2c_ll_master_init
       typeof(dev->fifo_conf) fifo_conf_reg;


### PR DESCRIPTION
## Overview

The ESP32-C5 / C6 / P4 carry a low power I2C controller in addition to the normal ports. This PR makes it usable through the existing `lgfx::i2c` API: the port is addressed by number, following the ESP-IDF convention of numbering it right after the normal ports (port 1 on C5 / C6, port 2 on P4).

```cpp
lgfx::i2c::init(1, 2, 3);   // ESP32-C5: low power port, SDA=GPIO2 / SCL=GPIO3 (fixed pair)
```

## What the two commits do

**Derive the per port I2C properties instead of hard coding them**
Groundwork: the FIFO depth, the number of normal ports and the source clock come from helpers / soc capability macros instead of literals scattered through the code. This also fixes the TX FIFO limit on the ESP32-C2, whose FIFO is 16 bytes, not 32.

**Support the low power I2C port on the chips that have one**
The low power controller shares its register layout with the normal ports, so the existing transaction code drives it as-is. Everything around the registers differs:

- Bring-up is delegated to the ESP-IDF master bus driver, which knows how to route the low power pads (fixed IOMUX pair on C5 / C6, LP GPIO matrix on P4) and their clock source.
- The pads live in the low power IO domain and keep their routing across a reset, so `release()` hands them back explicitly and `set_pin()` clears a leftover routing before taking a pin for a normal port.
- `set_pin()` is skipped for a low power port; it would re-route the pins through the normal GPIO matrix and disconnect the port from its own pads.
- The controller reaches the bus only through its internal open drain mode, so the forced outputs used by the normal ports are left off.
- The TwoWire pin propagation in `setPins()` applies only to the normal ports.

## Compatibility

- The low power path compiles only when the chip has the port (`SOC_LP_I2C_NUM`), the ESP-IDF master bus driver is available, and ESP-IDF is 5.4 or later. Older environments build the unchanged code paths.
- Behavior of the normal ports is unchanged on every chip.

## Verification

Verified on hardware for all three chips. On each, a scan on the low power port finds the same devices as a normal port wired to the same physical bus, and register reads return real data:

- ESP32-C5 (fixed pads SDA=GPIO2 / SCL=GPIO3): 4 devices, identical to the normal port reference
- ESP32-C6 (fixed pads SDA=GPIO6 / SCL=GPIO7): external SSD1315 at 0x3C, register read OK
- ESP32-P4 (LP GPIO matrix, tested on GPIO6 / GPIO7): external SSD1315 at 0x3C, register read OK
- Requesting the low power port with pins that do not match the fixed pair fails cleanly at `init()` (rejected by the bus driver)


