### PR TITLE
Bring the SDL simulator window to the foreground on macOS

### DIFF
--- a/src/lgfx/v1/platforms/sdl/Panel_sdl.cpp
+++ b/src/lgfx/v1/platforms/sdl/Panel_sdl.cpp
@@ -257,6 +257,11 @@ namespace lgfx
     _update_in_semaphore = SDL_CreateSemaphore(0);
     _update_out_semaphore = SDL_CreateSemaphore(0);
     for (size_t pin = 0; pin < EMULATED_GPIO_MAX; ++pin) { gpio_hi(pin); }
+#if defined ( __APPLE__ )
+    /// Since SDL 2.30.4, non-bundled apps are no longer brought to the foreground on macOS 14 or later.
+    /// Set the hint before SDL_Init so that the window appears in front. (can be overridden by the environment variable)
+    SDL_SetHint(SDL_HINT_MAC_BACKGROUND_APP, "0");
+#endif
     /*Initialize the SDL*/
     SDL_Init(SDL_INIT_VIDEO);
     SDL_StartTextInput();


### PR DESCRIPTION
## Overview

Since SDL 2.30.4, non-bundled binaries are no longer brought to the foreground on macOS 14 or later (libsdl-org/SDL#10340 changed the default behaviour of `SDL_HINT_MAC_BACKGROUND_APP` there). As a result, the SDL simulator window opens behind the frontmost application.

This PR sets the hint to "0" in `Panel_sdl::setup()` before `SDL_Init`, which restores the previous foreground behaviour for every application using `Panel_sdl::main` without modifying its own entry point. `SDL_SetHint` uses normal priority, so users can still override this via the `SDL_MAC_BACKGROUND_APP` environment variable.

## Verification

- macOS (Apple Silicon) + Homebrew SDL 2.32.10: without this change the simulator window opens behind the frontmost app; with it, the window comes to the foreground. Verified by checking the frontmost application before/after.
- Built the CMake_SDL example successfully.
- Other platforms are unaffected (`__APPLE__` guard).