### PR TITLE
Fix SPI bus pins left in open-drain mode on ESP-IDF v6

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -92,6 +92,10 @@ Contributors:
  #include <esp_private/gpio.h>
 #endif
 
+#if __has_include(<hal/gpio_ll.h>)
+ #include <hal/gpio_ll.h>
+#endif
+
 #if defined (ESP_IDF_VERSION_VAL)
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
   #include <hal/gpio_hal.h>
@@ -710,6 +714,22 @@ namespace lgfx
         devcfg.queue_size = 1;
         if (ESP_OK != spi_bus_add_device(static_cast<spi_host_device_t>(spi_host), &devcfg, &_spi_dev_handle[spi_host])) {
           ESP_LOGW("LGFX", "Failed to spi_bus_add_device. ");
+        }
+      }
+
+      // SPIバスのピンを push-pull 出力へ明示的に戻す。
+      // pinMode の input 系設定はパッドを open-drain にするが、ESP-IDF v6 以降の
+      // spi_bus_initialize はピンの open-drain 設定を解除しないため、直前のピン状態が
+      // 残っていると SCLK/MOSI が open-drain 駆動となり、高クロックで波形が立ち上がらない。
+      for (int pin : { spi_sclk, spi_mosi, spi_miso })
+      {
+        if ((size_t)pin < GPIO_NUM_MAX)
+        {
+#if __has_include(<hal/gpio_ll.h>)
+          gpio_ll_od_disable(&GPIO, (gpio_num_t)pin);
+#else // ESP-IDF v3 系 (無印 ESP32 のみ)
+          GPIO.pin[pin].pad_driver = 0;
+#endif
         }
       }
 

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -96,6 +96,10 @@ Contributors:
  #include <hal/gpio_ll.h>
 #endif
 
+#if __has_include(<esp_rom_gpio.h>)
+ #include <esp_rom_gpio.h>
+#endif
+
 #if defined (ESP_IDF_VERSION_VAL)
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
   #include <hal/gpio_hal.h>
@@ -233,29 +237,6 @@ namespace lgfx
   template <typename T>
   static inline typename std::enable_if<!has_func_sel<T>::value && !has_func_in_sel<T>::value, uint32_t>::type
   get_gpio_func_in_sel(T& cfg) { return cfg.in_sel; }
-
-  // ------- func_out_sel detect -------
-  // func_sel/funcn_out_sel/out_sel: A type characteristic that detects the presence of members
-  template <typename T, typename = void>
-  struct has_funcn_out_sel : std::false_type {};
-
-  template <typename T>
-  struct has_funcn_out_sel<T, decltype(void(std::declval<T&>().funcn_out_sel))> : std::true_type {};
-
-  // func_sel exist
-  template <typename T>
-  static inline typename std::enable_if<has_func_sel<T>::value>::type
-  set_gpio_func_out_sel(T& cfg, uint32_t val) { cfg.func_sel = val; }
-
-  // func_sel does not exist, funcn_out_sel exist 
-  template <typename T>
-  static inline typename std::enable_if<!has_func_sel<T>::value && has_funcn_out_sel<T>::value>::type
-  set_gpio_func_out_sel(T& cfg, uint32_t val) { cfg.funcn_out_sel = val; }
-  
-  // func_sel && funcn_out_sel does not exist  (use out_sel)
-  template <typename T>
-  static inline typename std::enable_if<!has_func_sel<T>::value && !has_funcn_out_sel<T>::value>::type
-  set_gpio_func_out_sel(T& cfg, uint32_t val) { cfg.out_sel = val; }
 
   static int search_pin_number(int peripheral_sig)
   {
@@ -460,9 +441,11 @@ namespace lgfx
 
     *io_mux_reg = io_mux_val;
 
-#if defined(CONFIG_IDF_TARGET_ESP32C61)
-    GPIO.pinn[pin].pinn_pad_driver = (mode == pin_mode_t::output) ? 0 : 1; // 1 = OpenDrain / 0 = normal output
-#else
+    // レジスタ構造体のメンバ名はチップ毎に異なるため、命名差を吸収する LL/ROM API へ委譲する
+#if __has_include(<hal/gpio_ll.h>)
+    if (mode == pin_mode_t::output) { gpio_ll_od_disable(&GPIO, (gpio_num_t)pin); }
+    else                            { gpio_ll_od_enable (&GPIO, (gpio_num_t)pin); } // OpenDrain
+#else // ESP-IDF v3 系 (無印 ESP32 のみ)
     GPIO.pin[pin].pad_driver = (mode == pin_mode_t::output) ? 0 : 1; // 1 = OpenDrain / 0 = normal output
 #endif
     if (mode != pin_mode_t::output) {
@@ -470,10 +453,10 @@ namespace lgfx
     }
     auto gpio_en_reg = gpio_en_regs[((pin >> 5) << 1) + 1];
     *gpio_en_reg = 1u << (pin & 31);
-#if defined(CONFIG_IDF_TARGET_ESP32C61)
-    set_gpio_func_out_sel(GPIO.funcn_out_sel_cfg[pin], SIG_GPIO_OUT_IDX);
-#else
-    set_gpio_func_out_sel(GPIO.func_out_sel_cfg[pin], SIG_GPIO_OUT_IDX);
+#if __has_include(<esp_rom_gpio.h>)
+    esp_rom_gpio_connect_out_signal(pin, SIG_GPIO_OUT_IDX, false, false);
+#else // ESP-IDF v3 系 (無印 ESP32 のみ)
+    GPIO.func_out_sel_cfg[pin].func_sel = SIG_GPIO_OUT_IDX;
 #endif
   }
 


### PR DESCRIPTION
## Root cause

On ESP-IDF v6, SPI panels can stop responding when the bus pins were configured as inputs beforehand (e.g. by board autodetection probing the bus lines):

1. `pinMode()` implements inputs as open-drain outputs driven high, which sets the pad's `pad_driver` (open-drain) flag.
2. Up to ESP-IDF v5, `spi_bus_initialize()` configured the bus pins via `gpio_set_direction(..., GPIO_MODE_INPUT_OUTPUT)`, which cleared the open-drain flag as a side effect.
3. ESP-IDF v6 routes the pins with `gpio_matrix_output()` only and no longer touches `pad_driver` (`components/esp_driver_spi/src/gpspi/spi_common.c`).

SCLK/MOSI then remain open-drain; through a weak pull-up the lines cannot rise at MHz clock rates and the panel never receives a valid command.

## Fix

- **1st commit**: explicitly restore the SPI bus pins to push-pull after `spi_bus_initialize()`. Harmless on all IDF versions (v5 and earlier already end up in this state).
- **2nd commit**: replace the chip-specific register-field `#ifdef` branches in `pinMode()` (`pad_driver` / `func_out_sel`) with `gpio_ll_od_enable/od_disable` and `esp_rom_gpio_connect_out_signal`, whose per-chip implementations absorb the register naming differences, so future chips need no new branches.

## Verification

- ESP32-S3 hardware + ESP-IDF v6.0.1: panel detection, drawing, and `readRect` round-trip verification pass; no regression on v5.5.4
- Builds: esp32s3 (ESP-IDF v5.5.4 / v6.0.1), esp32, esp32c61 (v5.5.4), Arduino-ESP32 2.x (ESP-IDF v4.4)
- CI on the fork: all six workflows green
