### PR TITLE
Panel_IT8951: add timeout to the BUSY-pin wait in _write_args()

### DIFF
--- a/src/lgfx/v1/panel/Panel_IT8951.cpp
+++ b/src/lgfx/v1/panel/Panel_IT8951.cpp
@@ -241,10 +241,14 @@ IT8951 Registers defines
     _bus->endTransaction();
   }
 
-  bool Panel_IT8951::_wait_busy(uint32_t timeout)
+  // Bounded poll of the BUSY pin, without touching chip-select.
+  // Returns false after `timeout` ms if BUSY never deasserts (e.g. the
+  // panel's boost converter browned out and left BUSY stuck), instead of
+  // spinning forever. Shared by _wait_busy() below and by _write_args(),
+  // which must keep CS asserted continuously across a multi-word burst
+  // and therefore can't use _wait_busy() directly.
+  bool Panel_IT8951::_wait_busy_pin(uint32_t timeout)
   {
-    _bus->wait();
-    cs_control(true);
     if (_cfg.pin_busy >= 0 && !lgfx::gpio_in(_cfg.pin_busy))
     {
       auto start_ms = millis();
@@ -263,6 +267,17 @@ IT8951 Registers defines
           delay(ms >> 4);
         }
       } while (!lgfx::gpio_in(_cfg.pin_busy));
+    }
+    return true;
+  }
+
+  bool Panel_IT8951::_wait_busy(uint32_t timeout)
+  {
+    _bus->wait();
+    cs_control(true);
+    if (!_wait_busy_pin(timeout))
+    {
+      return false;
     }
     cs_control(false);
     return true;
@@ -339,7 +354,13 @@ IT8951 Registers defines
       {
         uint32_t buf = getSwap16(args[i]);
         _bus->wait();
-        while (!lgfx::gpio_in(_cfg.pin_busy));
+        // CS must stay asserted for the whole multi-word burst, so this
+        // can't go through _wait_busy() (it toggles CS). A stuck BUSY
+        // line must still fail out here rather than hang forever.
+        if (!_wait_busy_pin())
+        {
+          return false;
+        }
         _bus->writeData(buf, 16);
       } while ( ++i < length );
       return true;

--- a/src/lgfx/v1/panel/Panel_IT8951.cpp
+++ b/src/lgfx/v1/panel/Panel_IT8951.cpp
@@ -359,6 +359,7 @@ IT8951 Registers defines
         // line must still fail out here rather than hang forever.
         if (!_wait_busy_pin())
         {
+          cs_control(true);
           return false;
         }
         _bus->writeData(buf, 16);

--- a/src/lgfx/v1/panel/Panel_IT8951.hpp
+++ b/src/lgfx/v1/panel/Panel_IT8951.hpp
@@ -88,6 +88,7 @@ namespace lgfx
     uint16_t _vcom = 0;
 
     bool _wait_busy( uint32_t timeout = 4096);
+    bool _wait_busy_pin( uint32_t timeout = 4096);
     bool _write_command( uint16_t cmd);
     bool _write_word( uint16_t data);
     bool _write_args( uint16_t cmd, uint16_t *args, int32_t length);


### PR DESCRIPTION
## Summary

- `Panel_IT8951::_write_args()` polled the BUSY GPIO between argument words with a raw `while (!lgfx::gpio_in(_cfg.pin_busy));` — the only BUSY wait in this file without a timeout. If BUSY gets stuck asserted (e.g. after a panel power brownout when switching between USB and battery on an M5Paper-class device), this loop spins forever and the whole calling stack hangs with it.
- The bounded poll is extracted from `_wait_busy()` into a CS-free helper `_wait_busy_pin(timeout = 4096)`. `_wait_busy()` wraps it with the same CS handling as before; `_write_args()` calls it directly per word (CS must stay asserted across the whole multi-word burst, so it cannot go through `_wait_busy()`), and bails out with `return false` if BUSY never clears.
- On the timeout path, CS is deasserted before returning so the failure-path CS state matches the other `_wait_busy()`-based paths.

## Testing

- Success path is unchanged: each word is still written only after BUSY deasserts, and CS is still held continuously across the burst.
- Compile-checked; the change is identical to one already validated against the full ESP32 CI matrix (Arduino 2.x/3.x, IDF 5.x).