### PR TITLE
CI: make every build lane pass on cacheless forks and survive registry hiccups

### DIFF
--- a/.github/scripts/installOpenCV.bat
+++ b/.github/scripts/installOpenCV.bat
@@ -33,7 +33,7 @@ mkdir build
 cd build
 :: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx::
 :: Configure OpenCV
-cmake -G "Visual Studio 17 2022" -T host=x64 -DCMAKE_INSTALL_PREFIX=%cwd%/Installation -D BUILD_opencv_java=OFF -D BUILD_opencv_python=OFF -D BUILD_EXAMPLES=OFF -D INSTALL_C_EXAMPLES=OFF -D INSTALL_PYTHON_EXAMPLES=OFF ..
+cmake -T host=x64 -DCMAKE_INSTALL_PREFIX=%cwd%/Installation -D BUILD_opencv_java=OFF -D BUILD_opencv_python=OFF -D BUILD_EXAMPLES=OFF -D INSTALL_C_EXAMPLES=OFF -D INSTALL_PYTHON_EXAMPLES=OFF ..
 ::DO_NOT_CHANGE::
 ::============================================::
 :: Compile OpenCV in release mode

--- a/.github/scripts/installSDL2.bat
+++ b/.github/scripts/installSDL2.bat
@@ -47,7 +47,7 @@ echo Building Debug version
 echo ============================================
 
 :: build debug version
-cmake -S . -B build/debug -G "Visual Studio 17 2022" -T host=x64 -DCMAKE_INSTALL_PREFIX=%cwd%/install -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+cmake -S . -B build/debug -T host=x64 -DCMAKE_INSTALL_PREFIX=%cwd%/install -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build build/debug --target install
 
 echo ============================================
@@ -55,6 +55,6 @@ echo Building Release version
 echo ============================================
 
 :: build release verion
-cmake -S . -B build/release -G "Visual Studio 17 2022" -T host=x64 -DCMAKE_INSTALL_PREFIX=%cwd%/install -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+cmake -S . -B build/release -T host=x64 -DCMAKE_INSTALL_PREFIX=%cwd%/install -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build build/release --target install
 

--- a/.github/workflows/OpenCVBuild.yml
+++ b/.github/workflows/OpenCVBuild.yml
@@ -42,12 +42,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - { os: windows-latest, OpenCV_DIR: "D:/a/LovyanGFX/LovyanGFX/opencv-4.5.5/opencv/build/" }
-          - { os: macos-latest,   OpenCV_DIR: "/usr/local/Cellar/opencv/4.5.5_2/" }
-          - { os: ubuntu-latest,  OpenCV_DIR: "/home/runner/work/LovyanGFX/LovyanGFX/opencv-install/opencv/build" }
+          - { os: macos-latest }
+          - { os: ubuntu-latest }
 
     steps:
       - name: Checkout
@@ -85,50 +85,18 @@ jobs:
           cd ${{ env.PROJECT_DIR }}
           mkdir build
           cd build
-          cmake -G "Visual Studio 17 2022" -A x64 -T ClangCL ..
+          cmake -A x64 -T ClangCL ..
           cmake --build . --config Debug
-
-      - name: 🐧 📦 Cache OpenCV for Linux
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/cache@v3
-        id: cache-opencv-linux
-        with:
-          path: /home/runner/work/LovyanGFX/LovyanGFX/opencv-install
-          key: ${{ matrix.os }}-opencv-cache
 
       - name: 🐧 🏗️ Install OpenCV for Linux
         if: matrix.os == 'ubuntu-latest'
-        uses: rayandrews/with-opencv-action@v1
-        with:
-          dir: /home/runner/work/LovyanGFX/LovyanGFX/opencv-install
-          cached: ${{ steps.cache-opencv-linux.outputs.cache-hit }}
-          BUILD_EXAMPLES: false
-          INSTALL_C_EXAMPLES: false
-          INSTALL_PYTHON_EXAMPLES: false
-          opencv-version: '4.5.5'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopencv-dev
 
-
-      - name: 🍏 📦 🍺 Cache brew deps for MacOS
-        if: matrix.os == 'macos-latest'
-        uses: actions/cache@v3
-        id: cache-opencv-macosx
-        with:
-          # Paths to cache:
-          # /usr/local/Homebrew - installation folder of Homebrew
-          # /usr/local/Cellar - installation folder of Homebrew formulae
-          # /usr/local/Frameworks, /usr/local/bin, /usr/local/opt - contain (links to) binaries installed by Homebrew formulae
-          # /usr/local/lib/python3.8 - Python3 packages installation
-          path: |
-            /usr/local/Homebrew
-            /usr/local/Cellar
-            /usr/local/Frameworks
-            /usr/local/bin
-            /usr/local/opt
-            /usr/local/lib/python3.8
-          key: ${{ matrix.os }}-opencv
 
       - name: 🍏 🍺 Install OpenCV+CMake brew packages for MacOS
-        if: matrix.os == 'macos-latest' && steps.cache-opencv-macosx.outputs.cache-hit != 'true'
+        if: matrix.os == 'macos-latest'
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: brew install opencv cmake

--- a/.github/workflows/PlatformioBuild.yml
+++ b/.github/workflows/PlatformioBuild.yml
@@ -119,6 +119,11 @@ jobs:
           cd ${{ env.PROJECT_DIR }}
           export pio_ver=${{ matrix.platform-version }}
           export pio_env="${pio_ver//./_}"
-          pio pkg install -e ${{ matrix.board }}-$pio_env --no-save --library file://$(realpath ../../../)
+          # registry hiccups are the dominant cause of spurious failures on
+          # this lane, so retry the network-bound package installs; the
+          # compile itself (pio run) is deliberately not retried
+          retry() { for i in 1 2 3; do "$@" && return 0; [ $i -eq 3 ] && return 1; echo "attempt $i failed, retrying in 20s: $*"; sleep 20; done; }
+          retry pio pkg install -e ${{ matrix.board }}-$pio_env --no-save
+          retry pio pkg install -e ${{ matrix.board }}-$pio_env --no-save --library file://$(realpath ../../../)
           [[ "$pio_env" == "portduino" ]] && { sudo apt update; sudo apt-get install libgpiod-dev libbluetooth-dev; export PLATFORMIO_SRC_DIR=portduino; }
           pio run -e ${{ matrix.board }}-$pio_env

--- a/.github/workflows/SDLBuild.yml
+++ b/.github/workflows/SDLBuild.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - { os: windows-2022 }
+          - { os: windows-latest }
           - { os: macos-26   }
           - { os: ubuntu-latest  }
 
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Cache SDL2 for Windows
-        if: ${{ matrix.os == 'windows-2022' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
         uses: actions/cache@v6
         id: cache-SLD2-windows
         with:
@@ -61,12 +61,12 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/scripts/installSDL2.bat') }}
 
       - name: Build SDL2 for Windows
-        if: matrix.os == 'windows-2022' && steps.cache-SLD2-windows.outputs.cache-hit != 'true'
+        if: startsWith(matrix.os, 'windows') && steps.cache-SLD2-windows.outputs.cache-hit != 'true'
         run: |
           .github/scripts/installSDL2.bat
 
       - name: Build LGFX_SDL2 for Windows
-        if: ${{ matrix.os == 'windows-2022' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
         env:
           CC: clang
           CXX: clang++
@@ -74,9 +74,9 @@ jobs:
         run: |
           cp .github/scripts/SDL.cmake ${{ env.PROJECT_DIR }}/CMakeLists.txt
           cd ${{ env.PROJECT_DIR }}
-          cmake -S . -B build/debug -G "Visual Studio 17 2022" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake -S . -B build/debug -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
           cmake --build build/debug --config Debug
-          cmake -S . -B build/release -G "Visual Studio 17 2022" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake -S . -B build/release -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
           cmake --build build/release --config Release
 
 
@@ -117,7 +117,7 @@ jobs:
 
 
       - name: Build LGFX_SDL2 for Mac
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
           brew install sdl2
           cp .github/scripts/SDL.cmake ${{ env.PROJECT_DIR }}/CMakeLists.txt
@@ -130,7 +130,7 @@ jobs:
 
   deploy:
     name: Deploy WASM Example 🚀
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && github.repository == 'lovyan03/LovyanGFX'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Why

Contributors should be able to validate changes on their own fork before opening a PR, but several lanes could never pass on a fork (where no build caches exist), one lane was silently building nothing, and today's registry outages showed the PlatformIO lane fails spuriously several times a day. Several of these are also time bombs for this repository itself, hidden only by warm caches or image-rollout timing.

## What

**OpenCVBuild**
- **Linux: install from apt.** The third-party `with-opencv-action` adds an Ubuntu xenial repository whose signing keys have expired, so any cache-miss run dies during apt. The build uses a plain `find_package(OpenCV REQUIRED)`, so `libopencv-dev` is sufficient — no source build, no cache.
- **Windows: stop pinning the `Visual Studio 17 2022` generator.** `windows-latest` now provisions the `windows-2025-vs2026` image where VS 2022 no longer exists. CMake's default generator works on any image, and OpenCV 4.5.5 builds cleanly under VS 2026.
- **macOS: drop the stale Intel-Homebrew cache** (`/usr/local/...`, `python3.8` paths from the Intel era). A stale cache hit even skips `brew install` and leaves the job without OpenCV.
- **`fail-fast: false`** so one platform lane can't cancel the other two.

**SDLBuild**
- **Windows: move from `windows-2022` to `windows-latest`** and drop the VS 2022 generator pin from the install script and both example configures (same time bomb as OpenCV — the pinned pairing breaks the moment the 2022 image retires). Editing the install script also invalidates the SDL2 build cache, so nothing built by the old toolchain gets reused. SDL2 2.0.22 builds cleanly under VS 2026.
- **Quote `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`**: on the new image, pwsh hands CMake the value `3` when the define is unquoted, failing validation at configure and at SDL2 package import.
- **Fix the silently disabled macOS lane**: the matrix entry says `macos-26` but the build step still checked `matrix.os == 'macos-latest'` — the macOS job has been reporting success without compiling anything. OS checks now match by prefix so an image bump can't silently disable a lane again.

**PlatformioBuild**
- **Retry the package installs.** The registry dropped connections four times today alone. The full dependency set is installed up front with up to three attempts; the compile itself is deliberately not retried so genuine build errors still fail fast.

**SDL pages deployment**: scoped to this repository, so a fork pushing its master branch builds everything but skips the deploy instead of failing on the missing pages environment.

## Testing

Validated on a cacheless fork — the environment these lanes could never survive before:
- OpenCV: green on all three OSes.
- SDL: green on all three OSes, including the first real macOS build after the no-op fix and the SDL2 source build under VS 2026.
- PlatformIO / SDL lanes green with the retry in place.