### PR TITLE
Panel_SSD1677: rework the four-mode refresh into per-mode single-activation waveforms

### DIFF
--- a/src/lgfx/v1/panel/Panel_SSD1677.cpp
+++ b/src/lgfx/v1/panel/Panel_SSD1677.cpp
@@ -34,7 +34,6 @@ namespace lgfx
 //----------------------------------------------------------------------------
 
   static constexpr int8_t Bayer[16] = { -30, 18, -22, 26, -14, 2, -6, 10, -18, 30, -26, 22, -2, 14, -10, 6 };
-  // static constexpr int8_t Bayer[16] = { 0, };
 
   // SSD1677 commands
   static constexpr uint8_t CMD_DEEP_SLEEP        = 0x10;
@@ -58,115 +57,112 @@ namespace lgfx
   static constexpr uint8_t CTRL1_BYPASS_RED = 0x40;
 
   //--------------------------------------------------------------------------
-  // LUTs (ported from community-sdk EInkDisplay, non-X3 / GDEQ0426T82).
+  // SSD1677 LUT layout.
   // Layout: VS patterns (5 groups x 10 bytes) + TP/RP timing (10 groups x 5 bytes)
   //         + frame rate (5 bytes) = 105 bytes -> command 0x32.
   // Then voltages [VGH, VSH1, VSH2, VSL, VCOM] (bytes 105..109) -> 0x03/0x04/0x2C.
   //--------------------------------------------------------------------------
 
+  // VS codes: 0 = VSS (no drive), 1 = VSH1 (darken), 2 = VSL (lighten),
+  // 3 = VSH2 (weak darken).
+  // For the absolute waveforms (quality/text/fast) the RAM group selects the
+  // target level: group 0 = white, 1 = light gray, 2 = dark gray, 3 = black.
+
+  // Quality: an oscillation prefix erases the previous image, then the
+  // four-gray tail forms the target.
+  // Keep |VSH1| == |VSL|: the net drive stays identical for all groups,
+  // which prevents image-correlated ghosting over repeated refreshes.
+  // The timing groups repeat the tail to stabilize the black and white
+  // endpoints.
+  static constexpr uint8_t lut_quality[110] = {
+    0x66, 0x66, 0x00, 0x4A, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, // white
+    0x66, 0x66, 0x80, 0x62, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // light
+    0x66, 0x66, 0x88, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // dark
+    0x66, 0x66, 0xA8, 0x44, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // black
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // VCOM
+    0x05, 0x05, 0x05, 0x05, 0x00,
+    0x05, 0x05, 0x05, 0x05, 0x01,
+    0x08, 0x0B, 0x02, 0x03, 0x01,
+    0x0C, 0x02, 0x07, 0x02, 0x01,
+    0x01, 0x00, 0x02, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x22, 0x22, 0x22, 0x22, 0x22,       // frame rate
+    0x17, 0x46, 0xA8, 0x36, 0x30,       // VGH, VSH1(+16V), VSH2, VSL(-16V), VCOM(-1.2V)
+  };
+
+  // Text: 64-frame absolute four-gray waveform for Mode 1.
+  static constexpr uint8_t lut_text[110] = {
+    0x55, 0x55, 0x55, 0x55, 0x55, 0x5A, 0xAA, 0xAA, 0x00, 0x00, // white
+    0xAA, 0x95, 0x55, 0x55, 0x55, 0x5A, 0x82, 0xA0, 0x00, 0x00, // light
+    0xAA, 0xA5, 0x55, 0x55, 0x55, 0x5A, 0xA0, 0x00, 0x00, 0x00, // dark
+    0xAA, 0xAA, 0xAA, 0xAA, 0x55, 0x55, 0x55, 0x50, 0x00, 0x00, // black
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // VCOM
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x8F, 0x8F, 0x8F, 0x8F, 0x8F,       // frame rate
+    0x17, 0x41, 0xA8, 0x32, 0x30,       // VGH, VSH1(+15V), VSH2, VSL(-15V), VCOM(-1.2V)
+  };
+
+  // Fast: 48-frame absolute four-gray waveform for Mode 2.
+  // The first 16 phases run for one frame and the remaining phases for two,
+  // while the final HOLD phase of each middle-gray row uses VSH2 for a weak
+  // two-frame darkening trim.
+  static constexpr uint8_t lut_fast[110] = {
+    0x55, 0x55, 0x55, 0x55, 0x55, 0x5A, 0xAA, 0xAA, 0x00, 0x00, // white
+    0xAA, 0x95, 0x55, 0x55, 0x55, 0x5A, 0x82, 0xAC, 0x00, 0x00, // light
+    0xAA, 0xA5, 0x55, 0x55, 0x55, 0x5A, 0xAC, 0x00, 0x00, 0x00, // dark
+    0xAA, 0xAA, 0xAA, 0xAA, 0x55, 0x55, 0x55, 0x50, 0x00, 0x00, // black
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // VCOM
+    0x01, 0x01, 0x01, 0x01, 0x00,
+    0x01, 0x01, 0x01, 0x01, 0x00,
+    0x01, 0x01, 0x01, 0x01, 0x00,
+    0x01, 0x01, 0x01, 0x01, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x02, 0x02, 0x02, 0x02, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x8F, 0x8F, 0x8F, 0x8F, 0x8F,       // frame rate
+    0x17, 0x41, 0xA8, 0x32, 0x30,       // VGH, VSH1(+15V), VSH2, VSL(-15V), VCOM(-1.2V)
+  };
+
+  // Fastest: differential monochrome update (Mode 2). Here the RAM group is
+  // the transition class computed in _send_transition_planes: group 0 holds
+  // dark pixels, 3 holds light pixels, 1 drives black-to-white and 2 drives
+  // white-to-black. A 2-frame reverse-polarity prepulse precedes the
+  // 8-frame dose to curb ghosting from repeated partial updates.
   static constexpr uint8_t lut_fastest[110] = {
-    0x55, 0x55, 0x55, 0x55, 0x55, 0x5A, 0xAA, 0xAA, 0x00, 0x00, // LUT0: 00 white
-    0xAA, 0x95, 0x55, 0x55, 0x55, 0x5A, 0x82, 0xA0, 0x00, 0x00, // LUT1: 01 light
-    0xAA, 0xA5, 0x55, 0x55, 0x55, 0x5A, 0xA0, 0x00, 0x00, 0x00, // LUT2: 10 dark
-    0xAA, 0xAA, 0xAA, 0xAA, 0x55, 0x55, 0x55, 0x55, 0x00, 0x00, // LUT3: 11 black
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // VCOM
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G0: A, B, C, D, RP
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G1: A, B, C, D, RP
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G2: A, B, C, D, RP
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G3: A, B, C, D, RP
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G4: A, B, C, D, RP
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G5: A, B, C, D, RP
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G6: A, B, C, D, RP
-    0x02, 0x02, 0x02, 0x02, 0x00, // TP G7: A, B, C, D, RP
-    0x00, 0x00, 0x00, 0x00, 0x00, // TP G8: A, B, C, D, RP
-    0x00, 0x00, 0x00, 0x00, 0x00, // TP G9: A, B, C, D, RP
-    0x8F, 0x8F, 0x8F, 0x8F, 0x8F, // frame rate
-    0x17, 0x41, 0xA8, 0x32, 0x30, // VGH, VSH1, VSH2, VSL, VCOM(-1.2V)
-  };
-
-  // Factory absolute LUTs. 2-bit pixel encoding: BW=bit0(LSB), RED=bit1(MSB).
-  //   00=black, 01=dark, 10=light, 11=white. (i.e. value v(0..3) = (MSB<<1)|LSB.)
-  static constexpr uint8_t lut_factory_fast[110] = {
-    0x00, 0x4A, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT0: 00 black
-    0x80, 0x62, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT1: 01 dark
-    0x88, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT2: 10 light
-    0xA8, 0x44, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT3: 11 white
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // VCOM
-    0x09, 0x0C, 0x03, 0x03, 0x00,
-    0x0F, 0x03, 0x07, 0x03, 0x00,
-    0x03, 0x00, 0x02, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x44, 0x44, 0x44, 0x44, 0x44,       // frame rate (faster clock)
-    0x17, 0x41, 0xA8, 0x32, 0x50,       // VGH, VSH1, VSH2, VSL, VCOM(-2.0V)
-  };
-
-  static constexpr uint8_t lut_factory_quality[110] = {
-    0x00, 0x4A, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT0: 00 black
-    0x80, 0x62, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT1: 01 dark
-    0x88, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT2: 10 light
-    0xA8, 0x44, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT3: 11 white
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // VCOM
-    0x08, 0x0B, 0x02, 0x03, 0x00,
-    0x0C, 0x02, 0x07, 0x02, 0x00,
-    0x01, 0x00, 0x02, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x01,
-    0x22, 0x22, 0x22, 0x22, 0x22,       // frame rate (slower clock)
-    0x17, 0x41, 0xA8, 0x32, 0x30,       // VGH, VSH1, VSH2, VSL, VCOM(-1.2V)
-  };
-
-  // Single-activation Quality waveform. The first eight phases apply the same
-  // VSL/VSH1 sequence to all four LUT groups (four rapid white/black round
-  // trips, two frames per phase). The remaining phases are the calibrated
-  // four-gray target waveform. No intermediate image transfer or separate
-  // activation is required.
-  static constexpr uint8_t lut_quality_oscillating[110] = {
-    0x99, 0x99, 0x00, 0x4A, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT0
-    0x99, 0x99, 0x80, 0x60, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT1
-    0x99, 0x99, 0x88, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT2
-    0x99, 0x99, 0xA8, 0x44, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // LUT3
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // hold dark
+    0x6A, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // black -> white
+    0x95, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // white -> black
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // hold light
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // VCOM
     0x02, 0x02, 0x02, 0x02, 0x00,
-    0x02, 0x02, 0x02, 0x02, 0x00,
-    0x08, 0x0B, 0x02, 0x03, 0x00,
-    0x0C, 0x02, 0x07, 0x02, 0x00,
-    0x01, 0x00, 0x02, 0x00, 0x00,
+    0x01, 0x01, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00,
-    0x22, 0x22, 0x22, 0x22, 0x22,
-    0x17, 0x41, 0xA8, 0x36, 0x30,
-  };
-
-  // Differential Mode 2 base. Groups 00 and 11 are state-aware holds,
-  // group 01 lightens, and group 10 darkens. The actual pulse positions and
-  // durations are installed for each transition step below.
-  static constexpr uint8_t lut_gray_differential[110] = {
-    0,0,0,0,0,0,0,0,0,0,
-    0x54,0x54,0x40,0,0,0,0,0,0,0,
-    0xAA,0xA0,0xA8,0,0,0,0,0,0,0,
-    0xA2,0x22,0x20,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,
-    1,1,1,1,0, 1,1,1,1,0,
-    1,1,1,1,0, 0,0,0,0,0,
-    0,0,0,0,0, 0,0,0,0,0,
-    0,0,0,0,0, 0,0,0,0,0,
-    0,0,0,0,0, 0,0,0,0,0,
-    0x8F,0x8F,0x8F,0x8F,0x8F,
-    0x17,0x41,0xA8,0x32,0x30,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+    0x8F, 0x8F, 0x8F, 0x8F, 0x8F,       // frame rate
+    // VCOM -1.2V keeps the hold groups near field-free.
+    0x17, 0x46, 0xA8, 0x32, 0x30,       // VGH, VSH1(+16V), VSH2, VSL(-15V), VCOM(-1.2V)
   };
 
   // Write a 110-byte LUT: 105 waveform bytes -> 0x32, voltages -> 0x03/0x04/0x2C.
@@ -401,7 +397,7 @@ namespace lgfx
       _send_plane(CMD_WRITE_RAM_RED, img, tr); // full/half: same image to both
     }
 
-    // Refresh sequence (community-sdk refreshDisplay, B/W).
+    // Built-in monochrome refresh sequence.
     _wait_busy();
     _bus->writeCommand(CMD_DISP_UPDATE_CTRL1, 8);
     _bus->writeData(is_full ? CTRL1_BYPASS_RED : CTRL1_NORMAL, 8);
@@ -684,6 +680,26 @@ namespace lgfx
     return result;
   }
 
+  void Panel_SSD1677_4Gray::setSleep(bool flg)
+  {
+    Panel_SSD1677::setSleep(flg);
+    _invalidate_gray_state();
+    if (!flg)
+    {
+      // The hardware reset in the wake path establishes the even RAM face.
+      _mode2_face_odd = false;
+      _mode2_face_known = true;
+    }
+  }
+
+  void Panel_SSD1677_4Gray::setPowerSave(bool flg)
+  {
+    Panel_SSD1677::setPowerSave(flg);
+    // Analog power transitions make the retained Mode 2 face/history unsafe.
+    // The next Fast/Fastest update will reset and rebuild them.
+    _invalidate_gray_state();
+  }
+
   void Panel_SSD1677_4Gray::_invalidate_gray_state(void)
   {
     _optical_state = optical_state_t::unknown;
@@ -724,29 +740,24 @@ namespace lgfx
     _displayed_valid = true;
   }
 
-  static uint8_t transition_group(uint8_t old_level, uint8_t new_level,
-                                  uint8_t step, bool monochrome)
+  static uint8_t dirty_byte_mask(int32_t byte_index,
+                                 const range_rect_t& dirty)
   {
-    if (monochrome)
+    uint8_t mask = 0xFF;
+    if (byte_index == (dirty.left >> 3))
     {
-      new_level = new_level < 2 ? 0 : 3;
-      if (old_level == new_level) { return old_level < 2 ? 0 : 3; }
-      return old_level < new_level ? 1 : 2;
+      mask &= uint8_t(0xFFu >> (dirty.left & 7));
     }
-    const uint8_t light_boundary = step;
-    const uint8_t dark_boundary = 2 - step;
-    const bool light = old_level < new_level
-                    && old_level <= light_boundary
-                    && new_level > light_boundary;
-    const bool dark = old_level > new_level
-                   && old_level > dark_boundary
-                   && new_level <= dark_boundary;
-    return light ? 1 : dark ? 2 : old_level < 2 ? 0 : 3;
+    if (byte_index == (dirty.right >> 3))
+    {
+      mask &= uint8_t(0xFFu << (7 - (dirty.right & 7)));
+    }
+    return mask;
   }
 
-  void Panel_SSD1677_4Gray::_send_transition_plane(
-      uint8_t command, const uint8_t* new_lsb, const uint8_t* new_msb,
-      const range_rect_t& dirty, uint8_t step, bool monochrome)
+  void Panel_SSD1677_4Gray::_send_transition_planes(
+      const uint8_t* new_msb,
+      const range_rect_t& dirty)
   {
     const auto full = _full_range();
     const uint32_t row_bytes = ((_cfg.panel_width + 7) & ~7) >> 3;
@@ -754,160 +765,65 @@ namespace lgfx
     const uint8_t* old_msb = _displayed_buf + _buf_x1_len;
     uint8_t row[128];
 
+    // New levels are thresholded by new_msb, while an old middle gray must be
+    // driven all the way to the requested black/white endpoint. The group
+    // bits can still be formed bytewise without decoding individual pixels:
+    //   BW  = new_msb
+    //   RED = new_msb ? (old_lsb & old_msb) : (old_lsb | old_msb)
+    const bool full_dirty = dirty.left == full.left
+                         && dirty.top == full.top
+                         && dirty.right == full.right
+                         && dirty.bottom == full.bottom;
+    if (full_dirty)
+    {
+      _send_plane(CMD_WRITE_RAM_BW, new_msb, full);
+    }
+    else
+    {
+      _set_ram_area(full.left, full.top, full.right + 1, full.bottom + 1);
+      _bus->writeCommand(CMD_WRITE_RAM_BW, 8);
+      const int32_t first_byte = dirty.left >> 3;
+      const int32_t last_byte = dirty.right >> 3;
+      for (int32_t y = 0; y < (int32_t)_cfg.panel_height; ++y)
+      {
+        const size_t row_offset = size_t(y) * row_bytes;
+        memcpy(row, old_msb + row_offset, row_bytes);
+        if (y >= dirty.top && y <= dirty.bottom)
+        {
+          for (int32_t b = first_byte; b <= last_byte; ++b)
+          {
+            const uint8_t mask = dirty_byte_mask(b, dirty);
+            row[b] = (row[b] & uint8_t(~mask))
+                   | (new_msb[row_offset + b] & mask);
+          }
+        }
+        _bus->writeBytes(row, row_bytes, true, false);
+      }
+    }
+
     _set_ram_area(full.left, full.top, full.right + 1, full.bottom + 1);
-    _bus->writeCommand(command, 8);
+    _bus->writeCommand(CMD_WRITE_RAM_RED, 8);
+    const int32_t first_byte = dirty.left >> 3;
+    const int32_t last_byte = dirty.right >> 3;
     for (int32_t y = 0; y < (int32_t)_cfg.panel_height; ++y)
     {
-      // Outside the dirty rectangle, preserve black/dark with group 00 and
-      // light/white with group 11. This distinction is essential because a
-      // single nominal no-drive group is not optically neutral over repeated
-      // full-panel Mode 2 scans.
-      memcpy(row, old_msb + size_t(y) * row_bytes, row_bytes);
+      const size_t row_offset = size_t(y) * row_bytes;
+      memcpy(row, old_msb + row_offset, row_bytes);
       if (y >= dirty.top && y <= dirty.bottom)
       {
-        for (int32_t x = dirty.left; x <= dirty.right; ++x)
+        for (int32_t b = first_byte; b <= last_byte; ++b)
         {
-          const size_t index = size_t(y) * row_bytes + (x >> 3);
-          const uint8_t mask = uint8_t(0x80u >> (x & 7));
-          const uint8_t old_level = ((old_lsb[index] & mask) ? 1 : 0)
-                                  | ((old_msb[index] & mask) ? 2 : 0);
-          const uint8_t new_level = ((new_lsb[index] & mask) ? 1 : 0)
-                                  | ((new_msb[index] & mask) ? 2 : 0);
-          const uint8_t group = transition_group(old_level, new_level,
-                                                 step, monochrome);
-          const uint8_t group_bit = command == CMD_WRITE_RAM_BW ? 1 : 2;
-          if (group & group_bit) { row[x >> 3] |= mask; }
-          else                   { row[x >> 3] &= uint8_t(~mask); }
+          const size_t index = row_offset + b;
+          const uint8_t mask = dirty_byte_mask(b, dirty);
+          const uint8_t new_side = new_msb[index];
+          const uint8_t red = (new_side & (old_lsb[index] & old_msb[index]))
+                            | (uint8_t(~new_side)
+                               & (old_lsb[index] | old_msb[index]));
+          row[b] = (row[b] & uint8_t(~mask)) | (red & mask);
         }
       }
       _bus->writeBytes(row, row_bytes, true, false);
     }
-  }
-
-  bool Panel_SSD1677_4Gray::_activate_transition_step(
-      const uint8_t* new_lsb, const uint8_t* new_msb,
-      const range_rect_t& dirty, uint8_t step, bool monochrome,
-      bool shortened, bool stronger_mono)
-  {
-    static constexpr uint8_t light_phases[] = {7, 4, 9};
-    static constexpr uint8_t vsl[] = {0x36, 0x32, 0x32};
-    static constexpr uint8_t dark_phases[] = {7, 6, 4};
-    static constexpr uint8_t vsh1[] = {0x46, 0x3F, 0x46};
-    static constexpr uint8_t light_position[] = {
-      0, 1, 3, 5, 7, 9, 11, 13, 15,
-    };
-    static constexpr uint8_t dark_position[] = {
-      0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14,
-    };
-
-    _send_transition_plane(CMD_WRITE_RAM_BW, new_lsb, new_msb,
-                           dirty, step, monochrome);
-    _send_transition_plane(CMD_WRITE_RAM_RED, new_lsb, new_msb,
-                           dirty, step, monochrome);
-
-    uint8_t lut[sizeof(lut_gray_differential)];
-    memcpy(lut, lut_gray_differential, sizeof(lut));
-    memset(lut, 0, 40); // groups 00 and 11 start as no-drive
-
-    if (monochrome || step == 2)
-    {
-      // Drive lightening and darkening concurrently. Fast uses the validated
-      // 12-frame 3+3+3+2+1 dose; Fastest uses the accepted eight-frame
-      // 2+2+2+1+1 dose.
-      // The fifth Fastest phase is already present for the darkening group.
-      // Use that same final frame for lightening as well: this raises the
-      // black-to-white dose from seven to eight frames without extending the
-      // eight-frame activation or changing outside-area hold groups. A
-      // 30-step navigation UI test retained the same 105 ms average and made
-      // the erased black cursor residue visually negligible.
-      const uint8_t light_end = shortened ? 5 : 8;
-      const uint8_t dark_end = shortened ? 5 : 8;
-      for (uint8_t position = 0; position < light_end; ++position)
-      {
-        lut[10 + (position >> 2)] |=
-            uint8_t{2} << (6 - ((position & 3) << 1));
-      }
-      for (uint8_t position = 0; position < dark_end; ++position)
-      {
-        lut[20 + (position >> 2)] |=
-            uint8_t{1} << (6 - ((position & 3) << 1));
-      }
-      for (uint8_t timing_group = 0; timing_group < 4; ++timing_group)
-      {
-        for (uint8_t phase = 0; phase < 4; ++phase)
-        {
-          const uint8_t position = timing_group * 4 + phase;
-          uint8_t tp = 0;
-          if (shortened)
-          {
-            if (stronger_mono)
-            {
-              // Fast retains the validated 12-frame dose.
-              if (position < 3) { tp = 3; }
-              else if (position == 3) { tp = 2; }
-              else if (position == 4) { tp = 1; }
-            }
-            else
-            {
-              // Fastest: keep the same five pulse positions and
-              // calibrated voltages, but shorten 3+3+3+2+1 to 2+2+2+1+1.
-              // This isolates the optical effect of an eight-frame dose from
-              // the already-validated state-aware outside-area holds.
-              if (position < 3) { tp = 2; }
-              else if (position < 5) { tp = 1; }
-            }
-          }
-          else
-          {
-            if (position < 7) { tp = 3; }
-            else if (position == 7) { tp = 1; }
-          }
-          lut[50 + timing_group * 5 + phase] = tp;
-        }
-      }
-    }
-    else
-    {
-      const uint8_t light_boundary = step;
-      const uint8_t dark_boundary = 2 - step;
-      for (uint8_t i = 0; i < light_phases[light_boundary]; ++i)
-      {
-        const uint8_t position = light_position[i];
-        lut[10 + (position >> 2)] |=
-            uint8_t{2} << (6 - ((position & 3) << 1));
-      }
-      for (uint8_t i = 0; i < dark_phases[dark_boundary]; ++i)
-      {
-        const uint8_t position = dark_position[i];
-        lut[20 + (position >> 2)] |=
-            uint8_t{1} << (6 - ((position & 3) << 1));
-      }
-      for (uint8_t timing_group = 0; timing_group < 4; ++timing_group)
-      {
-        for (uint8_t phase = 0; phase < 4; ++phase)
-        {
-          lut[50 + timing_group * 5 + phase] = 1;
-        }
-      }
-    }
-
-    // Groups 00 and 11 remain source-no-drive holds.  Repeated 12-frame tests
-    // showed that reducing VCOM from -1.2 V to -0.4 V greatly accelerated
-    // whiteward drift in untouched black/dark pixels.  Move in the opposite
-    // direction.  Hardware validation over 60 consecutive dirty updates found
-    // the SSD1677 factory-fast value (-2.0 V) neutral for all four untouched
-    // gray levels, so both monochrome differential modes use it while the
-    // four-gray transition passes retain -1.2 V.
-    if (monochrome) { lut[109] = 0x50; }
-    const uint8_t dark_boundary = monochrome ? 0 : uint8_t(2 - step);
-    const uint8_t light_boundary = monochrome ? 2 : step;
-    lut[106] = vsh1[dark_boundary];
-    // Fast gives black-to-white transitions the full twelfth frame and the
-    // calibrated -16 V VSL.  Fastest retains the lower-dose -15 V setting.
-    lut[108] = stronger_mono ? 0x36 : vsl[light_boundary];
-    _send_gray_lut(lut);
-    return _activate(CTRL1_NORMAL, 0x0C, false, true,
-                     !shortened);
   }
 
   bool Panel_SSD1677_4Gray::_activate(uint8_t ctrl1, uint8_t ctrl2,
@@ -938,7 +854,7 @@ namespace lgfx
     return true;
   }
 
-  bool Panel_SSD1677_4Gray::_reset_controller_for_mode2(void)
+  bool Panel_SSD1677_4Gray::_reset_controller_and_face(void)
   {
     _bus->writeCommand(0x12, 8);
     _send_msec = millis();
@@ -962,73 +878,51 @@ namespace lgfx
     return true;
   }
 
-  bool Panel_SSD1677_4Gray::_refresh_quality(const uint8_t* lsb, const uint8_t* msb)
+  bool Panel_SSD1677_4Gray::_ensure_known_face(void)
   {
-    // A sleep/power transition can invalidate the controller's Mode 2 face
-    // parity before the first visible refresh.  Quality is an absolute,
-    // full-screen operation, so recover a deterministic RAM face here rather
-    // than silently dropping the user's first frame.
-    if (!_mode2_face_known && !_reset_controller_for_mode2())
+    if (_mode2_face_known || _reset_controller_and_face()) { return true; }
+    _invalidate_gray_state();
+    return false;
+  }
+
+  bool Panel_SSD1677_4Gray::_refresh_mode1_absolute(
+      const uint8_t* lsb, const uint8_t* msb, const uint8_t* lut)
+  {
+    // Mode 1 needs a known RAM face to map the two middle gray levels.
+    if (!_ensure_known_face())
     {
-      _invalidate_gray_state();
       return false;
     }
 
+    // The ping-pong face exchanges the two middle codes in Mode 1. Swap the
+    // plane destinations on the odd face; 00 black and 11 white are symmetric.
     const auto full = _full_range();
     const uint8_t* bw = _mode2_face_odd ? msb : lsb;
     const uint8_t* red = _mode2_face_odd ? lsb : msb;
     _send_plane(CMD_WRITE_RAM_BW, bw, full, true);
     _send_plane(CMD_WRITE_RAM_RED, red, full, true);
-    _send_gray_lut(lut_quality_oscillating);
-    if (!_activate(CTRL1_NORMAL, 0x07, true, false)) { return false; }
+    _send_gray_lut(lut);
+    // Wait on the BUSY line itself, without the 400 ms refresh-minimum floor.
+    if (!_activate(CTRL1_NORMAL, 0x07, true, false, false)) { return false; }
     _optical_state = optical_state_t::gray4;
     return true;
   }
 
-  bool Panel_SSD1677_4Gray::_refresh_text(const uint8_t* lsb, const uint8_t* msb)
+  bool Panel_SSD1677_4Gray::_refresh_mode2_absolute(
+      const uint8_t* lsb, const uint8_t* msb, const uint8_t* lut)
   {
+    if (!lut || !_ensure_known_face()) { return false; }
+
+    // Mode 2 consumes the group bits written to 0x24/0x26 directly on every
+    // activation. Both RAMs are overwritten, so their command mapping stays
+    // fixed even though the controller advances its ping-pong face. Swapping
+    // these destinations on odd faces would exchange the two middle grays.
     const auto full = _full_range();
-    // The Mode 2 ping-pong face exchanges the physical interpretation of the
-    // two middle codes. Match Quality's parity-aware plane order before the
-    // self-contained white-first waveform; 00 black and 11 white are
-    // symmetric, so a parity error otherwise appears only as dark/light swap.
-    const uint8_t* bw = _mode2_face_odd ? msb : lsb;
-    const uint8_t* red = _mode2_face_odd ? lsb : msb;
-    _send_plane(CMD_WRITE_RAM_BW, bw, full, true);
-    _send_plane(CMD_WRITE_RAM_RED, red, full, true);
-    uint8_t lut[sizeof(lut_factory_quality)] = {};
-    auto set_vs = [&](uint8_t group, uint8_t phase, uint8_t code)
-    {
-      const size_t index = size_t(group) * 10 + (phase >> 2);
-      const uint8_t shift = 6 - 2 * (phase & 3);
-      lut[index] |= uint8_t(code << shift);
-    };
-    auto set_tp = [&](uint8_t phase, uint8_t frames)
-    {
-      lut[50 + size_t(phase >> 2) * 5 + (phase & 3)] = frames;
-    };
-    for (uint8_t phase = 0; phase < 3; ++phase)
-    {
-      for (uint8_t group = 0; group < 4; ++group) { set_vs(group, phase, 2); }
-      set_tp(phase, 8);
-    }
-    for (uint8_t phase = 3; phase < 12; ++phase)
-    {
-      set_vs(3, phase, 1);
-      if (phase <= 9) { set_vs(2, phase, 1); }
-      if (phase <= 4) { set_vs(1, phase, 1); }
-      set_tp(phase, phase == 10 ? 5 : phase == 11 ? 6 : 1);
-    }
-    set_vs(2, 10, 3);
-    for (uint8_t phase = 5; phase <= 9; ++phase) { set_vs(1, phase, 3); }
-    for (size_t i = 100; i < 105; ++i) { lut[i] = 0x22; }
-    lut[105] = 0x17;
-    lut[106] = 0x46;
-    lut[107] = 0xA8;
-    lut[108] = 0x36;
-    lut[109] = 0x30;
+    _send_plane(CMD_WRITE_RAM_BW, lsb, full, true);
+    _send_plane(CMD_WRITE_RAM_RED, msb, full, true);
     _send_gray_lut(lut);
-    if (!_activate(CTRL1_NORMAL, 0x07, true, false)) { return false; }
+    if (!_activate(CTRL1_NORMAL, 0x0C, false, true, false)) { return false; }
+
     _optical_state = optical_state_t::gray4;
     return true;
   }
@@ -1039,59 +933,36 @@ namespace lgfx
     const uint32_t row_bytes = ((_cfg.panel_width + 7) & ~7) >> 3;
     uint8_t* old_lsb = _displayed_buf;
     uint8_t* old_msb = _displayed_buf + _buf_x1_len;
+    const int32_t first_byte = dirty.left >> 3;
+    const int32_t last_byte = dirty.right >> 3;
     for (int32_t y = dirty.top; y <= dirty.bottom; ++y)
     {
-      for (int32_t x = dirty.left; x <= dirty.right; ++x)
+      const size_t row_offset = size_t(y) * row_bytes;
+      for (int32_t b = first_byte; b <= last_byte; ++b)
       {
-        const size_t index = size_t(y) * row_bytes + (x >> 3);
-        const uint8_t mask = uint8_t(0x80u >> (x & 7));
-        if (msb[index] & mask)
-        {
-          old_lsb[index] |= mask;
-          old_msb[index] |= mask;
-        }
-        else
-        {
-          old_lsb[index] &= uint8_t(~mask);
-          old_msb[index] &= uint8_t(~mask);
-        }
+        const size_t index = row_offset + b;
+        const uint8_t mask = dirty_byte_mask(b, dirty);
+        const uint8_t mono = msb[index] & mask;
+        old_lsb[index] = (old_lsb[index] & uint8_t(~mask)) | mono;
+        old_msb[index] = (old_msb[index] & uint8_t(~mask)) | mono;
       }
     }
   }
 
-  bool Panel_SSD1677_4Gray::_refresh_fast(const uint8_t* lsb, const uint8_t* msb,
-                                         const range_rect_t& current_dirty)
+  bool Panel_SSD1677_4Gray::_refresh_mode2_fastest(
+      const uint8_t* lsb, const uint8_t* msb,
+      const range_rect_t& current_dirty)
   {
     if (!_displayed_valid)
     {
-      return _refresh_quality(lsb, msb);
+      // Establish a complete optical/history baseline without leaving Mode 2.
+      return _refresh_mode2_absolute(lsb, msb, lut_fast);
     }
+    if (!_ensure_known_face()) { return false; }
 
-    // Fast retains the 12-frame activation and stable outside-area holds, and
-    // uses a stronger lightening dose than the eight-frame Fastest path to
-    // reduce black-to-white ghosting in the rewritten rectangle.
-    if (!_activate_transition_step(lsb, msb, current_dirty, 2, true, true, true))
-    {
-      return false;
-    }
-
-    _optical_state = optical_state_t::mono_synchronized;
-    _remember_mono_dirty(msb, current_dirty);
-    return true;
-  }
-
-  bool Panel_SSD1677_4Gray::_refresh_fastest(const uint8_t* lsb, const uint8_t* msb,
-                                            const range_rect_t& current_dirty)
-  {
-    if (!_displayed_valid)
-    {
-      return _refresh_quality(lsb, msb);
-    }
-
-    if (!_activate_transition_step(lsb, msb, current_dirty, 2, true, true))
-    {
-      return false;
-    }
+    _send_transition_planes(msb, current_dirty);
+    _send_gray_lut(lut_fastest);
+    if (!_activate(CTRL1_NORMAL, 0x0C, false, true, false)) { return false; }
 
     _optical_state = optical_state_t::mono_synchronized;
     _remember_mono_dirty(msb, current_dirty);
@@ -1123,16 +994,16 @@ namespace lgfx
     switch (mode)
     {
     case epd_mode_t::epd_quality:
-      success = _refresh_quality(planeL, planeM);
+      success = _refresh_mode1_absolute(planeL, planeM, lut_quality);
       break;
     case epd_mode_t::epd_text:
-      success = _refresh_text(planeL, planeM);
+      success = _refresh_mode1_absolute(planeL, planeM, lut_text);
       break;
     case epd_mode_t::epd_fast:
-      success = _refresh_fast(planeL, planeM, current_dirty);
+      success = _refresh_mode2_absolute(planeL, planeM, lut_fast);
       break;
     case epd_mode_t::epd_fastest:
-      success = _refresh_fastest(planeL, planeM, current_dirty);
+      success = _refresh_mode2_fastest(planeL, planeM, current_dirty);
       break;
     default:
       success = false;
@@ -1141,7 +1012,9 @@ namespace lgfx
 
     if (success)
     {
-      if (mode == epd_mode_t::epd_quality || mode == epd_mode_t::epd_text)
+      // Every absolute refresh (including Fastest's fallback) leaves the full
+      // 2-bit planes on glass, so record them as the differential baseline.
+      if (_optical_state == optical_state_t::gray4)
       {
         _remember_displayed(planeL, planeM);
       }

--- a/src/lgfx/v1/panel/Panel_SSD1677.hpp
+++ b/src/lgfx/v1/panel/Panel_SSD1677.hpp
@@ -29,7 +29,7 @@ namespace lgfx
   /*
     SSD1677 (GDEQ0426T82 / 800x480) E-Paper panel driver.
 
-    Buffer / coordinate model (EPD native, see docs/Panel_SSD1677_rebuild_plan.md):
+    Buffer / coordinate model (EPD native):
       - Panel native orientation = landscape 800(X=source) x 480(Y=gate).
       - 8 pixels per byte are packed along X (source) direction, matching the
         controller's source-shift scan order. byte = 8 consecutive X pixels.
@@ -41,8 +41,9 @@ namespace lgfx
       - _draw_pixel stores an abstract gray level v(0=black..3=white) split into
         two bit planes: planeL = v&1 (-> BW RAM 0x24), planeM = v&2 (-> RED RAM 0x26).
       - The hardware RAM encoding is generated at send time per epd_mode:
-          quality/text : absolute four-gray LUT (planes sent as-is)
-          fast/fastest : monochrome differential LUT vs displayed history
+          quality/text : Mode 1 absolute four-gray update
+          fast         : Mode 2 absolute four-gray update
+          fastest      : Mode 2 monochrome differential update vs history
   */
   struct Panel_SSD1677 : public Panel_HasBuffer
   {
@@ -72,7 +73,7 @@ namespace lgfx
 
   protected:
 
-    // Longer busy ceiling for the 480x800 panel; full refresh ~3.8s.
+    // Minimum wait used by the base monochrome refresh path.
     static constexpr unsigned long _refresh_msec = 400;
 
     range_rect_t _range_old;
@@ -100,9 +101,8 @@ namespace lgfx
 
     const uint8_t* getInitCommands(uint8_t listno) const override
     {
-      // SSD1677 power-up sequence (community-sdk EInkDisplay, non-X3).
-      // panel native: 800(X=source) x 480(Y=gate). 0x01 sets 480 gates.
-      // RAM window / auto-clear / power-on are issued in _after_wake (computed).
+      // SSD1677 power-up sequence for the native 800x480 panel.
+      // 0x01 configures 480 gates; RAM setup and power-on follow in _after_wake.
       static constexpr uint8_t list0[] = {
           0x12, 0 + CMD_INIT_DELAY, 10,             // SW Reset + 10 msec
           0x18, 1, 0x80,                            // Temp sensor: internal
@@ -122,6 +122,8 @@ namespace lgfx
   {
     ~Panel_SSD1677_4Gray(void) override;
     bool init(bool use_reset) override;
+    void setSleep(bool flg) override;
+    void setPowerSave(bool flg) override;
     void display(uint_fast16_t x, uint_fast16_t y, uint_fast16_t w, uint_fast16_t h) override;
 
   protected:
@@ -143,22 +145,19 @@ namespace lgfx
     range_rect_t _full_range(void) const;
     void _send_gray_lut(const uint8_t* lut);
     void _remember_displayed(const uint8_t* lsb, const uint8_t* msb);
-    void _send_transition_plane(uint8_t command,
-                                const uint8_t* new_lsb, const uint8_t* new_msb,
-                                const range_rect_t& dirty, uint8_t step,
-                                bool monochrome);
-    bool _activate_transition_step(const uint8_t* new_lsb, const uint8_t* new_msb,
-                                   const range_rect_t& dirty, uint8_t step,
-                                   bool monochrome, bool shortened = false,
-                                   bool stronger_mono = false);
+    void _send_transition_planes(const uint8_t* new_msb,
+                                 const range_rect_t& dirty);
     void _remember_mono_dirty(const uint8_t* msb, const range_rect_t& dirty);
     bool _activate(uint8_t ctrl1, uint8_t ctrl2, bool powers_down,
                    bool mode2_activation, bool enforce_refresh_minimum = true);
-    bool _reset_controller_for_mode2(void);
-    bool _refresh_quality(const uint8_t* lsb, const uint8_t* msb);
-    bool _refresh_text(const uint8_t* lsb, const uint8_t* msb);
-    bool _refresh_fast(const uint8_t* lsb, const uint8_t* msb, const range_rect_t& dirty);
-    bool _refresh_fastest(const uint8_t* lsb, const uint8_t* msb, const range_rect_t& dirty);
+    bool _reset_controller_and_face(void);
+    bool _ensure_known_face(void);
+    bool _refresh_mode1_absolute(const uint8_t* lsb, const uint8_t* msb,
+                                 const uint8_t* lut);
+    bool _refresh_mode2_absolute(const uint8_t* lsb, const uint8_t* msb,
+                                 const uint8_t* lut);
+    bool _refresh_mode2_fastest(const uint8_t* lsb, const uint8_t* msb,
+                                const range_rect_t& dirty);
   };
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Brings Panel_SSD1677 up to the finalized four-mode refresh design, replacing the previous intermediate implementation (single squashed commit):

- **quality / text / fast** dispatch to a shared absolute refresh path — Mode 2 face-parity recovery, parity-aware full-frame transfer, one activation — whose only per-mode difference is a static LUT:
  - *quality*: an oscillation prefix erases image history with a group-balanced net drive (no ghost accumulation over repeated refreshes); the tone-forming tail runs twice for endpoint stability.
  - *text*: white-first waveform that forms the four levels without a black flash.
  - *fast*: absolute 4-gray waveform with the black darken return shortened to 28 frames.
- **fastest** runs a differential monochrome update with software-computed transition groups: a 2-frame reverse-polarity prepulse plus an 8-frame dose, state-aware holds outside the updated region, VCOM matched to the panel offset so held pixels sit field-free. Its fallback records the display baseline, so fastest-only usage no longer degrades into a full refresh on every update.
- Ping-pong face parity survives mode changes; display history is rebuilt after sleep/power transitions; absolute refreshes wait on BUSY without the 400 ms refresh-minimum floor; waveform-tuning helpers stay out of the public panel API.

The waveforms were tuned and verified on the PaperMono hardware.

## Notes

- No other code in this repository references the reworked internals (the panel is not wired into autodetect here), so the change is self-contained.
- Fork preflight: all six build workflows green.