### PR TITLE
Reach the I2C / SPI buses through plain GPIO with a negative port number

### DIFF
--- a/src/lgfx/v1/platforms/arduino_default/common.cpp
+++ b/src/lgfx/v1/platforms/arduino_default/common.cpp
@@ -66,39 +66,53 @@ namespace lgfx
 
   namespace spi
   {
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
     /// ピン割り当ては Arduino の SPI ライブラリが持つ既定に従う。
     static SPIClass* _spi_instance = nullptr;
 
     cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
     {
+      if (spi_host < 0) { return soft_spi_init(spi_host, spi_sclk, spi_miso, spi_mosi); }
       _spi_instance = getSPIInstance(spi_host);
       _spi_instance->begin();
       return {};
     }
     void release(int spi_host)
     {
+      if (spi_host < 0) { soft_spi_release(spi_host); return; }
       if (_spi_instance == nullptr) { return; }
       _spi_instance->end();
       _spi_instance = nullptr;
     }
     void beginTransaction(int spi_host, uint32_t freq, int spi_mode)
     {
+      if (spi_host < 0) { soft_spi_beginTransaction(spi_host, freq, spi_mode); return; }
       if (_spi_instance == nullptr) { return; }
       SPISettings setting(freq, MSBFIRST, getSPIDataMode(spi_mode));
       _spi_instance->beginTransaction(setting);
     }
     void endTransaction(int spi_host)
     {
+      if (spi_host < 0) { return; }  // a software host holds nothing to release
       if (_spi_instance == nullptr) { return; }
       _spi_instance->endTransaction();
     }
     void writeBytes(int spi_host, const uint8_t* data, size_t length)
     {
+      if (spi_host < 0) { soft_spi_writeBytes(spi_host, data, length); return; }
       if (_spi_instance == nullptr) { return; }
       spiWriteBytes(_spi_instance, data, length);
     }
     void readBytes(int spi_host, uint8_t* data, size_t length)
     {
+      if (spi_host < 0) { soft_spi_readBytes(spi_host, data, length); return; }
       if (_spi_instance == nullptr) { return; }
       _spi_instance->transfer(data, length);
     }
@@ -109,27 +123,24 @@ namespace lgfx
 
   namespace i2c
   {
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
 #ifdef TwoWire_h
-    cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl) { Wire.begin(); return {};}
-    cpp::result<void, error_t> release(int i2c_port) { Wire.end(); return {};}
-    cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read) {  Wire.endTransmission(true); Wire.beginTransmission(i2c_addr); return {};}
-    cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read) { Wire.beginTransmission(i2c_addr); return {};}
-    cpp::result<void, error_t> endTransaction(int i2c_port) { Wire.endTransmission(true); return {};}
-    cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length) { Wire.write(data, length); return {};}
-    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length)
-      {
-        Wire.readBytes((char *)data, (size_t)length);
-        /*
-        printf("0x");
-        for (int i=0; i< length; i++) {
-          printf("%02x ", data[i]);
-        }
-        printf("\n");
-        */
-        return {};
-      }
+    cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl) { if (i2c_port < 0) { auto res = soft_i2c_setPins(i2c_port, pin_sda, pin_scl); return res.has_error() ? res : soft_i2c_init(i2c_port); } Wire.begin(); return {};}
+    cpp::result<void, error_t> release(int i2c_port) { if (i2c_port < 0) { return soft_i2c_release(i2c_port); } Wire.end(); return {};}
+    cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read) { if (i2c_port < 0) { return soft_i2c_restart(i2c_port, i2c_addr, freq, read); } Wire.endTransmission(true); Wire.beginTransmission(i2c_addr); return {};}
+    cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read) { if (i2c_port < 0) { return soft_i2c_beginTransaction(i2c_port, i2c_addr, freq, read); } Wire.beginTransmission(i2c_addr); return {};}
+    cpp::result<void, error_t> endTransaction(int i2c_port) { if (i2c_port < 0) { return soft_i2c_endTransaction(i2c_port); } Wire.endTransmission(true); return {};}
+    cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length) { if (i2c_port < 0) { return soft_i2c_writeBytes(i2c_port, data, length); } Wire.write(data, length); return {};}
     cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack)
     {
+      if (i2c_port < 0) { return soft_i2c_readBytes(i2c_port, data, length, last_nack); }
       Wire.readBytes((char *)data, (size_t)length);
       /*
       printf("0x");
@@ -152,7 +163,7 @@ namespace lgfx
 
     cpp::result<void, error_t> transactionRead(int i2c_port, int addr, uint8_t *readdata, uint8_t readlen, uint32_t freq)  {
       cpp::result<void, error_t> res;
-      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = readBytes(i2c_port, readdata, readlen)).has_value())
+      if ((res = beginTransaction(i2c_port, addr, freq, true)).has_value() && (res = readBytes(i2c_port, readdata, readlen, true)).has_value())
       {
         res = endTransaction(i2c_port);
       }
@@ -162,7 +173,7 @@ namespace lgfx
     cpp::result<void, error_t> transactionWriteRead(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint8_t *readdata, size_t readlen, uint32_t freq)  {
       cpp::result<void, error_t> res;
       if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = writeBytes(i2c_port, writedata, writelen)).has_value() &&
-      (res = restart(i2c_port, addr, freq, false)).has_value() && (res = readBytes(i2c_port, readdata, readlen)).has_value())
+      (res = restart(i2c_port, addr, freq, true)).has_value() && (res = readBytes(i2c_port, readdata, readlen, true)).has_value())
       {
         res = endTransaction(i2c_port);
       }
@@ -193,23 +204,73 @@ namespace lgfx
      }
 
      #else
-    cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> release(int i2c_port) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> endTransaction(int i2c_port) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack) { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl) { if (i2c_port < 0) { auto res = soft_i2c_setPins(i2c_port, pin_sda, pin_scl); return res.has_error() ? res : soft_i2c_init(i2c_port); } return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> release(int i2c_port) { if (i2c_port < 0) { return soft_i2c_release(i2c_port); } return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read) { if (i2c_port < 0) { return soft_i2c_restart(i2c_port, i2c_addr, freq, read); } return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read) { if (i2c_port < 0) { return soft_i2c_beginTransaction(i2c_port, i2c_addr, freq, read); } return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> endTransaction(int i2c_port) { if (i2c_port < 0) { return soft_i2c_endTransaction(i2c_port); } return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length) { if (i2c_port < 0) { return soft_i2c_writeBytes(i2c_port, data, length); } return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack) { if (i2c_port < 0) { return soft_i2c_readBytes(i2c_port, data, length, last_nack); } return cpp::fail(error_t::unknown_err); }
 
 //--------
+// The negative (software) ports reach these through the primitives above, the
+// same way a hardware port does; a fail from beginTransaction on a hardware
+// port keeps the external behavior unchanged.
 
-    cpp::result<void, error_t> transactionWrite(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> transactionRead(int i2c_port, int addr, uint8_t *readdata, uint8_t readlen, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> transactionWriteRead(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint8_t *readdata, size_t readlen, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> transactionWrite(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint32_t freq)
+    {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value())
+      {
+        res = writeBytes(i2c_port, writedata, writelen);
+      }
+      auto last = endTransaction(i2c_port);
+      return res.has_error() ? res : last;
+    }
 
-    cpp::result<uint8_t, error_t> readRegister8(int i2c_port, int addr, uint8_t reg, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> writeRegister8(int i2c_port, int addr, uint8_t reg, uint8_t data, uint8_t mask, uint32_t freq)  { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> transactionRead(int i2c_port, int addr, uint8_t *readdata, uint8_t readlen, uint32_t freq)
+    {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, true)).has_value())
+      {
+        res = readBytes(i2c_port, readdata, readlen, true);
+      }
+      auto last = endTransaction(i2c_port);
+      return res.has_error() ? res : last;
+    }
+
+    cpp::result<void, error_t> transactionWriteRead(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint8_t *readdata, size_t readlen, uint32_t freq)
+    {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value()
+       && (res = writeBytes(i2c_port, writedata, writelen)).has_value()
+       && (res = restart(i2c_port, addr, freq, true)).has_value()
+      )
+      {
+        res = readBytes(i2c_port, readdata, readlen, true);
+      }
+      auto last = endTransaction(i2c_port);
+      return res.has_error() ? res : last;
+    }
+
+    cpp::result<uint8_t, error_t> readRegister8(int i2c_port, int addr, uint8_t reg, uint32_t freq)
+    {
+      auto res = transactionWriteRead(i2c_port, addr, &reg, 1, &reg, 1, freq);
+      if (res.has_value()) { return reg; }
+      return cpp::fail( res.error() );
+    }
+
+    cpp::result<void, error_t> writeRegister8(int i2c_port, int addr, uint8_t reg, uint8_t data, uint8_t mask, uint32_t freq)
+    {
+      uint8_t tmp[2] = { reg, data };
+      if (mask)
+      {
+        auto res = transactionWriteRead(i2c_port, addr, &reg, 1, &tmp[1], 1, freq);
+        if (res.has_error()) { return res; }
+        tmp[1] = (tmp[1] & mask) | data;
+      }
+      return transactionWrite(i2c_port, addr, tmp, 2, freq);
+    }
 #endif
   }
 

--- a/src/lgfx/v1/platforms/esp32/Bus_I2C.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_I2C.cpp
@@ -119,6 +119,7 @@ namespace lgfx
 
   void Bus_I2C::wait(void)
   {
+    if (_cfg.i2c_port < 0) { return; } // a software port transfers synchronously
 #if I2C_NUM_MAX > 1
     auto dev = (_cfg.i2c_port == 0) ? &I2C0 : &I2C1;
 #else
@@ -130,6 +131,7 @@ namespace lgfx
 
   bool Bus_I2C::busy(void) const
   {
+    if (_cfg.i2c_port < 0) { return false; } // a software port transfers synchronously
 #if I2C_NUM_MAX > 1
     auto dev = (_cfg.i2c_port == 0) ? &I2C0 : &I2C1;
 #else

--- a/src/lgfx/v1/platforms/esp32/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_I2C.hpp
@@ -35,7 +35,7 @@ namespace lgfx
       uint32_t freq_read = 400000;
       int16_t pin_scl = 22;
       int16_t pin_sda = 21;
-      uint8_t i2c_port = 0;      // e.g. ESP32 0=I2C_NUM_0 / 1=I2C_NUM_1
+      int8_t i2c_port = 0;       // e.g. ESP32 0=I2C_NUM_0 / 1=I2C_NUM_1 / negative=software
       uint8_t i2c_addr = 0x3C;
       uint32_t prefix_cmd = 0x00;
       uint32_t prefix_data = 0x40;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -630,6 +630,14 @@ namespace lgfx
 #endif
     static spi_device_handle_t _spi_dev_handle[spi_periph_num] = {nullptr};
 
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
     cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
     {
       return init(spi_host, spi_sclk, spi_miso, spi_mosi, 0); // SPI_DMA_CH_AUTO;
@@ -638,6 +646,11 @@ namespace lgfx
     cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi, int dma_channel)
     {
 //ESP_LOGI("LGFX","spi::init host:%d, sclk:%d, miso:%d, mosi:%d, dma:%d", spi_host, spi_sclk, spi_miso, spi_mosi, dma_channel);
+      if (spi_host < 0)
+      {
+        return soft_spi_init(spi_host, spi_sclk, spi_miso, spi_mosi);
+      }
+
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
 
@@ -725,6 +738,7 @@ namespace lgfx
     cpp::result<void, error_t> initQuad(int spi_host, int spi_sclk, int spi_io0, int spi_io1, int spi_io2, int spi_io3, int dma_channel)
     {
       //ESP_LOGI("LGFX","spi::init host:%d, sclk:%d, miso:%d, mosi:%d, dma:%d", spi_host, spi_sclk, spi_miso, spi_mosi, dma_channel);
+      if (spi_host < 0) { return cpp::fail(error_t::invalid_arg); }  // the software hosts are single bit only
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
 
@@ -800,6 +814,11 @@ namespace lgfx
     void release(int spi_host)
     {
 //ESP_LOGI("LGFX","spi::release");
+      if (spi_host < 0)
+      {
+        soft_spi_release(spi_host);
+        return;
+      }
 #if defined (ARDUINO) && __has_include (<SPI.h>) // Arduino ESP32
       if (_spi_handle[spi_host] != nullptr)
       {
@@ -824,6 +843,11 @@ namespace lgfx
 
     void beginTransaction(int spi_host)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_beginTransaction(spi_host);
+        return;
+      }
 #if defined (ARDUINO) // Arduino ESP32
       spiSimpleTransaction(_spi_handle[spi_host]);
 #else // ESP-IDF
@@ -840,6 +864,11 @@ namespace lgfx
 
     void beginTransaction(int spi_host, uint32_t freq, int spi_mode)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_beginTransaction(spi_host, freq, spi_mode);
+        return;
+      }
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
       uint32_t clkdiv = FreqToClockDiv(getApbFrequency(), freq);
@@ -885,6 +914,7 @@ namespace lgfx
 
     void endTransaction(int spi_host)
     {
+      if (spi_host < 0) { return; }  // a software host holds nothing to release
       if (_spi_dev_handle[spi_host]) {
 #if defined (ARDUINO) // Arduino ESP32
         spiEndTransaction(_spi_handle[spi_host]);
@@ -902,6 +932,11 @@ namespace lgfx
 
     void writeBytes(int spi_host, const uint8_t* data, size_t len)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_writeBytes(spi_host, data, len);
+        return;
+      }
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
       if (len > 64) len = 64;
@@ -913,6 +948,11 @@ namespace lgfx
 
     void readBytes(int spi_host, uint8_t* data, size_t len)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_readBytes(spi_host, data, len);
+        return;
+      }
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
       if (len > 64) len = 64;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -1270,6 +1270,27 @@ namespace lgfx
     };
     i2c_context_t i2c_context[I2C_NUM_MAX];
 
+    static inline bool isSoftPort(int i2c_port) { return i2c_port < 0; }
+
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+// pinMode() here puts a pin in open drain output with the latch high and the
+// input stage enabled, so a line is driven and released by toggling the latch
+// alone; the direction changing default of the fragment is not needed.
+
+#define SOFT_I2C_LINE_LO(pin) gpio_lo(pin)
+#define SOFT_I2C_LINE_HI(pin) gpio_hi(pin)
+#define SOFT_I2C_LOCK(ctx) do { \
+    if ((ctx).lock_handle == nullptr) { (ctx).lock_handle = xSemaphoreCreateMutex(); } \
+    xSemaphoreTake((SemaphoreHandle_t)(ctx).lock_handle, portMAX_DELAY); \
+  } while (0)
+#define SOFT_I2C_UNLOCK(ctx) xSemaphoreGive((SemaphoreHandle_t)(ctx).lock_handle)
+#define SOFT_I2C_YIELD() taskYIELD()
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
 #if LGFX_LP_I2C_NUM > 0 && SOC_RTCIO_PIN_COUNT > 0
     /// Hand a pin back from the low power IO domain.
     /// A pin routed to the low power I2C keeps that routing across a reset, because it is
@@ -1497,6 +1518,7 @@ namespace lgfx
 
     cpp::result<void, error_t> release(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_release(i2c_port); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_context[i2c_port].initialized)
       {
@@ -1558,12 +1580,13 @@ namespace lgfx
 
     cpp::result<void, error_t> setPins(int i2c_port, int pin_sda, int pin_scl)
     {
-      if ((i2c_port >= I2C_NUM_MAX)
-       || ((uint32_t)pin_scl >= GPIO_NUM_MAX)
+      if (((uint32_t)pin_scl >= GPIO_NUM_MAX)
        || ((uint32_t)pin_sda >= GPIO_NUM_MAX))
       {
         return cpp::fail(error_t::invalid_arg);
       }
+      if (isSoftPort(i2c_port)) { return soft_i2c_setPins(i2c_port, pin_sda, pin_scl); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
 
       if (i2c_context[i2c_port].initialized
        && i2c_context[i2c_port].pin_scl == (gpio_num_t)pin_scl
@@ -1602,20 +1625,25 @@ namespace lgfx
 
     cpp::result<int, error_t> getPinSDA(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_getPinSDA(i2c_port); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       return i2c_context[i2c_port].pin_sda;
     }
 
     cpp::result<int, error_t> getPinSCL(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_getPinSCL(i2c_port); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       return i2c_context[i2c_port].pin_scl;
     }
 
     cpp::result<void, error_t> init(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_init(i2c_port); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       gpio_num_t pin_sda = i2c_context[i2c_port].pin_sda;
       gpio_num_t pin_scl = i2c_context[i2c_port].pin_scl;
-      if ((i2c_port >= I2C_NUM_MAX)
-       || ((uint32_t)pin_scl >= GPIO_NUM_MAX)
+      if (((uint32_t)pin_scl >= GPIO_NUM_MAX)
        || ((uint32_t)pin_sda >= GPIO_NUM_MAX))
       {
         return cpp::fail(error_t::invalid_arg);
@@ -1706,6 +1734,7 @@ namespace lgfx
 
     cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_restart(i2c_port, i2c_addr, freq, read); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_addr < I2C_7BIT_ADDR_MIN || i2c_addr > I2C_10BIT_ADDR_MAX) return cpp::fail(error_t::invalid_arg);
 
@@ -1832,8 +1861,8 @@ namespace lgfx
 
     cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_beginTransaction(i2c_port, i2c_addr, freq, read); }
       if (i2c_port >= I2C_NUM_MAX) return cpp::fail(error_t::invalid_arg);
-
       if ((uint32_t)i2c_context[i2c_port].pin_sda >= GPIO_NUM_MAX || (uint32_t)i2c_context[i2c_port].pin_scl >= GPIO_NUM_MAX) return cpp::fail(error_t::invalid_arg);
 
 //ESP_LOGI("LGFX", "i2c::beginTransaction : port:%d / addr:%02x / freq:%d / rw:%d", i2c_port, i2c_addr, freq, read);
@@ -1922,12 +1951,14 @@ namespace lgfx
 
     cpp::result<void, error_t> endTransaction(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_endTransaction(i2c_port); }
       if (i2c_port >= I2C_NUM_MAX) return cpp::fail(error_t::invalid_arg);
       return i2c_wait(i2c_port, true);
     }
 //*/
     cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_writeBytes(i2c_port, data, length); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_context[i2c_port].state.has_error()) { return cpp::fail(i2c_context[i2c_port].state.error()); }
       if (i2c_context[i2c_port].state != i2c_context_t::state_write) { return cpp::fail(error_t::mode_mismatch); }
@@ -1964,8 +1995,9 @@ namespace lgfx
       return res;
     }
 
-    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *readdata, size_t length, bool last_nack = false)
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *readdata, size_t length, bool last_nack)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_readBytes(i2c_port, readdata, length, last_nack); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_context[i2c_port].state.has_error()) { return cpp::fail(i2c_context[i2c_port].state.error()); }
       if (i2c_context[i2c_port].state != i2c_context_t::state_read) { return cpp::fail(error_t::mode_mismatch); }

--- a/src/lgfx/v1/platforms/esp8266/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/esp8266/Bus_I2C.hpp
@@ -35,7 +35,7 @@ namespace lgfx
       uint32_t freq_read = 400000;
       int16_t pin_scl = 22;
       int16_t pin_sda = 21;
-      uint8_t i2c_port = 0;
+      int8_t i2c_port = 0;
       uint8_t i2c_addr = 0x3C;
       uint32_t prefix_cmd = 0x00;
       uint32_t prefix_data = 0x40;

--- a/src/lgfx/v1/platforms/esp8266/common.cpp
+++ b/src/lgfx/v1/platforms/esp8266/common.cpp
@@ -118,8 +118,17 @@ namespace lgfx
   /// unimplemented.
   namespace spi
   {
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
     cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
     {
+      if (spi_host < 0) { return soft_spi_init(spi_host, spi_sclk, spi_miso, spi_mosi); }
 #if defined ( ARDUINO )
       SPI.pins(spi_sclk, spi_miso, spi_mosi, -1);
       SPI.begin();
@@ -147,12 +156,14 @@ namespace lgfx
     }
     void release(int spi_host)
     {
+      if (spi_host < 0) { soft_spi_release(spi_host); return; }
 #if defined ( ARDUINO )
       SPI.end();
 #endif
     }
     void beginTransaction(int spi_host, uint32_t freq, int spi_mode)
     {
+      if (spi_host < 0) { soft_spi_beginTransaction(spi_host, freq, spi_mode); return; }
 #if defined ( ARDUINO )
       SPI.setFrequency(freq);
       SPI.setBitOrder(MSBFIRST);
@@ -162,10 +173,12 @@ namespace lgfx
     }
     void beginTransaction(int spi_host)
     {
+      if (spi_host < 0) { soft_spi_beginTransaction(spi_host); return; }
       SPI1U &= ~(SPIUMISO | SPIUDUPLEX);
     }
     void endTransaction(int spi_host)
     {
+      if (spi_host < 0) { return; }  // a software host holds nothing to release
       while (SPI1CMD & SPIBUSY);
 #if defined ( ARDUINO )
       SPI.endTransaction();
@@ -174,6 +187,7 @@ namespace lgfx
     }
     void writeBytes(int spi_host, const uint8_t* data, size_t length)
     {
+      if (spi_host < 0) { soft_spi_writeBytes(spi_host, data, length); return; }
       const uint32_t u1 = ((length << 3) - 1) << SPILMOSI;
       while (SPI1CMD & SPIBUSY);
       SPI1U1 = u1;
@@ -182,6 +196,7 @@ namespace lgfx
     }
     void readBytes(int spi_host, uint8_t* data, size_t length)
     {
+      if (spi_host < 0) { soft_spi_readBytes(spi_host, data, length); return; }
       const uint32_t u1 = ((length << 3) - 1) << SPILMISO;
       while (SPI1CMD & SPIBUSY);
       SPI1U1 = u1;
@@ -338,8 +353,21 @@ namespace lgfx
     };
     i2c_context_t i2c_context[I2C_NUM_MAX];
 
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
     cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl)
     {
+      if (i2c_port < 0)
+      {
+        auto res = soft_i2c_setPins(i2c_port, pin_sda, pin_scl);
+        return res.has_error() ? res : soft_i2c_init(i2c_port);
+      }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       auto i2c = &i2c_context[i2c_port];
 
@@ -354,10 +382,12 @@ namespace lgfx
     }
     cpp::result<void, error_t> release(int i2c_port)
     {
+      if (i2c_port < 0) { return soft_i2c_release(i2c_port); }
       return {};
     }
     cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read)
     {
+      if (i2c_port < 0) { return soft_i2c_restart(i2c_port, i2c_addr, freq, read); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       auto i2c = &i2c_context[i2c_port];
 
@@ -384,10 +414,12 @@ namespace lgfx
     }
     cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read)
     {
+      if (i2c_port < 0) { return soft_i2c_beginTransaction(i2c_port, i2c_addr, freq, read); }
       return restart(i2c_port, i2c_addr, freq, read);
     }
     cpp::result<void, error_t> endTransaction(int i2c_port)
     {
+      if (i2c_port < 0) { return soft_i2c_endTransaction(i2c_port); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       auto i2c = &i2c_context[i2c_port];
 
@@ -399,6 +431,7 @@ namespace lgfx
     }
     cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length)
     {
+      if (i2c_port < 0) { return soft_i2c_writeBytes(i2c_port, data, length); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       auto i2c = &i2c_context[i2c_port];
       if (length)
@@ -415,6 +448,7 @@ namespace lgfx
     }
     cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack)
     {
+      if (i2c_port < 0) { return soft_i2c_readBytes(i2c_port, data, length, last_nack); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       auto i2c = &i2c_context[i2c_port];
       while (length--)

--- a/src/lgfx/v1/platforms/rp2040/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/rp2040/Bus_I2C.hpp
@@ -35,7 +35,7 @@ namespace lgfx
       uint32_t freq_read = 400000;
       int16_t pin_scl = 22;
       int16_t pin_sda = 21;
-      uint8_t i2c_port = 0;
+      int8_t i2c_port = 0;
       uint8_t i2c_addr = 0x3C;
       uint32_t prefix_cmd = 0x00;
       uint32_t prefix_data = 0x40;

--- a/src/lgfx/v1/platforms/rp2040/common.cpp
+++ b/src/lgfx/v1/platforms/rp2040/common.cpp
@@ -208,6 +208,14 @@ namespace lgfx
 
   namespace spi
   {
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
     namespace
     {
       struct spi_info_str {
@@ -368,6 +376,7 @@ namespace lgfx
 
     cpp::result<void, error_t> init(int spi_port, int pin_sclk, int pin_miso, int pin_mosi)
     {
+      if (spi_port < 0) { return soft_spi_init(spi_port, pin_sclk, pin_miso, pin_mosi); }
       DBGPRINT("enter %s\n", __func__);
       if (spi_port < 0 || spi_port >= n_spi)
       {
@@ -444,6 +453,7 @@ namespace lgfx
 
     void release(int spi_port)
     {
+      if (spi_port < 0) { soft_spi_release(spi_port); return; }
       if (spi_info[spi_port].ref_count == 0)
       {
         return;
@@ -466,6 +476,7 @@ namespace lgfx
 
     void beginTransaction(int spi_port, uint32_t freq, int spi_mode)
     {
+      if (spi_port < 0) { soft_spi_beginTransaction(spi_port, freq, spi_mode); return; }
       static constexpr spi_cpha_t cpha_table[] = { SPI_CPHA_0, SPI_CPHA_1, SPI_CPHA_0, SPI_CPHA_1 };
       static constexpr spi_cpol_t cpol_table[] = { SPI_CPOL_0, SPI_CPOL_0, SPI_CPOL_1, SPI_CPOL_1 };
       if (spi_mode < 0 || spi_mode > 3)
@@ -478,7 +489,7 @@ namespace lgfx
 
     void endTransaction([[maybe_unused]]int spi_port)
     {
-
+      if (spi_port < 0) { return; }  // a software host holds nothing to release
     }
 
 
@@ -515,6 +526,7 @@ namespace lgfx
 
     void readBytes(int spi_port, uint8_t* dst, size_t length)
     {
+      if (spi_port < 0) { soft_spi_readBytes(spi_port, dst, length); return; }
       uint8_t *p;
       p = dst;
       clear_rx_fifo (spi_port);
@@ -546,6 +558,14 @@ namespace lgfx
 
   namespace i2c
   {
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
     namespace
     {
       // constant
@@ -1027,6 +1047,11 @@ namespace lgfx
 
     cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl)
     {
+      if (i2c_port < 0)
+      {
+        auto res = soft_i2c_setPins(i2c_port, pin_sda, pin_scl);
+        return res.has_error() ? res : soft_i2c_init(i2c_port);
+      }
       volatile i2c_hw_t *const i2c_regs = i2c_dev[i2c_port];
       auto info = &i2c_info[i2c_port];
       if (i2c_port < 0 || i2c_port >= n_i2c)
@@ -1069,6 +1094,7 @@ namespace lgfx
 
     cpp::result<void, error_t> release(int i2c_port)
     {
+      if (i2c_port < 0) { return soft_i2c_release(i2c_port); }
       volatile i2c_hw_t * const i2c_regs = i2c_dev[i2c_port];
       auto info = &i2c_info[i2c_port];
 
@@ -1088,6 +1114,7 @@ namespace lgfx
 
     cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, [[maybe_unused]] bool read)
     {
+      if (i2c_port < 0) { return soft_i2c_restart(i2c_port, i2c_addr, freq, read); }
       volatile i2c_hw_t *const i2c_regs = i2c_dev[i2c_port];
       DBG_ENTER();
       // readで読み出しが行われない可能性があるので、stop conditionに遷移する
@@ -1103,6 +1130,7 @@ namespace lgfx
 
     cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, [[maybe_unused]] bool read)
     {
+      if (i2c_port < 0) { return soft_i2c_beginTransaction(i2c_port, i2c_addr, freq, read); }
       volatile i2c_hw_t *const i2c_regs = i2c_dev[i2c_port];
       auto info = &i2c_info[i2c_port];
       DBG_ENTER();
@@ -1119,6 +1147,7 @@ namespace lgfx
 
     cpp::result<void, error_t> endTransaction(int i2c_port)
     {
+      if (i2c_port < 0) { return soft_i2c_endTransaction(i2c_port); }
       DBG_ENTER();
       // 未送信の最終データをstop conditionで送信
       if (!send_last_byte(i2c_port, stop_state_t::stop, need_wait_t::wait)) {
@@ -1129,6 +1158,7 @@ namespace lgfx
 
     cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length)
     {
+      if (i2c_port < 0) { return soft_i2c_writeBytes(i2c_port, data, length); }
       DBGPRINTFUNC("%d\n", length);
       if (length == 0) {
         return {};
@@ -1150,8 +1180,9 @@ namespace lgfx
       return {};
     }
 
-    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack = false)
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack)
     {
+      if (i2c_port < 0) { return soft_i2c_readBytes(i2c_port, data, length, last_nack); }
       volatile i2c_hw_t *const i2c_regs = i2c_dev[i2c_port];
       auto info = &i2c_info[i2c_port];
       if (length == 0) {
@@ -1187,7 +1218,7 @@ namespace lgfx
     cpp::result<void, error_t> transactionRead(int i2c_port, int addr, uint8_t *readdata, uint8_t readlen, uint32_t freq)
     {
       cpp::result<void, error_t> res;
-      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = readBytes(i2c_port, readdata, readlen)).has_value())
+      if ((res = beginTransaction(i2c_port, addr, freq, true)).has_value() && (res = readBytes(i2c_port, readdata, readlen, true)).has_value())
       {
         res = endTransaction(i2c_port);
       }
@@ -1197,7 +1228,7 @@ namespace lgfx
     cpp::result<void, error_t> transactionWriteRead(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint8_t *readdata, size_t readlen, uint32_t freq)
     {
       cpp::result<void, error_t> res;
-      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = writeBytes(i2c_port, writedata, writelen)).has_value() && (res = restart(i2c_port, addr, freq, false)).has_value() && (res = readBytes(i2c_port, readdata, readlen)).has_value())
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value() && (res = writeBytes(i2c_port, writedata, writelen)).has_value() && (res = restart(i2c_port, addr, freq, true)).has_value() && (res = readBytes(i2c_port, readdata, readlen, true)).has_value())
       {
         res = endTransaction(i2c_port);
       }

--- a/src/lgfx/v1/platforms/samd21/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/samd21/Bus_I2C.hpp
@@ -31,7 +31,7 @@ namespace lgfx
   public:
     struct config_t
     {
-      uint8_t sercom_index = 0;
+      int8_t sercom_index = 0;
       uint32_t freq_write = 400000;
       uint32_t freq_read = 400000;
       int16_t pin_scl = samd21::PORT_A | 9;

--- a/src/lgfx/v1/platforms/samd21/common.cpp
+++ b/src/lgfx/v1/platforms/samd21/common.cpp
@@ -317,8 +317,17 @@ namespace lgfx
 
   namespace spi
   {
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
     cpp::result<void, error_t> init(int sercom_index, int pin_sclk, int pin_miso, int pin_mosi)
     {
+      if (sercom_index < 0) { return soft_spi_init(sercom_index, pin_sclk, pin_miso, pin_mosi); }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       int dipo = -1;
@@ -423,6 +432,7 @@ namespace lgfx
     //void release(int spi_host) {}
     void release(int sercom_index)
     {
+      if (sercom_index < 0) { soft_spi_release(sercom_index); return; }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
 
@@ -440,6 +450,7 @@ namespace lgfx
 
     void beginTransaction(int sercom_index, uint32_t freq, int spi_mode)
     {
+      if (sercom_index < 0) { soft_spi_beginTransaction(sercom_index, freq, spi_mode); return; }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
 
@@ -457,10 +468,12 @@ namespace lgfx
 
     void endTransaction(int sercom_index)
     {
+      if (sercom_index < 0) { return; }  // a software host holds nothing to release
     }
 
     void writeBytes(int sercom_index, const uint8_t* data, size_t length)
     {
+      if (sercom_index < 0) { soft_spi_writeBytes(sercom_index, data, length); return; }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *spi = &sercom->SPI;
@@ -474,6 +487,7 @@ namespace lgfx
 
     void readBytes(int sercom_index, uint8_t* data, size_t length)
     {
+      if (sercom_index < 0) { soft_spi_readBytes(sercom_index, data, length); return; }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *spi = &sercom->SPI;
@@ -491,6 +505,14 @@ namespace lgfx
 
   namespace i2c // TODO: implement.
   {
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
     static constexpr uint8_t WIRE_MASTER_ACT_REPEAT_START = 0x01;
     static constexpr uint8_t WIRE_MASTER_ACT_READ = 0x02;
     static constexpr uint8_t WIRE_MASTER_ACT_STOP = 0x03;
@@ -601,6 +623,11 @@ namespace lgfx
 
     cpp::result<void, error_t> init(int sercom_index, int pin_sda, int pin_scl)
     {
+      if (sercom_index < 0)
+      {
+        auto res = soft_i2c_setPins(sercom_index, pin_sda, pin_scl);
+        return res.has_error() ? res : soft_i2c_init(sercom_index);
+      }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       if (samd21::sercom_ref_count[sercom_index] == 0)
@@ -634,6 +661,7 @@ namespace lgfx
 
     cpp::result<void, error_t> release(int sercom_index)
     {
+      if (sercom_index < 0) { return soft_i2c_release(sercom_index); }
       if (samd21::sercom_ref_count[sercom_index] > 1)
       {
         samd21::sercom_ref_count[sercom_index]--;
@@ -652,6 +680,7 @@ namespace lgfx
 
     cpp::result<void, error_t> restart(int sercom_index, int i2c_addr, uint32_t freq, bool read)
     {
+      if (sercom_index < 0) { return soft_i2c_restart(sercom_index, i2c_addr, freq, read); }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *i2cm = &sercom->I2CM;
@@ -665,6 +694,7 @@ namespace lgfx
 
     cpp::result<void, error_t> beginTransaction(int sercom_index, int i2c_addr, uint32_t freq, bool read)
     {
+      if (sercom_index < 0) { return soft_i2c_beginTransaction(sercom_index, i2c_addr, freq, read); }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *i2cm = &sercom->I2CM;
@@ -680,6 +710,7 @@ namespace lgfx
 
     cpp::result<void, error_t> endTransaction(int sercom_index)
     {
+      if (sercom_index < 0) { return soft_i2c_endTransaction(sercom_index); }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *i2cm = &sercom->I2CM;
@@ -690,6 +721,7 @@ namespace lgfx
 
     cpp::result<void, error_t> writeBytes(int sercom_index, const uint8_t *data, size_t length)
     {
+      if (sercom_index < 0) { return soft_i2c_writeBytes(sercom_index, data, length); }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *i2cm = &sercom->I2CM;
@@ -703,8 +735,9 @@ namespace lgfx
       return {};
     }
 
-    cpp::result<void, error_t> readBytes(int sercom_index, uint8_t *data, size_t length, bool last_nack = false)
+    cpp::result<void, error_t> readBytes(int sercom_index, uint8_t *data, size_t length, bool last_nack)
     {
+      if (sercom_index < 0) { return soft_i2c_readBytes(sercom_index, data, length, last_nack); }
       auto sercomData = samd21::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *i2cm = &sercom->I2CM;
@@ -742,7 +775,7 @@ namespace lgfx
     {
       cpp::result<void, error_t> res;
       if ((res = beginTransaction(sercom_index, addr, freq, true)).has_value()
-       && (res = readBytes(sercom_index, readdata, readlen)).has_value()
+       && (res = readBytes(sercom_index, readdata, readlen, true)).has_value()
       )
       {
         res = endTransaction(sercom_index);
@@ -756,7 +789,7 @@ namespace lgfx
       if ((res = beginTransaction(sercom_index, addr, freq, false)).has_value()
        && (res = writeBytes(sercom_index, writedata, writelen)).has_value()
        && (res = restart(sercom_index, addr, freq, true)).has_value()
-       && (res = readBytes(sercom_index, readdata, readlen)).has_value()
+       && (res = readBytes(sercom_index, readdata, readlen, true)).has_value()
       )
       {
         res = endTransaction(sercom_index);

--- a/src/lgfx/v1/platforms/samd51/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/samd51/Bus_I2C.hpp
@@ -35,7 +35,7 @@ namespace lgfx
       uint32_t freq_read = 400000;
       int16_t pin_scl ;
       int16_t pin_sda ;
-      uint8_t i2c_port ;
+      int8_t i2c_port ;
       uint8_t i2c_addr ;
       uint32_t prefix_cmd = 0x00;
       uint32_t prefix_data = 0x40;

--- a/src/lgfx/v1/platforms/samd51/common.cpp
+++ b/src/lgfx/v1/platforms/samd51/common.cpp
@@ -403,6 +403,14 @@ namespace lgfx
 
   namespace spi // TODO: implement.
   {
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
     static void resetSPI(SercomSpi* spi)
     {
       //Setting the Software Reset bit to 1
@@ -414,6 +422,7 @@ namespace lgfx
 
     cpp::result<void, error_t> init(int sercom_index, int pin_sclk, int pin_miso, int pin_mosi)
     {
+      if (sercom_index < 0) { return soft_spi_init(sercom_index, pin_sclk, pin_miso, pin_mosi); }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       int dopo = -1;
@@ -478,6 +487,7 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
     void release(int sercom_index)
     {
+      if (sercom_index < 0) { soft_spi_release(sercom_index); return; }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return; }
 
       auto sercom_data = samd51::getSercomData(sercom_index);
@@ -501,6 +511,7 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
     void beginTransaction(int sercom_index, uint32_t freq, int spi_mode)
     {
+      if (sercom_index < 0) { soft_spi_beginTransaction(sercom_index, freq, spi_mode); return; }
       auto sercomData = samd51::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
 
@@ -518,10 +529,12 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
     void endTransaction(int sercom_index)
     {
+      if (sercom_index < 0) { return; }  // a software host holds nothing to release
     }
 
     void writeBytes(int sercom_index, const uint8_t* data, size_t length)
     {
+      if (sercom_index < 0) { soft_spi_writeBytes(sercom_index, data, length); return; }
       auto sercomData = samd51::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercomData->sercomPtr);
       auto *spi = &sercom->SPI;
@@ -535,6 +548,7 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
     void readBytes(int sercom_index, uint8_t* data, size_t length)
     {
+      if (sercom_index < 0) { soft_spi_readBytes(sercom_index, data, length); return; }
       auto sercom_data = samd51::getSercomData(sercom_index);
       auto sercom = reinterpret_cast<Sercom*>(sercom_data->sercomPtr);
       auto *spi = &sercom->SPI;
@@ -553,6 +567,14 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
   namespace i2c // TODO: implement.
   {
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
     struct i2c_context_t
     {
       enum state_t
@@ -586,6 +608,11 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
     cpp::result<void, error_t> init(int sercom_index, int pin_sda, int pin_scl)
     {
+      if (sercom_index < 0)
+      {
+        auto res = soft_i2c_setPins(sercom_index, pin_sda, pin_scl);
+        return res.has_error() ? res : soft_i2c_init(sercom_index);
+      }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       int pad_sda;
@@ -643,6 +670,7 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
     cpp::result<void, error_t> release(int sercom_index)
     {
+      if (sercom_index < 0) { return soft_i2c_release(sercom_index); }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       auto sercomData = samd51::getSercomData(sercom_index);
@@ -663,6 +691,7 @@ auto mastermode = SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
 
     cpp::result<void, error_t> restart(int sercom_index, int i2c_addr, uint32_t freq, bool read)
     {
+      if (sercom_index < 0) { return soft_i2c_restart(sercom_index, i2c_addr, freq, read); }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       auto sercomData = samd51::getSercomData(sercom_index);
@@ -770,6 +799,7 @@ Serial.println("restart:ok");
 
     cpp::result<void, error_t> beginTransaction(int sercom_index, int i2c_addr, uint32_t freq, bool read)
     {
+      if (sercom_index < 0) { return soft_i2c_beginTransaction(sercom_index, i2c_addr, freq, read); }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 /*
       auto sercomData = samd51::getSercomData(sercom_index);
@@ -827,6 +857,7 @@ Serial.println("restart:ok");
 
     cpp::result<void, error_t> endTransaction(int sercom_index)
     {
+      if (sercom_index < 0) { return soft_i2c_endTransaction(sercom_index); }
       return i2c_wait(sercom_index, true);
 
 /*
@@ -845,6 +876,7 @@ Serial.println("restart:ok");
 
     cpp::result<void, error_t> writeBytes(int sercom_index, const uint8_t *data, size_t length)
     {
+      if (sercom_index < 0) { return soft_i2c_writeBytes(sercom_index, data, length); }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       auto sercomData = samd51::getSercomData(sercom_index);
@@ -863,8 +895,9 @@ Serial.println("restart:ok");
       return res;
     }
 
-    cpp::result<void, error_t> readBytes(int sercom_index, uint8_t *data, size_t length, bool last_nack = false)
+    cpp::result<void, error_t> readBytes(int sercom_index, uint8_t *data, size_t length, bool last_nack)
     {
+      if (sercom_index < 0) { return soft_i2c_readBytes(sercom_index, data, length, last_nack); }
       if ((size_t)sercom_index >= SERCOM_INST_NUM) { return cpp::fail(error_t::invalid_arg); }
 
       auto res = i2c_wait(sercom_index);
@@ -938,7 +971,7 @@ Serial.println("read fail");
     {
       cpp::result<void, error_t> res;
       if ((res = beginTransaction(sercom_index, addr, freq, true)).has_value()
-       && (res = readBytes(sercom_index, readdata, readlen)).has_value()
+       && (res = readBytes(sercom_index, readdata, readlen, true)).has_value()
       )
       {
         res = endTransaction(sercom_index);
@@ -952,7 +985,7 @@ Serial.println("read fail");
       if ((res = beginTransaction(sercom_index, addr, freq, false)).has_value()
        && (res = writeBytes(sercom_index, writedata, writelen)).has_value()
        && (res = restart(sercom_index, addr, freq, true)).has_value()
-       && (res = readBytes(sercom_index, readdata, readlen)).has_value()
+       && (res = readBytes(sercom_index, readdata, readlen, true)).has_value()
       )
       {
         res = endTransaction(sercom_index);

--- a/src/lgfx/v1/platforms/sdl/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/sdl/Bus_I2C.hpp
@@ -35,7 +35,7 @@ namespace lgfx
       uint32_t freq_read = 400000;
       int16_t pin_scl = 22;
       int16_t pin_sda = 21;
-      uint8_t i2c_port = 0;
+      int8_t i2c_port = 0;
       uint8_t i2c_addr = 0x3C;
       uint32_t prefix_cmd = 0x00;
       uint32_t prefix_data = 0x40;

--- a/src/lgfx/v1/platforms/soft_i2c.inl
+++ b/src/lgfx/v1/platforms/soft_i2c.inl
@@ -1,0 +1,409 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+// I2C on plain GPIO, selected by a negative port number: port -1 is slot 0,
+// port -2 is slot 1. It reaches a bus without claiming a peripheral unit, for
+// when every unit is taken or when touching one is undesirable.
+//
+// This file is not a header but a code fragment: a platform implementation
+// includes it inside its i2c namespace, and delegates to the soft_i2c_*()
+// functions at the top of each public function when the port is negative.
+// Everything here has internal linkage, so nothing beyond the negative port
+// convention becomes part of the library interface.
+//
+// The transaction semantics mirror the peripheral paths: an unacknowledged
+// address surfaces at the next operation or at endTransaction, not at
+// beginTransaction. On a failure the bus is stopped and the lock released
+// right away, and the stored error is reported (and cleared) later.
+// Clock stretching is honored wherever SCL is released.
+#if !defined ( LGFX_INTERNAL_SOFT_I2C )
+ #error "soft_i2c.inl is an implementation fragment of the i2c namespace; it cannot be included directly."
+#endif
+
+// An I2C line is only ever driven low or released, never driven high. The
+// default implementation releases by turning the pin back into an input and
+// drives by turning it into an output whose latch was parked low, which works
+// on any platform. A platform whose pinMode() gives an input mode an open
+// drain output stage (esp32) overrides these with plain latch toggles and
+// skips the direction changes.
+#if !defined ( SOFT_I2C_LINE_LO )
+ #define SOFT_I2C_LINE_LO(pin)   do { gpio_lo(pin); pinMode(pin, pin_mode_t::output); } while (0)
+ #define SOFT_I2C_LINE_HI(pin)   pinMode(pin, pin_mode_t::input_pullup)
+#endif
+
+// Serialization of the transactions on a slot. A platform with an RTOS wraps
+// a mutex over the lock_handle member; the default is single threaded.
+#if !defined ( SOFT_I2C_LOCK )
+ #define SOFT_I2C_LOCK(ctx)
+ #define SOFT_I2C_UNLOCK(ctx)
+#endif
+
+// Called while waiting out a stretched clock.
+#if !defined ( SOFT_I2C_YIELD )
+ #if defined ( ARDUINO )
+  #define SOFT_I2C_YIELD() yield()
+ #else
+  #define SOFT_I2C_YIELD()
+ #endif
+#endif
+
+//----------------------------------------------------------------------------
+
+    static constexpr int soft_i2c_port_count = 2;
+
+    static constexpr int soft_i2c_7bit_addr_min = 0x08;
+    static constexpr int soft_i2c_7bit_addr_max = 0x77;
+    static constexpr int soft_i2c_10bit_addr_max = 1023;
+
+    struct soft_i2c_context_t
+    {
+      enum state_t
+      {
+        state_disconnect,
+        state_write,
+        state_read
+      };
+      cpp::result<state_t, error_t> state;
+      void* lock_handle = nullptr;  // storage for the SOFT_I2C_LOCK hooks
+      int pin_sda = -1;
+      int pin_scl = -1;
+      uint32_t freq = 0;
+      uint32_t half_us = 0;  // 0 = unthrottled
+      bool initialized = false;
+    };
+    static soft_i2c_context_t soft_i2c_context[soft_i2c_port_count];
+
+    static inline bool soft_i2c_valid_port(int i2c_port) { return -soft_i2c_port_count <= i2c_port && i2c_port < 0; }
+    static inline soft_i2c_context_t& soft_i2c_ctx(int i2c_port) { return soft_i2c_context[~i2c_port]; }
+
+    static inline void soft_i2c_half_wait(uint32_t half_us)
+    { if (half_us) { delayMicroseconds(half_us); } }
+
+    static inline void soft_i2c_set_freq(soft_i2c_context_t& ctx, uint32_t freq)
+    {
+      if (freq == 0) { freq = 100000; }  // an unset frequency falls back to the usual default
+      ctx.freq = freq;
+      // Rounded up: the throttled clock must not come out above the request.
+      ctx.half_us = (freq >= 500000) ? 0 : (500000 + freq - 1) / freq;
+    }
+
+    /// Release SCL and wait for it to actually rise, honoring clock stretching.
+    static inline bool soft_i2c_scl_hi(const soft_i2c_context_t& ctx)
+    {
+      SOFT_I2C_LINE_HI(ctx.pin_scl);
+      soft_i2c_half_wait(ctx.half_us);
+      if (gpio_in(ctx.pin_scl)) { return true; }
+      auto us = micros();
+      do
+      {
+        SOFT_I2C_YIELD();
+        if (gpio_in(ctx.pin_scl)) { return true; }
+      } while ((micros() - us) < 13000); // the same order as a peripheral timeout
+      return false;
+    }
+
+    /// Returns true when the byte was acknowledged.
+    static inline bool soft_i2c_write_byte(const soft_i2c_context_t& ctx, uint8_t data)
+    {
+      size_t i = 0;
+      do
+      {
+        SOFT_I2C_LINE_LO(ctx.pin_scl);
+        if (data & 0x80) { SOFT_I2C_LINE_HI(ctx.pin_sda); } else { SOFT_I2C_LINE_LO(ctx.pin_sda); }
+        data <<= 1;
+        soft_i2c_half_wait(ctx.half_us);
+        if (!soft_i2c_scl_hi(ctx)) { return false; }
+      } while (++i < 8);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);  // release the data line for the acknowledge
+      soft_i2c_half_wait(ctx.half_us);
+      if (!soft_i2c_scl_hi(ctx)) { return false; }
+      bool ack = !gpio_in(ctx.pin_sda);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      return ack;
+    }
+
+    static inline bool soft_i2c_read_byte(const soft_i2c_context_t& ctx, uint8_t* data, bool ack)
+    {
+      uint_fast8_t byte = 0;
+      SOFT_I2C_LINE_HI(ctx.pin_sda);  // released: the device drives the data line
+      size_t i = 0;
+      do
+      {
+        SOFT_I2C_LINE_LO(ctx.pin_scl);
+        soft_i2c_half_wait(ctx.half_us);
+        if (!soft_i2c_scl_hi(ctx)) { return false; }
+        byte = (byte << 1) + (gpio_in(ctx.pin_sda) ? 1 : 0);
+      } while (++i < 8);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      if (ack) { SOFT_I2C_LINE_LO(ctx.pin_sda); } else { SOFT_I2C_LINE_HI(ctx.pin_sda); }
+      soft_i2c_half_wait(ctx.half_us);
+      if (!soft_i2c_scl_hi(ctx)) { return false; }
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      *data = byte;
+      return true;
+    }
+
+    /// Returns false when the clock could not be released for the stop condition.
+    static inline bool soft_i2c_stop_cond(const soft_i2c_context_t& ctx)
+    {
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      SOFT_I2C_LINE_LO(ctx.pin_sda);
+      soft_i2c_half_wait(ctx.half_us);
+      bool ok = soft_i2c_scl_hi(ctx);
+      soft_i2c_half_wait(ctx.half_us);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      soft_i2c_half_wait(ctx.half_us);
+      return ok;
+    }
+
+    /// Free a bus whose device was left mid transfer (e.g. by a reset) and holds
+    /// the data line, by clocking the leftover bits out.
+    static inline void soft_i2c_recover(const soft_i2c_context_t& ctx)
+    {
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      size_t i = 0;
+      while (!gpio_in(ctx.pin_sda) && ++i <= 9)
+      {
+        SOFT_I2C_LINE_LO(ctx.pin_scl);
+        soft_i2c_half_wait(ctx.half_us);
+        soft_i2c_scl_hi(ctx);
+      }
+      soft_i2c_stop_cond(ctx);
+    }
+
+    /// Ends a transfer on a failure. The bus is stopped and the lock released
+    /// right away; the error is stored so that it surfaces from the following
+    /// operation or from endTransaction, as it does on a peripheral path.
+    static inline void soft_i2c_abort(soft_i2c_context_t& ctx)
+    {
+      soft_i2c_stop_cond(ctx);
+      ctx.state = cpp::fail(error_t::connection_lost);
+      SOFT_I2C_UNLOCK(ctx);
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_send_address(soft_i2c_context_t& ctx, int i2c_addr, bool read)
+    {
+      bool ack;
+      if (i2c_addr <= soft_i2c_7bit_addr_max)
+      {
+        ack = soft_i2c_write_byte(ctx, i2c_addr << 1 | (read ? 1 : 0));
+      }
+      else
+      {
+        ack = soft_i2c_write_byte(ctx, 0xF0 | (i2c_addr >> 8) << 1)
+           && soft_i2c_write_byte(ctx, i2c_addr & 0xFF);
+        if (ack && read)
+        { // A 10 bit read re-addresses the high byte in read mode.
+          SOFT_I2C_LINE_HI(ctx.pin_sda);
+          soft_i2c_half_wait(ctx.half_us);
+          ack = soft_i2c_scl_hi(ctx);
+          if (ack)
+          {
+            SOFT_I2C_LINE_LO(ctx.pin_sda);
+            soft_i2c_half_wait(ctx.half_us);
+            SOFT_I2C_LINE_LO(ctx.pin_scl);
+            ack = soft_i2c_write_byte(ctx, 0xF0 | (i2c_addr >> 8) << 1 | 1);
+          }
+        }
+      }
+      if (!ack)
+      {
+        soft_i2c_abort(ctx);
+        return {};
+      }
+      ctx.state = read ? soft_i2c_context_t::state_t::state_read : soft_i2c_context_t::state_t::state_write;
+      return {};
+    }
+
+// ------------------------------------------------------------------------
+// Mirrors of the public functions, for the negative ports.
+
+    static inline cpp::result<void, error_t> soft_i2c_release(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.initialized)
+      {
+        ctx.initialized = false;
+        // Park the pins the same way the peripheral paths do.
+        if (ctx.pin_scl >= 0) { pinMode(ctx.pin_scl, pin_mode_t::input_pullup); }
+        if (ctx.pin_sda >= 0) { pinMode(ctx.pin_sda, pin_mode_t::input_pullup); }
+      }
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_setPins(int i2c_port, int pin_sda, int pin_scl)
+    {
+      if (!soft_i2c_valid_port(i2c_port) || pin_sda < 0 || pin_scl < 0)
+      {
+        return cpp::fail(error_t::invalid_arg);
+      }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.initialized && ctx.pin_sda == pin_sda && ctx.pin_scl == pin_scl)
+      {
+        return {};
+      }
+      soft_i2c_release(i2c_port).has_value();
+      ctx.pin_sda = pin_sda;
+      ctx.pin_scl = pin_scl;
+      return {};
+    }
+
+    static inline cpp::result<int, error_t> soft_i2c_getPinSDA(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      return soft_i2c_ctx(i2c_port).pin_sda;
+    }
+
+    static inline cpp::result<int, error_t> soft_i2c_getPinSCL(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      return soft_i2c_ctx(i2c_port).pin_scl;
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_init(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.pin_sda < 0 || ctx.pin_scl < 0) { return cpp::fail(error_t::invalid_arg); }
+      if (ctx.initialized)
+      {
+        soft_i2c_release(i2c_port).has_value();
+      }
+      soft_i2c_set_freq(ctx, 100000);  // until a transfer brings its own
+      // Both lines are released; the pullup carries them high when the bus is
+      // healthy. ( see SOFT_I2C_LINE_HI for how a line is driven afterwards )
+      pinMode(ctx.pin_sda, pin_mode_t::input_pullup);
+      pinMode(ctx.pin_scl, pin_mode_t::input_pullup);
+      ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+      ctx.initialized = true;
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.pin_sda < 0 || ctx.pin_scl < 0) { return cpp::fail(error_t::invalid_arg); }
+      if (i2c_addr < soft_i2c_7bit_addr_min || i2c_addr > soft_i2c_10bit_addr_max) { return cpp::fail(error_t::invalid_arg); }
+      SOFT_I2C_LOCK(ctx);
+      ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+      soft_i2c_set_freq(ctx, freq);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      if (!soft_i2c_scl_hi(ctx))
+      { // The clock never rose: no start condition can be made on this bus.
+        soft_i2c_abort(ctx);
+        return {};
+      }
+      if (!gpio_in(ctx.pin_sda))
+      {
+        soft_i2c_recover(ctx);
+        if (!gpio_in(ctx.pin_sda))
+        { // The data line is still held; without it no start condition can be
+          // made, and the acknowledge bits would read as permanently asserted.
+          soft_i2c_abort(ctx);
+          return {};
+        }
+      }
+      SOFT_I2C_LINE_LO(ctx.pin_sda);  // start condition
+      soft_i2c_half_wait(ctx.half_us);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      return soft_i2c_send_address(ctx, i2c_addr, read);
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_restart(int i2c_port, int i2c_addr, uint32_t freq, bool read)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      if (i2c_addr < soft_i2c_7bit_addr_min || i2c_addr > soft_i2c_10bit_addr_max) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error()) { return cpp::fail(ctx.state.error()); }
+      if (ctx.state == soft_i2c_context_t::state_disconnect)
+      { // Only an open transaction can be restarted; the lock is not held here.
+        return cpp::fail(error_t::mode_mismatch);
+      }
+      soft_i2c_set_freq(ctx, freq);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);  // repeated start
+      soft_i2c_half_wait(ctx.half_us);
+      if (!soft_i2c_scl_hi(ctx))
+      {
+        soft_i2c_abort(ctx);
+        return {};
+      }
+      SOFT_I2C_LINE_LO(ctx.pin_sda);
+      soft_i2c_half_wait(ctx.half_us);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      return soft_i2c_send_address(ctx, i2c_addr, read);
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_endTransaction(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error())
+      { // The failing operation has already stopped the bus and released the lock;
+        // report its error here and clear it.
+        auto err = ctx.state.error();
+        ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+        return cpp::fail(err);
+      }
+      if (ctx.state == soft_i2c_context_t::state_disconnect) { return {}; }
+      bool stopped = soft_i2c_stop_cond(ctx);
+      ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+      SOFT_I2C_UNLOCK(ctx);
+      if (!stopped) { return cpp::fail(error_t::connection_lost); }
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_writeBytes(int i2c_port, const uint8_t *data, size_t length)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error()) { return cpp::fail(ctx.state.error()); }
+      if (ctx.state != soft_i2c_context_t::state_write) { return cpp::fail(error_t::mode_mismatch); }
+      if (!length) { return {}; }
+      do
+      {
+        if (!soft_i2c_write_byte(ctx, *data++))
+        {
+          soft_i2c_abort(ctx);
+          return cpp::fail(error_t::connection_lost);
+        }
+      } while (--length);
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_readBytes(int i2c_port, uint8_t *readdata, size_t length, bool last_nack)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error()) { return cpp::fail(ctx.state.error()); }
+      if (ctx.state != soft_i2c_context_t::state_read) { return cpp::fail(error_t::mode_mismatch); }
+      if (!length) { return {}; }
+      do
+      {
+        if (!soft_i2c_read_byte(ctx, readdata++, !(last_nack && length == 1)))
+        {
+          soft_i2c_abort(ctx);
+          return cpp::fail(error_t::connection_lost);
+        }
+      } while (--length);
+      return {};
+    }
+
+//----------------------------------------------------------------------------

--- a/src/lgfx/v1/platforms/soft_spi.inl
+++ b/src/lgfx/v1/platforms/soft_spi.inl
@@ -1,0 +1,168 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+// SPI on plain GPIO, selected by a negative host number: host -1 is slot 0,
+// host -2 is slot 1. It reaches a bus without claiming an SPI peripheral, and
+// the convention matches the touch driver configs, where a negative host has
+// always meant bit banged GPIO.
+//
+// This file is not a header but a code fragment: a platform implementation
+// includes it inside its spi namespace, and delegates to the soft_spi_*()
+// functions at the top of each public function when the host is negative.
+// Everything here has internal linkage, so nothing beyond the negative host
+// convention becomes part of the library interface. Only the portable pin
+// functions are used, which keeps the fragment platform independent.
+#if !defined ( LGFX_INTERNAL_SOFT_SPI )
+ #error "soft_spi.inl is an implementation fragment of the spi namespace; it cannot be included directly."
+#endif
+
+//----------------------------------------------------------------------------
+
+    static constexpr int soft_spi_host_count = 2;
+
+    struct soft_spi_context_t
+    {
+      int pin_sclk = -1;
+      int pin_miso = -1;
+      int pin_mosi = -1;
+      uint32_t half_us = 0;  // 0 = unthrottled
+      uint8_t mode = 0;
+    };
+    static soft_spi_context_t soft_spi_context[soft_spi_host_count];
+
+    static inline bool soft_spi_valid_host(int spi_host) { return -soft_spi_host_count <= spi_host && spi_host < 0; }
+    static inline soft_spi_context_t& soft_spi_ctx(int spi_host) { return soft_spi_context[~spi_host]; }
+
+    static inline void soft_spi_half_wait(uint32_t half_us)
+    {
+      if (half_us) { delayMicroseconds(half_us); }
+    }
+
+    static inline void soft_spi_clock_idle(int pin_sclk, uint8_t spi_mode)
+    {
+      if (pin_sclk < 0) { return; }
+      if (spi_mode & 2) { gpio_hi(pin_sclk); } else { gpio_lo(pin_sclk); }
+    }
+
+    /// Full duplex byte shift, MSB first. read_data may be the write_data
+    /// buffer (in place), or nullptr to discard the incoming bits.
+    /// half_us throttles the clock (0 = unthrottled); the clock is left at its
+    /// idle level, which the caller has to establish before the first call
+    /// ( see soft_spi_clock_idle ).
+    static inline void soft_spi_transfer(uint8_t* read_data, const uint8_t* write_data, size_t len, const soft_spi_context_t& ctx)
+    {
+      if (!len) { return; }
+      const int pin_sclk = ctx.pin_sclk;
+      const int pin_miso = ctx.pin_miso;
+      const int pin_mosi = ctx.pin_mosi;
+      const uint32_t half_us = ctx.half_us;
+      const bool cpha = ctx.mode & 1;
+      const bool lead = !(ctx.mode & 2);  // the clock level of the leading edge
+      do
+      {
+        uint_fast8_t w = *write_data++;
+        uint_fast8_t r = 0;
+        uint_fast8_t mask = 0x80;
+        do
+        {
+          if (!cpha)
+          { // The data is set while the clock idles and sampled on the leading edge.
+            if (pin_mosi >= 0) { if (w & mask) { gpio_hi(pin_mosi); } else { gpio_lo(pin_mosi); } }
+            soft_spi_half_wait(half_us);
+            if (lead) { gpio_hi(pin_sclk); } else { gpio_lo(pin_sclk); }
+            if (pin_miso >= 0 && gpio_in(pin_miso)) { r += mask; }
+            soft_spi_half_wait(half_us);
+            if (lead) { gpio_lo(pin_sclk); } else { gpio_hi(pin_sclk); }
+          }
+          else
+          { // The data is set on the leading edge and sampled on the trailing edge.
+            if (lead) { gpio_hi(pin_sclk); } else { gpio_lo(pin_sclk); }
+            if (pin_mosi >= 0) { if (w & mask) { gpio_hi(pin_mosi); } else { gpio_lo(pin_mosi); } }
+            soft_spi_half_wait(half_us);
+            if (lead) { gpio_lo(pin_sclk); } else { gpio_hi(pin_sclk); }
+            if (pin_miso >= 0 && gpio_in(pin_miso)) { r += mask; }
+            soft_spi_half_wait(half_us);
+          }
+        } while (mask >>= 1);
+        if (read_data) { *read_data++ = r; }
+      } while (--len);
+    }
+
+// ------------------------------------------------------------------------
+// Mirrors of the public functions, for the negative hosts.
+
+    static inline cpp::result<void, error_t> soft_spi_init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return cpp::fail(error_t::invalid_arg); }
+      if (spi_sclk < 0) { return cpp::fail(error_t::invalid_arg); }  // the clock is not optional
+      auto& ctx = soft_spi_ctx(spi_host);
+      ctx.pin_sclk = spi_sclk;
+      ctx.pin_miso = spi_miso;
+      ctx.pin_mosi = spi_mosi;
+      ctx.mode = 0;
+      ctx.half_us = 0;
+      if (spi_sclk >= 0)
+      {
+        gpio_lo(spi_sclk); // low first, so that no HIGH pulse leaves the pin (panels without CS)
+        pinMode(spi_sclk, pin_mode_t::output);
+      }
+      if (spi_mosi >= 0) { pinMode(spi_mosi, pin_mode_t::output); }
+      if (spi_miso >= 0) { pinMode(spi_miso, pin_mode_t::input_pullup); }
+      return {};
+    }
+
+    static inline void soft_spi_release(int spi_host)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      auto& ctx = soft_spi_ctx(spi_host);
+      if (ctx.pin_sclk >= 0) { pinMode(ctx.pin_sclk, pin_mode_t::input); }
+      if (ctx.pin_miso >= 0) { pinMode(ctx.pin_miso, pin_mode_t::input); }
+      if (ctx.pin_mosi >= 0) { pinMode(ctx.pin_mosi, pin_mode_t::input); }
+      ctx = soft_spi_context_t();
+    }
+
+    static inline void soft_spi_beginTransaction(int spi_host)
+    { // Nothing to acquire; just make sure the clock rests at its idle level.
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      auto& ctx = soft_spi_ctx(spi_host);
+      soft_spi_clock_idle(ctx.pin_sclk, ctx.mode);
+    }
+
+    static inline void soft_spi_beginTransaction(int spi_host, uint32_t freq, int spi_mode)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      auto& ctx = soft_spi_ctx(spi_host);
+      ctx.mode = spi_mode & 3;
+      if (freq == 0) { freq = 100000; }  // an unset frequency falls back to a safe default
+      // Best effort, rounded up: the throttled clock must not come out above the request.
+      ctx.half_us = (freq >= 500000) ? 0 : (500000 + freq - 1) / freq;
+      soft_spi_beginTransaction(spi_host);
+    }
+
+    static inline void soft_spi_writeBytes(int spi_host, const uint8_t* data, size_t length)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      soft_spi_transfer(nullptr, data, length, soft_spi_ctx(spi_host));
+    }
+
+    static inline void soft_spi_readBytes(int spi_host, uint8_t* data, size_t length)
+    { // Full duplex, in place: the same semantics as the peripheral paths.
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      soft_spi_transfer(data, data, length, soft_spi_ctx(spi_host));
+    }
+
+//----------------------------------------------------------------------------

--- a/src/lgfx/v1/platforms/spresense/common.cpp
+++ b/src/lgfx/v1/platforms/spresense/common.cpp
@@ -60,12 +60,39 @@ namespace lgfx
   /// unimplemented.
   namespace spi
   {
-    cpp::result<void, error_t> init(int , int , int , int )  { return cpp::fail(error_t::unknown_err); }
-    void release(int ) {}
-    void beginTransaction(int , uint32_t , int ) {}
-    void endTransaction(int ) {}
-    void writeBytes(int , const uint8_t* , size_t ) {}
-    void readBytes(int , uint8_t* , size_t ) {}
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
+    cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
+    {
+      if (spi_host < 0) { return soft_spi_init(spi_host, spi_sclk, spi_miso, spi_mosi); }
+      return cpp::fail(error_t::unknown_err);
+    }
+    void release(int spi_host)
+    {
+      if (spi_host < 0) { soft_spi_release(spi_host); return; }
+    }
+    void beginTransaction(int spi_host, uint32_t freq, int spi_mode)
+    {
+      if (spi_host < 0) { soft_spi_beginTransaction(spi_host, freq, spi_mode); return; }
+    }
+    void endTransaction(int spi_host)
+    {
+      if (spi_host < 0) { return; }  // a software host holds nothing to release
+    }
+    void writeBytes(int spi_host, const uint8_t* data, size_t length)
+    {
+      if (spi_host < 0) { soft_spi_writeBytes(spi_host, data, length); return; }
+    }
+    void readBytes(int spi_host, uint8_t* data, size_t length)
+    {
+      if (spi_host < 0) { soft_spi_readBytes(spi_host, data, length); return; }
+    }
   }
 
 //----------------------------------------------------------------------------
@@ -73,22 +100,113 @@ namespace lgfx
   /// unimplemented.
   namespace i2c
   {
-    cpp::result<void, error_t> init(int , int , int ) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> release(int ) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> restart(int , int , uint32_t , bool ) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> beginTransaction(int , int , uint32_t , bool ) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> endTransaction(int ) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> writeBytes(int , const uint8_t *, size_t ) { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> readBytes(int , uint8_t *, size_t, bool ) { return cpp::fail(error_t::unknown_err); }
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
+    cpp::result<void, error_t> init(int i2c_port, int pin_sda, int pin_scl)
+    {
+      if (i2c_port < 0)
+      {
+        auto res = soft_i2c_setPins(i2c_port, pin_sda, pin_scl);
+        return res.has_error() ? res : soft_i2c_init(i2c_port);
+      }
+      return cpp::fail(error_t::unknown_err);
+    }
+    cpp::result<void, error_t> release(int i2c_port)
+    {
+      if (i2c_port < 0) { return soft_i2c_release(i2c_port); }
+      return cpp::fail(error_t::unknown_err);
+    }
+    cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read)
+    {
+      if (i2c_port < 0) { return soft_i2c_restart(i2c_port, i2c_addr, freq, read); }
+      return cpp::fail(error_t::unknown_err);
+    }
+    cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read)
+    {
+      if (i2c_port < 0) { return soft_i2c_beginTransaction(i2c_port, i2c_addr, freq, read); }
+      return cpp::fail(error_t::unknown_err);
+    }
+    cpp::result<void, error_t> endTransaction(int i2c_port)
+    {
+      if (i2c_port < 0) { return soft_i2c_endTransaction(i2c_port); }
+      return cpp::fail(error_t::unknown_err);
+    }
+    cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length)
+    {
+      if (i2c_port < 0) { return soft_i2c_writeBytes(i2c_port, data, length); }
+      return cpp::fail(error_t::unknown_err);
+    }
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *data, size_t length, bool last_nack)
+    {
+      if (i2c_port < 0) { return soft_i2c_readBytes(i2c_port, data, length, last_nack); }
+      return cpp::fail(error_t::unknown_err);
+    }
 
 //--------
+// The negative (software) ports reach these through the primitives above, the
+// same way a hardware port does; a fail from beginTransaction on a hardware
+// port keeps the external behavior unchanged.
 
-    cpp::result<void, error_t> transactionWrite(int , int , const uint8_t *, uint8_t , uint32_t )  { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> transactionRead(int , int , uint8_t *, uint8_t , uint32_t )  { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> transactionWriteRead(int , int , const uint8_t *, uint8_t , uint8_t *, size_t , uint32_t )  { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> transactionWrite(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint32_t freq)
+    {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value())
+      {
+        res = writeBytes(i2c_port, writedata, writelen);
+      }
+      auto last = endTransaction(i2c_port);
+      return res.has_error() ? res : last;
+    }
 
-    cpp::result<uint8_t, error_t> readRegister8(int , int , uint8_t , uint32_t )  { return cpp::fail(error_t::unknown_err); }
-    cpp::result<void, error_t> writeRegister8(int , int , uint8_t , uint8_t , uint8_t , uint32_t )  { return cpp::fail(error_t::unknown_err); }
+    cpp::result<void, error_t> transactionRead(int i2c_port, int addr, uint8_t *readdata, uint8_t readlen, uint32_t freq)
+    {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, true)).has_value())
+      {
+        res = readBytes(i2c_port, readdata, readlen, true);
+      }
+      auto last = endTransaction(i2c_port);
+      return res.has_error() ? res : last;
+    }
+
+    cpp::result<void, error_t> transactionWriteRead(int i2c_port, int addr, const uint8_t *writedata, uint8_t writelen, uint8_t *readdata, size_t readlen, uint32_t freq)
+    {
+      cpp::result<void, error_t> res;
+      if ((res = beginTransaction(i2c_port, addr, freq, false)).has_value()
+       && (res = writeBytes(i2c_port, writedata, writelen)).has_value()
+       && (res = restart(i2c_port, addr, freq, true)).has_value()
+      )
+      {
+        res = readBytes(i2c_port, readdata, readlen, true);
+      }
+      auto last = endTransaction(i2c_port);
+      return res.has_error() ? res : last;
+    }
+
+    cpp::result<uint8_t, error_t> readRegister8(int i2c_port, int addr, uint8_t reg, uint32_t freq)
+    {
+      auto res = transactionWriteRead(i2c_port, addr, &reg, 1, &reg, 1, freq);
+      if (res.has_value()) { return reg; }
+      return cpp::fail( res.error() );
+    }
+
+    cpp::result<void, error_t> writeRegister8(int i2c_port, int addr, uint8_t reg, uint8_t data, uint8_t mask, uint32_t freq)
+    {
+      uint8_t tmp[2] = { reg, data };
+      if (mask)
+      {
+        auto res = transactionWriteRead(i2c_port, addr, &reg, 1, &tmp[1], 1, freq);
+        if (res.has_error()) { return res; }
+        tmp[1] = (tmp[1] & mask) | data;
+      }
+      return transactionWrite(i2c_port, addr, tmp, 2, freq);
+    }
   }
 
 //----------------------------------------------------------------------------

--- a/src/lgfx/v1/touch/Touch_XPT2046.cpp
+++ b/src/lgfx/v1/touch/Touch_XPT2046.cpp
@@ -34,13 +34,6 @@ namespace lgfx
       lgfx::gpio_hi(_cfg.pin_cs);
       lgfx::pinMode(_cfg.pin_cs, lgfx::pin_mode_t::output);
     }
-    if (_cfg.spi_host < 0)
-    {
-      pinMode(_cfg.pin_sclk, lgfx::pin_mode_t::output);
-      pinMode(_cfg.pin_mosi, lgfx::pin_mode_t::output);
-      pinMode(_cfg.pin_miso, lgfx::pin_mode_t::input_pullup);
-    }
-    else
     if (lgfx::spi::init(_cfg.spi_host, _cfg.pin_sclk, _cfg.pin_miso, _cfg.pin_mosi).has_error())
     {
       return false;
@@ -53,30 +46,6 @@ namespace lgfx
 
     _inited = true;
     return true;
-  }
-
-  static void transfer(uint8_t* read_data, const uint8_t* write_data, size_t len, const Touch_XPT2046::config_t *cfg)
-  {
-    int pin_sclk = cfg->pin_sclk;
-    int pin_miso = cfg->pin_miso;
-    int pin_mosi = cfg->pin_mosi;
-
-    do
-    {
-      uint_fast8_t r = 0;
-      uint_fast8_t mask = 0x80;
-      uint_fast8_t d = *write_data++;
-      do
-      {
-        gpio_lo(pin_sclk);
-        if (d & mask) { gpio_hi(pin_mosi); } else { gpio_lo(pin_mosi); }
-        gpio_hi(pin_sclk);
-        if (gpio_in(pin_miso)) { r += mask; }
-      } while (mask >>= 1);
-
-      *read_data++ = (uint8_t)r;
-    } while (--len);
-    gpio_lo(pin_sclk);
   }
 
   uint_fast8_t Touch_XPT2046::getTouchRaw(touch_point_t* __restrict tp, uint_fast8_t count)
@@ -102,22 +71,13 @@ namespace lgfx
     memcpy(&data[16], data, 16);
     memcpy(&data[32], data, 24);
 
-    if (_cfg.spi_host < 0)
-    {
+    spi::beginTransaction(_cfg.spi_host, _cfg.freq, 0);
+    if (_cfg.pin_cs > -1)
       lgfx::gpio_lo(_cfg.pin_cs);
-      transfer(data, data, 57, &_cfg);
+    spi::readBytes(_cfg.spi_host, data, 57);
+    if (_cfg.pin_cs > -1)
       lgfx::gpio_hi(_cfg.pin_cs);
-    }
-    else
-    {
-      spi::beginTransaction(_cfg.spi_host, _cfg.freq, 0);
-      if (_cfg.pin_cs > -1)
-        lgfx::gpio_lo(_cfg.pin_cs);
-      spi::readBytes(_cfg.spi_host, data, 57);
-      if (_cfg.pin_cs > -1)
-        lgfx::gpio_hi(_cfg.pin_cs);
-      spi::endTransaction(_cfg.spi_host);
-    }
+    spi::endTransaction(_cfg.spi_host);
 
     size_t ix = 0, iy = 0, iz = 0;
     uint_fast16_t xt[7], yt[7], zt[7];


### PR DESCRIPTION
## Overview

A negative I2C port / SPI host number now selects a software (bit banged) bus driven on plain GPIO: port -1 is slot 0, port -2 is slot 1 (two slots each). It reaches a bus without claiming a peripheral unit, for when every unit is taken or when touching one is undesirable.

The convention matches the existing `Touch_XPT2046` setting where a negative `spi_host` has always meant bit banged GPIO. Negative numbers were never valid anywhere else (they fell through the bound checks into negative array indexing), so no existing meaning changes.

## Public contract

**The stable public surface is the negative port / host number only**, accepted by the existing config fields (`i2c_port` / `spi_host` of the touch configs, and `i2c_port` of the Bus_I2C config, which is now signed). The implementations are internal fragments (`soft_i2c.inl` / `soft_spi.inl`) included inside each platform's `i2c` / `spi` namespace with internal linkage: no new public API is added, and everything inside the fragments remains an implementation detail.

## Behavior

- I2C: clock stretching is honored (13 ms class timeout), a held SDA is recovered at transaction start, 10 bit addresses work, and the error semantics mirror the peripheral path (an unacknowledged address surfaces at the following operation or at `endTransaction`, not at `beginTransaction`).
- SPI: full duplex, MSB first, modes 0-3; the clock is throttled on a best effort basis below 500 kHz and runs unthrottled above.
- Platform specifics enter through macro hooks: line driving (esp32 toggles the open drain latches its `pinMode()` provides, the default switches the pin direction), locking (a FreeRTOS mutex on esp32, single threaded elsewhere) and the yield used while a stretched clock is waited out.
- Covered platforms: esp32 family, esp8266, rp2040, samd21, samd51, spresense, arduino_default. On spresense the software ports work even though the hardware stubs remain unimplemented. The PC backends (sdl / opencv / framebuffer) keep rejecting negative numbers.
- `Touch_XPT2046` loses its private bit banged branch and calls the spi functions whatever the sign of the host; `Bus_I2C` accepts a negative port.

## Verification

- Hardware (ESP32-C5 / C6 / P4): I2C scans and register reads over both software slots match the hardware ports (including the low power port) on the same physical bus; an SPI loopback passes every mode at throttled and unthrottled speeds, through a single open drain pin and through a jumper between two pins; out of range slots are rejected at init.
- Builds: esp32 / esp32s3 (IDF 4.4 and 5.x) / esp32c5 / esp32c6 / esp32p4 / esp8266 / rp2040 / samd21 / samd51 / teensy41 / native (SDL).