### PR TITLE
Fix SPI DMA on the AHB_DMA generation (C5/C61) and CHSC6540 retry exhaustion

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
@@ -103,6 +103,12 @@ Contributors:
   #define DMA_OUTLINK_START_CH0      AHB_DMA_OUTLINK_START_CH0
   #define DMA_OUTFIFO_EMPTY_CH0      AHB_DMA_OUTFIFO_EMPTY_CH0
   #define SIZE_OF_DMA_OUT_CH (sizeof(AHB_DMA.channel[0]))
+  // AHB_DMA 世代のうち C5/C61 は OUT_LINK レジスタが制御ビットのみになり、
+  // ディスクリプタアドレスは別レジスタ (チャンネルごとに 4 バイト刻み) へ書く;
+  // (同じ AHB_DMA でも H4 はアドレスレジスタをチャンネルブロック内に持つため対象外)
+  #if defined (CONFIG_IDF_TARGET_ESP32C5) || defined (CONFIG_IDF_TARGET_ESP32C61)
+   #define DMA_OUT_LINK_ADDR_CH0_REG  AHB_DMA_OUT_LINK_ADDR_CH0_REG
+  #endif
  #else
   #if __has_include(<soc/gdma_struct.h>)
    #if !defined DMA_OUT_LINK_CH0_REG
@@ -224,6 +230,8 @@ namespace lgfx
       _spi_dma_outstatus_reg = reg(DMA_OUTFIFO_STATUS_CH0_REG + assigned_dma_ch * SIZE_OF_DMA_OUT_CH);
       #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
       _spi_dma_out_link2_reg = reg(AXI_DMA_OUT_LINK2_CH0_REG  + assigned_dma_ch * SIZE_OF_DMA_OUT_CH);
+      #elif defined ( DMA_OUT_LINK_ADDR_CH0_REG )
+      _spi_dma_out_link2_reg = reg(DMA_OUT_LINK_ADDR_CH0_REG  + assigned_dma_ch * sizeof(uint32_t));
       #endif
     }
 #elif defined ( CONFIG_IDF_TARGET_ESP32 ) || !defined ( CONFIG_IDF_TARGET )
@@ -712,7 +720,7 @@ namespace lgfx
       if (use_dma)
       {
         auto spi_dma_out_link_reg = _spi_dma_out_link_reg;
-        #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+        #if defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( DMA_OUT_LINK_ADDR_CH0_REG )
         auto spi_dma_out_link2_reg = _spi_dma_out_link2_reg;
         #endif
         auto cmd = _spi_cmd_reg;
@@ -728,7 +736,7 @@ namespace lgfx
         auto dma = reg(SPI_DMA_CONF_REG(_spi_port));
         *dma = 0; /// Clear previous transfer
         uint32_t len = ((length - 1) & ((SPI_MS_DATA_BITLEN)>>3)) + 1;
-        #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+        #if defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( DMA_OUT_LINK_ADDR_CH0_REG )
         *spi_dma_out_link2_reg = ((uint32_t)(_dmadesc));
         *spi_dma_out_link_reg = DMA_OUTLINK_START_CH0 ;
         #else
@@ -946,7 +954,7 @@ label_start:
     *_spi_dma_out_link_reg = 0;
 
 #if defined ( SOC_GDMA_SUPPORTED ) && defined ( DMA_OUTLINK_START_CH0 )
-    #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+    #if defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( DMA_OUT_LINK_ADDR_CH0_REG )
     *_spi_dma_out_link2_reg = ((uint32_t)(_dmadesc));
     *_spi_dma_out_link_reg = DMA_OUTLINK_START_CH0;
     #else

--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
@@ -193,7 +193,8 @@ namespace lgfx
     volatile uint32_t* _spi_cmd_reg = nullptr;
     volatile uint32_t* _spi_user_reg = nullptr;
     volatile uint32_t* _spi_dma_out_link_reg = nullptr;
-    #if defined (CONFIG_IDF_TARGET_ESP32P4)
+    // P4 (AXI_DMA) と C5/C61 (AHB_DMA) はディスクリプタアドレスを OUT_LINK と別のレジスタへ書く;
+    #if defined (CONFIG_IDF_TARGET_ESP32P4) || defined (CONFIG_IDF_TARGET_ESP32C5) || defined (CONFIG_IDF_TARGET_ESP32C61)
     volatile uint32_t* _spi_dma_out_link2_reg = nullptr;
     #endif
     volatile uint32_t* _spi_dma_outstatus_reg = nullptr;

--- a/src/lgfx/v1/touch/Touch_CHSC6540.cpp
+++ b/src/lgfx/v1/touch/Touch_CHSC6540.cpp
@@ -72,13 +72,17 @@ namespace lgfx
         {
           flip = !flip;
           size_t points = std::min<uint_fast8_t>(count, tmp[0]);
-          if (points && lgfx::i2c::readBytes(_cfg.i2c_port, &tmp[1], points * 6 - 2))
-          {}
+          if (points && !lgfx::i2c::readBytes(_cfg.i2c_port, &tmp[1], points * 6 - 2))
+          { // 座標を読み切れなかったフレームは破棄する (ゼロ埋めの座標を有効タッチとして返さないため);
+            tmp[0] = 0;
+          }
         }
         if (lgfx::i2c::endTransaction(_cfg.i2c_port)) {}
         if (tmp[0] == 0 || memcmp(buf[0], buf[1], len) == 0) break;
       }
-      if (0 == --retry) return 0;
+      // リトライを使い切った場合はタッチ無しとせず直近の読み値を採用する。
+      // (指の移動中は連続読出しが一致しないため、return 0 だとフリックが取れない)
+      if (0 == --retry) { break; }
     }
     if (count > tmp[0]) count = tmp[0];
 


### PR DESCRIPTION
Two fixes, one per commit:

- **Write the DMA descriptor address where AHB_DMA (C5/C61) expects it** — on these chips the OUT_LINK register no longer carries the descriptor address; it lives in a separate OUT_LINK_ADDR_CHn register (4 bytes per channel). The old OR-into-START write was silently ignored, so the DMA started with no descriptor and the first transfer hung waiting on the OUT FIFO. Reuses the two-register path already needed on the P4 (AXI_DMA); the H4, whose AHB_DMA lays these registers out per channel block, keeps the old path. Verified on an ESP32-C5.
- **Report the last reading when Touch_CHSC6540 runs out of retries** — while a finger is moving no two consecutive reads agree, so the retries ran out and the function reported "no touch", breaking drags and flicks mid-gesture. Adopt the most recent reading, the way Touch_FT5x06 already does; a frame whose coordinate payload could not be read is dropped instead of turning into a touch at (0,0).
