### PR TITLE
Light_PWM: fall back to the legacy LEDC API when the core version macro is absent

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -36,10 +36,11 @@ Contributors:
   #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
    #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) ledcAttach(pin_bl, freq, bits)
    #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pin_bl, duty)
-  #elif ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 0)
-   #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) { ledcSetup(pwm_channel, freq, bits); ledcAttachPin(pin_bl, pwm_channel); }
-   #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pwm_channel, duty)
   #endif
+ #endif
+ #if !defined LGFX_LEDCINIT // pre-3.x cores, including 1.x where ESP_ARDUINO_VERSION is absent
+  #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) { ledcSetup(pwm_channel, freq, bits); ledcAttachPin(pin_bl, pwm_channel); }
+  #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pwm_channel, duty)
  #endif
 
 #else // esp-idf


### PR DESCRIPTION
## Summary

`LGFX_LEDCINIT` / `LGFX_LEDCWRITE` are only defined inside `#if defined ESP_ARDUINO_VERSION`, and that macro was introduced with arduino-esp32 **2.0.0** (`esp_arduino_version.h` does not exist on the 1.x tags). On a 1.x core neither branch defines the macros, so the calls in `init()` / `setBrightness()` fail to compile.

This keeps the new-API branch only where the version is provably 3.0.0+, and turns the 2.x branch into an unconditional fallback (`#if !defined LGFX_LEDCINIT`), which restores compilability on the 1.x cores.

## Verification against arduino-esp32 headers

| core | `ESP_ARDUINO_VERSION` | branch taken | ledc API present in `esp32-hal-ledc.h` |
|---|---|---|---|
| 1.0.6 | absent (header 404s on the tag) | fallback | `ledcSetup` / `ledcAttachPin` / `ledcWrite(channel, duty)` only |
| 2.0.0 / 2.0.17 | defined | fallback (same content as the previous `>= 2.0.0` branch — no behavior change) | legacy API present |
| 3.0.0 / 3.3.x | defined, >= 3.0.0 | new API | `ledcAttach(pin, freq, res)` / `ledcWrite(pin, duty)`; `ledcSetup` / `ledcAttachPin` removed |

The two-level nesting is deliberate: `ESP_ARDUINO_VERSION_VAL` is also a 2.0.0 addition, so a single-line `#if defined X && X >= VAL(...)` would be a preprocessing error on 1.x.

Both macro variants stay covered by CI (2.0.17 jobs compile the fallback, 3.x jobs the new API).