### PR TITLE
Light_PWM: fix inverted IDF version guard for ledc intr_type

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -81,7 +81,7 @@ namespace lgfx
      ledc_channel.hpoint     = 0;
  #if defined ESP_IDF_VERSION_VAL
   // when ledc_channel_config_t.intr_type is deprecated, no need to explicitly configure interrupt, handled in the driver
-  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
      ledc_channel.intr_type  = LEDC_INTR_DISABLE;
   #endif
  #endif


### PR DESCRIPTION
## Summary

The guard around the `intr_type` assignment in `Light_PWM::init()` is inverted. The comment states that `ledc_channel_config_t.intr_type` is deprecated from ESP-IDF v6 and no longer needs explicit configuration, but the condition writes the field only on `ESP_IDF_VERSION >= 6.0.0` — the exact case it was meant to exclude — and skips it everywhere else.

## Verification against ESP-IDF sources

- IDF `release/v6.0` and `master`, `components/esp_driver_ledc/include/driver/ledc.h`:
  `ledc_intr_type_t intr_type __attribute__((deprecated));` — the field still exists but any write triggers `-Wdeprecated-declarations` (an error under `-Werror`).
- IDF v5.5: `intr_type` carries no deprecation attribute; setting it is the documented usage.

## Impact

- On IDF earlier than v6 the assignment was skipped, but builds kept working by accident: `ledc_channel` is a zero-initialized static and `LEDC_INTR_DISABLE == 0`.
- On IDF v6 the deprecated field was written, producing the warning the guard was meant to avoid.

Flipping the comparison to `<` restores the intended behavior on both sides.