### PR TITLE
CI: official IDF containers, tiered version matrix, and queue relief

### DIFF
--- a/.github/scripts/esp-idf-versions.php
+++ b/.github/scripts/esp-idf-versions.php
@@ -36,7 +36,12 @@
 $hardcoded_fqbns = [/*'esp32@4.3.6', 'esp32@4.1.4'*/];
 
 // restrict output to these idf targets, other targets will be ignored
-$idf_boards     = ['esp32', 'esp32s2', 'esp32s3', 'esp32c2', 'esp32c3', 'esp32c5', 'esp32c6', 'esp32p4', 'esp32h2'];
+$idf_boards     = ['esp32', 'esp32s2', 'esp32s3', 'esp32c2', 'esp32c3', 'esp32c5', 'esp32c6', 'esp32c61', 'esp32p4', 'esp32h2'];
+
+// matrix mode, selected by the workflow through the IDF_MATRIX_MODE env var:
+//   'quick' = representative versions only (oldest current + newest of each major release)
+//   'full'  = every current version (scheduled runs, manual dispatch)
+$matrix_mode = getenv('IDF_MATRIX_MODE') ?: 'full';
 
 // get the official support matrix from the espressif website
 // it contains a JavaScript object declaration with all necessary chip/version informations
@@ -50,7 +55,8 @@ $idf_versions_json = JsConverter::convertToArray( $js );
 isset($idf_versions_json['VERSIONS']) or php_die("invalid JSON in ".$idf_versions_js_url);
 !empty($idf_versions_json['VERSIONS']) or php_die("no VERSIONS found in ".$idf_versions_js_url);
 
-$fqbns = [];
+// collect the current versions first: [version name => supported targets]
+$versions = [];
 
 foreach($idf_versions_json['VERSIONS'] as $version)
 {
@@ -59,22 +65,42 @@ foreach($idf_versions_json['VERSIONS'] as $version)
   if($version['old']!=='false')
     continue; // only keep current versions
 
-  foreach($version['supported_targets'] as $board)
-  {
-    if(in_array($board, $idf_boards)) // only keep supported targets
-    {
-      // e.g. esp32@5.2.1
-      $fqbns[] = $board.'@'.str_replace(["v","V"], "", $version['name']);
-    }
-  }
-
+  $name = str_replace(["v","V"], "", $version['name']);
+  $versions[$name] = array_unique( array_merge( $versions[$name] ?? [], $version['supported_targets'] ) );
 }
 
-// merge collected fqbns with hardcoded fqbns
-array_push($fqbns, ...$hardcoded_fqbns);
+!empty($versions) or php_die("no current versions found in ".$idf_versions_js_url);
+uksort($versions, 'version_compare');
+
+if($matrix_mode !== 'full')
+{
+  // quick mode: keep the oldest current version (backward compatibility floor)
+  // plus the newest version of each major release (latest 5.x, latest 6.x, ...)
+  $keep = [ array_key_first($versions) => true ];
+  $newest_per_major = [];
+  foreach(array_keys($versions) as $name)
+    $newest_per_major[ explode('.', $name)[0] ] = $name; // ascending order, so the last write wins
+  foreach($newest_per_major as $name)
+    $keep[$name] = true;
+  $versions = array_intersect_key($versions, $keep);
+}
+
+// build the matrix entries, keyed by fqbn so duplicates collapse
+$entries = [];
+foreach($versions as $name => $targets)
+  foreach($targets as $board)
+    if(in_array($board, $idf_boards)) // only keep supported targets
+      $entries[$board.'@'.$name] = [ 'target' => $board, 'idf' => $name ];
+
+// merge with hardcoded fqbns (e.g. 'esp32@4.3.6')
+foreach($hardcoded_fqbns as $fqbn)
+{
+  [$board, $name] = explode('@', $fqbn);
+  $entries[$fqbn] = [ 'target' => $board, 'idf' => $name ];
+}
 
 // print the json and exit
-php_die( json_encode( [ "esp-idf-fqbn" => $fqbns ], JSON_PRETTY_PRINT ), 0 );
+php_die( json_encode( [ "include" => array_values($entries) ], JSON_PRETTY_PRINT ), 0 );
 
 // same as die() with with end of line
 function php_die($msg, $errcode=1)

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -13,7 +13,19 @@ on:
     - '**.c'
     - '**ArduinoBuild.yml'
   pull_request:
+    paths:
+    - '**.ino'
+    - '**.cpp'
+    - '**.hpp'
+    - '**.h'
+    - '**.c'
+    - '**ArduinoBuild.yml'
   workflow_dispatch:
+
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -24,7 +24,7 @@ on:
 
 # supersede queued/running builds of the same branch or PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -11,6 +11,7 @@ on:
     - '**.hpp'
     - '**.h'
     - '**.c'
+    - '**library.properties'
     - '**ArduinoBuild.yml'
   pull_request:
     paths:
@@ -19,6 +20,7 @@ on:
     - '**.hpp'
     - '**.h'
     - '**.c'
+    - '**library.properties'
     - '**ArduinoBuild.yml'
   workflow_dispatch:
 

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -41,7 +41,7 @@ on:
 
 # supersede queued/running builds of the same branch or PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -13,8 +13,10 @@ on:
     - '**.hpp'
     - '**.h'
     - '**.c'
+    - '**.cmake'
+    - '**CMakeLists.txt'
+    - '**sdkconfig*'
     - '**IDFBuild.yml'
-    - 'CMakeLists.txt'
     - '**esp-idf-versions.php'
   pull_request:
     paths:
@@ -23,8 +25,10 @@ on:
     - '**.hpp'
     - '**.h'
     - '**.c'
+    - '**.cmake'
+    - '**CMakeLists.txt'
+    - '**sdkconfig*'
     - '**IDFBuild.yml'
-    - 'CMakeLists.txt'
     - '**esp-idf-versions.php'
   schedule:
     # weekly full matrix, also catches freshly released IDF versions

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -3,7 +3,6 @@ name: IDFBuild
 
 
 env:
-  REPO_URL: https://github.com/espressif/esp-idf
   PROJECT_DIR: examples/Test/build_test
 
 on:
@@ -16,9 +15,34 @@ on:
     - '**.c'
     - '**IDFBuild.yml'
     - 'CMakeLists.txt'
-    - 'esp-idf-versions.php'
+    - '**esp-idf-versions.php'
   pull_request:
+    paths:
+    - '**.ino'
+    - '**.cpp'
+    - '**.hpp'
+    - '**.h'
+    - '**.c'
+    - '**IDFBuild.yml'
+    - 'CMakeLists.txt'
+    - '**esp-idf-versions.php'
+  schedule:
+    # weekly full matrix, also catches freshly released IDF versions
+    - cron: '0 3 * * 1'
   workflow_dispatch:
+    inputs:
+      matrix_mode:
+        description: 'quick = representative IDF versions, full = all current versions'
+        type: choice
+        options:
+        - quick
+        - full
+        default: full
+
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
@@ -27,11 +51,12 @@ jobs:
     name: Version planner ⊹
     runs-on: ubuntu-latest
     env:
-      max-versions: 3 # maximum core versions to test, starting at latest
+      # scheduled and manually dispatched runs build the full matrix,
+      # regular push/PR runs build the representative 'quick' matrix
+      IDF_MATRIX_MODE: ${{ github.event_name == 'schedule' && 'full' || github.event_name == 'workflow_dispatch' && inputs.matrix_mode || 'quick' }}
     outputs:
       matrix: ${{steps.set-matrix.outputs.matrix}}
       project_dir: ${{steps.set-matrix.outputs.project_dir}}
-      repo_url: ${{steps.set-matrix.outputs.repo_url}}
 
     steps:
     - name: Checkout
@@ -39,7 +64,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Setup matrix
+    - name: Setup matrix (${{ env.IDF_MATRIX_MODE }})
       id: set-matrix
       run: |
         matrix=`php .github/scripts/esp-idf-versions.php`
@@ -49,12 +74,13 @@ jobs:
         matrix="${matrix//$'\r'/''}"  # remove cr
         echo "matrix=${matrix}" >> $GITHUB_OUTPUT
         echo "project_dir=${{env.PROJECT_DIR}}" >> $GITHUB_OUTPUT
-        echo "repo_url=${{env.REPO_URL}}" >> $GITHUB_OUTPUT
 
   build:
-    name: idf ${{ matrix.esp-idf-fqbn }}
+    name: idf ${{ matrix.target }}@${{ matrix.idf }}
     needs: set_matrix
     runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:v${{ matrix.idf }}
 
     strategy:
       matrix: ${{fromJSON(needs.set_matrix.outputs.matrix)}}
@@ -66,45 +92,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # - name: Cache pip for ${{ matrix.esp-idf-fqbn }}
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/.cache/pip
-      #     key: ${{ runner.os }}-pip-${{ matrix.esp-idf-fqbn }}-${{ hashFiles('**/requirements.txt') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pip-
-      #
-      # - name: Cache espressif tools for ${{ matrix.esp-idf-fqbn }}
-      #   uses: actions/cache@v3
-      #   id: espressif
-      #   with:
-      #     path: |
-      #       ~/.espressif
-      #     key: ${{ runner.os }}-espressif-${{ matrix.esp-idf-fqbn }}-${{ hashFiles('**/lockfiles') }}
-      #
-      # - name: Cache esp-idf for ${{ matrix.esp-idf-fqbn }}
-      #   id: cache-idf
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/esp/esp-idf
-      #     key: ${{ runner.os }}-idf-${{ matrix.esp-idf-fqbn }}-${{ hashFiles('**/lockfiles') }}
-
-      - name: Get/Check IDF ${{ matrix.esp-idf-fqbn }}
+      - name: Build example for ${{ matrix.target }}@${{ matrix.idf }}
+        shell: bash
+        working-directory: ${{ needs.set_matrix.outputs.project_dir }}
         run: |
-          mkdir -p ~/esp
-          cd ~/esp
-          idf_fqbn="${{ matrix.esp-idf-fqbn }}"
-          idf_version=${idf_fqbn#*@}
-          if [ ! -d "./esp-idf/" ]; then git clone -b v$idf_version --recursive ${{ needs.set_matrix.outputs.repo_url }} esp-idf; fi
-          cd ~/esp/esp-idf
-          if [ ! -d "~/.espressif" ]; then ./install.sh; fi
-
-      - name: Build example for ${{ matrix.esp-idf-fqbn }}
-        run: |
-          source ~/esp/esp-idf/export.sh
-          idf_fqbn="${{ matrix.esp-idf-fqbn }}"
-          idf_board=${idf_fqbn%%@*}
-          cd ${{ needs.set_matrix.outputs.project_dir }}
-          idf.py set-target $idf_board
+          . $IDF_PATH/export.sh
+          idf.py set-target ${{ matrix.target }}
           idf.py build
-

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -55,9 +55,11 @@ jobs:
     name: Version planner ⊹
     runs-on: ubuntu-latest
     env:
-      # scheduled and manually dispatched runs build the full matrix,
-      # regular push/PR runs build the representative 'quick' matrix
-      IDF_MATRIX_MODE: ${{ github.event_name == 'schedule' && 'full' || github.event_name == 'workflow_dispatch' && inputs.matrix_mode || 'quick' }}
+      # pull requests and scheduled runs build the full matrix so the merge
+      # gate always validates every current IDF version; plain pushes
+      # (post-merge smoke on develop, work-in-progress branches on forks)
+      # build the representative 'quick' matrix
+      IDF_MATRIX_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'schedule') && 'full' || github.event_name == 'workflow_dispatch' && inputs.matrix_mode || 'quick' }}
     outputs:
       matrix: ${{steps.set-matrix.outputs.matrix}}
       project_dir: ${{steps.set-matrix.outputs.project_dir}}

--- a/.github/workflows/OpenCVBuild.yml
+++ b/.github/workflows/OpenCVBuild.yml
@@ -22,7 +22,7 @@ on:
 
 # supersede queued/running builds of the same branch or PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/OpenCVBuild.yml
+++ b/.github/workflows/OpenCVBuild.yml
@@ -17,6 +17,15 @@ on:
     - '**OpenCV.cmake'
     - '**installOpenCV.bat'
   pull_request:
+    paths:
+    - '**.ino'
+    - '**.cpp'
+    - '**.hpp'
+    - '**.h'
+    - '**.c'
+    - '**OpenCVBuild.yml'
+    - '**OpenCV.cmake'
+    - '**installOpenCV.bat'
 
 #  workflow_dispatch:
 

--- a/.github/workflows/OpenCVBuild.yml
+++ b/.github/workflows/OpenCVBuild.yml
@@ -20,6 +20,11 @@ on:
 
 #  workflow_dispatch:
 
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   LGFXOpenCV:

--- a/.github/workflows/PicoSDKBuild.yml
+++ b/.github/workflows/PicoSDKBuild.yml
@@ -18,7 +18,7 @@ on:
 
 # supersede queued/running builds of the same branch or PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/PicoSDKBuild.yml
+++ b/.github/workflows/PicoSDKBuild.yml
@@ -16,6 +16,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.board }}@${{ matrix.sdk-version }}

--- a/.github/workflows/PicoSDKBuild.yml
+++ b/.github/workflows/PicoSDKBuild.yml
@@ -12,8 +12,19 @@ on:
     - '**.hpp'
     - '**.h'
     - '**.c'
+    - '**.cmake'
+    - '**CMakeLists.txt'
     - '**PicoSDKBuild.yml'
   pull_request:
+    paths:
+    - '**.ino'
+    - '**.cpp'
+    - '**.hpp'
+    - '**.h'
+    - '**.c'
+    - '**.cmake'
+    - '**CMakeLists.txt'
+    - '**PicoSDKBuild.yml'
   workflow_dispatch:
 
 # supersede queued/running builds of the same branch or PR

--- a/.github/workflows/PlatformioBuild.yml
+++ b/.github/workflows/PlatformioBuild.yml
@@ -13,7 +13,19 @@ on:
     - '**.c'
     - '**PlatformioBuild.yml'
   pull_request:
+    paths:
+    - '**.ino'
+    - '**.cpp'
+    - '**.hpp'
+    - '**.h'
+    - '**.c'
+    - '**PlatformioBuild.yml'
   workflow_dispatch:
+
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/PlatformioBuild.yml
+++ b/.github/workflows/PlatformioBuild.yml
@@ -24,7 +24,7 @@ on:
 
 # supersede queued/running builds of the same branch or PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/PlatformioBuild.yml
+++ b/.github/workflows/PlatformioBuild.yml
@@ -11,6 +11,8 @@ on:
     - '**.hpp'
     - '**.h'
     - '**.c'
+    - '**platformio*.ini'
+    - '**library.json'
     - '**PlatformioBuild.yml'
   pull_request:
     paths:
@@ -19,6 +21,8 @@ on:
     - '**.hpp'
     - '**.h'
     - '**.c'
+    - '**platformio*.ini'
+    - '**library.json'
     - '**PlatformioBuild.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Why

Measured on recent develop runs:

- Each IDF job spends **4.7 min cloning/installing esp-idf vs 1.6 min actually building** — 42 jobs burn ~255 runner-minutes per push, ~75% of it on setup.
- One push fans out to 100+ jobs across the build workflows while GitHub runs at most 20 concurrently; with back-to-back merges a PlatformIO run reached **74 min wall time for ~3 min jobs**, purely from queueing.
- The `max-versions: 3` knob in IDFBuild was never read by the planner script, which currently emits **all 5 current versions x 9 targets**, including a duplicated `esp32c5@6.0.2` entry coming from the data source.

## What

**IDFBuild** (the version planner keeps tracking `idf_versions.js` — that design is unchanged):

- Build jobs now run inside the official `espressif/idf:v<version>` containers (all current versions have published tags; verified v5.2.7 through v6.0.2). No more per-job clone/install.
- The planner emits a `target`/`idf` include matrix and gains two modes:
  - **full** (pull requests, weekly schedule, manual dispatch): every current version — the merge gate always validates the complete matrix, and newly released IDF versions get caught within a week.
  - **quick** (plain pushes): oldest current version + newest of each major — today 5.2.7, 5.5.5, 6.0.2 → ~27 jobs. Serves as the post-merge smoke on develop and keeps work-in-progress pushes on forks cheap.
- Entries are deduplicated, and `esp32c61` joins the target list.
- Path filters now also cover build configuration files (`**.cmake`, nested `CMakeLists.txt`, `sdkconfig*`, `platformio*.ini`, `library.json` / `library.properties`), not just sources.

**All build workflows**: `concurrency` keyed by event name and PR number (no cross-fork collisions, the weekly schedule can't be cancelled by a develop push) with `cancel-in-progress`; `pull_request` triggers get the same paths filters as `push`.

## Measured effect (this PR's runs)

- IDF jobs: 6.1 min → **3.2 min** each (container pull included); per-push IDF runner time 255 min → 87 min (quick) / ~140 min (full).
- Whole-push wall time: 30–74 min before → **~12 min** (quick) / ~20 min (full on PRs).

## Notes

- If any branch protection lists IDFBuild/ArduinoBuild jobs as required checks, the paths filters would leave doc-only PRs waiting on skipped checks — worth a quick look before merging.
- `pull_request` CI validates the merge preview at run time; if develop moves after the last run, "Require branches to be up to date before merging" is the strict guard (optional, given the PR volume here).
- SDLBuild keeps its existing pages-deployment concurrency group untouched.