### PR TITLE
Clear stale open-drain pad state in QSPI, parallel bus, and PWM backlight init

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -19,6 +19,7 @@ Contributors:
 #include <sdkconfig.h>
 
 #include "Light_PWM.hpp"
+#include "common.hpp"
 
 #if defined ( ARDUINO )
  #include <esp32-hal-ledc.h>
@@ -65,6 +66,15 @@ namespace lgfx
 
   bool Light_PWM::init(uint8_t brightness)
   {
+    // The LEDC driver does not fully normalize the pad state: the open-drain
+    // flag is never cleared, and ESP-IDF v6 no longer selects the GPIO
+    // function in IO_MUX. Reconfigure the pin as a push-pull GPIO output
+    // first, latching it to the "off" level to avoid a visible glitch.
+    if ((size_t)_cfg.pin_bl < GPIO_NUM_MAX)
+    {
+      if (_cfg.invert) { gpio_hi(_cfg.pin_bl); } else { gpio_lo(_cfg.pin_bl); }
+      lgfx::pinMode(_cfg.pin_bl, pin_mode_t::output);
+    }
 
 #if defined ( ARDUINO )
 

--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -21,13 +21,14 @@ Contributors:
 #include "Light_PWM.hpp"
 #include "common.hpp"
 
+#include <driver/gpio.h>
+
 #if defined ( ARDUINO )
  #include <esp32-hal-ledc.h>
  #if __has_include(<esp_arduino_version.h>)
   #include <esp_arduino_version.h>
  #endif
 #else
- #include <driver/gpio.h>
  #include <driver/ledc.h>
 #endif
 
@@ -40,7 +41,7 @@ Contributors:
   #endif
  #endif
  #if !defined LGFX_LEDCINIT // pre-3.x cores, including 1.x where ESP_ARDUINO_VERSION is absent
-  #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) { ledcSetup(pwm_channel, freq, bits); ledcAttachPin(pin_bl, pwm_channel); }
+  #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) ( ledcSetup(pwm_channel, freq, bits) > 0 && (ledcAttachPin(pin_bl, pwm_channel), true) )
   #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pwm_channel, duty)
  #endif
 
@@ -66,19 +67,21 @@ namespace lgfx
 
   bool Light_PWM::init(uint8_t brightness)
   {
+    if ((size_t)_cfg.pin_bl >= GPIO_NUM_MAX || !GPIO_IS_VALID_OUTPUT_GPIO((gpio_num_t)_cfg.pin_bl))
+    {
+      return false;
+    }
+
     // The LEDC driver does not fully normalize the pad state: the open-drain
     // flag is never cleared, and ESP-IDF v6 no longer selects the GPIO
     // function in IO_MUX. Reconfigure the pin as a push-pull GPIO output
     // first, latching it to the "off" level to avoid a visible glitch.
-    if ((size_t)_cfg.pin_bl < GPIO_NUM_MAX)
-    {
-      if (_cfg.invert) { gpio_hi(_cfg.pin_bl); } else { gpio_lo(_cfg.pin_bl); }
-      lgfx::pinMode(_cfg.pin_bl, pin_mode_t::output);
-    }
+    if (_cfg.invert) { gpio_hi(_cfg.pin_bl); } else { gpio_lo(_cfg.pin_bl); }
+    lgfx::pinMode(_cfg.pin_bl, pin_mode_t::output);
 
 #if defined ( ARDUINO )
 
-    LGFX_LEDCINIT(_cfg.pin_bl, _cfg.freq, PWM_BITS, _cfg.pwm_channel);
+    bool result = LGFX_LEDCINIT(_cfg.pin_bl, _cfg.freq, PWM_BITS, _cfg.pwm_channel);
 
 #else // esp-idf
 
@@ -97,7 +100,7 @@ namespace lgfx
   #endif
  #endif
     };
-    ledc_channel_config(&ledc_channel);
+    bool result = (ESP_OK == ledc_channel_config(&ledc_channel));
     static ledc_timer_config_t ledc_timer;
     {
       ledc_timer.speed_mode = LGFX_LEDC_SPEED_MODE;     // timer mode
@@ -105,10 +108,11 @@ namespace lgfx
       ledc_timer.freq_hz = _cfg.freq;                        // frequency of PWM signal
       ledc_timer.timer_num = ledc_channel.timer_sel;    // timer index
     };
-    ledc_timer_config(&ledc_timer);
+    result = (ESP_OK == ledc_timer_config(&ledc_timer)) && result;
 
 #endif
 
+    if (!result) { return false; }
     setBrightness(brightness);
     return true;
   }

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -92,6 +92,8 @@ Contributors:
  #include <esp_private/gpio.h>
 #endif
 
+#include <initializer_list>
+
 #if __has_include(<hal/gpio_ll.h>)
  #include <hal/gpio_ll.h>
 #endif
@@ -625,6 +627,25 @@ namespace lgfx
 
 // ------------------------------------------------------------------------
 
+    // Clear stale open-drain state on the bus pins.
+    // spi_bus_initialize does not clear the pad open-drain flag (ESP-IDF v6
+    // no longer configures it at all), so a pin left in open-drain mode by a
+    // previous use may not rise fast enough at typical SPI clock rates.
+    static void clear_open_drain(std::initializer_list<int> pins)
+    {
+      for (int pin : pins)
+      {
+        if ((size_t)pin < GPIO_NUM_MAX)
+        {
+#if __has_include(<hal/gpio_ll.h>)
+          gpio_ll_od_disable(&GPIO, (gpio_num_t)pin);
+#else // ESP-IDF v3 (plain ESP32 only)
+          GPIO.pin[pin].pad_driver = 0;
+#endif
+        }
+      }
+    }
+
     cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
     {
       return init(spi_host, spi_sclk, spi_miso, spi_mosi, 0); // SPI_DMA_CH_AUTO;
@@ -700,21 +721,7 @@ namespace lgfx
         }
       }
 
-      // SPIバスのピンを push-pull 出力へ明示的に戻す。
-      // pinMode の input 系設定はパッドを open-drain にするが、ESP-IDF v6 以降の
-      // spi_bus_initialize はピンの open-drain 設定を解除しないため、直前のピン状態が
-      // 残っていると SCLK/MOSI が open-drain 駆動となり、高クロックで波形が立ち上がらない。
-      for (int pin : { spi_sclk, spi_mosi, spi_miso })
-      {
-        if ((size_t)pin < GPIO_NUM_MAX)
-        {
-#if __has_include(<hal/gpio_ll.h>)
-          gpio_ll_od_disable(&GPIO, (gpio_num_t)pin);
-#else // ESP-IDF v3 系 (無印 ESP32 のみ)
-          GPIO.pin[pin].pad_driver = 0;
-#endif
-        }
-      }
+      clear_open_drain({ spi_sclk, spi_mosi, spi_miso });
 
       writereg(SPI_USER_REG(spi_port), SPI_USR_MOSI | SPI_USR_MISO | SPI_DOUTDIN);  // need SD card access (full duplex setting)
       writereg(SPI_CTRL_REG(spi_port), 0);
@@ -796,6 +803,8 @@ namespace lgfx
       }
 
 #pragma GCC diagnostic pop
+
+      clear_open_drain({ spi_sclk, spi_io0, spi_io1, spi_io2, spi_io3 });
 
       writereg(SPI_USER_REG(spi_port), SPI_USR_MOSI | SPI_USR_MISO | SPI_DOUTDIN);  // need SD card access (full duplex setting)
       writereg(SPI_CTRL_REG(spi_port), 0);

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.cpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.cpp
@@ -96,6 +96,13 @@ namespace lgfx
 
   bool Bus_Parallel16::init(void)
   {
+    // The GPIO matrix routing used below does not configure pad direction /
+    // open-drain, so normalize the data pins as push-pull GPIO outputs first.
+    for (int pin : _cfg.pin_data)
+    {
+      lgfx::pinMode(pin, pin_mode_t::output);
+    }
+
     _init_pin();
 
     for (size_t i = 0; i < 3; ++i)

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.cpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.cpp
@@ -96,6 +96,13 @@ namespace lgfx
 
   bool Bus_Parallel8::init(void)
   {
+    // The GPIO matrix routing used below does not configure pad direction /
+    // open-drain, so normalize the data pins as push-pull GPIO outputs first.
+    for (int pin : _cfg.pin_data)
+    {
+      lgfx::pinMode(pin, pin_mode_t::output);
+    }
+
     _init_pin();
 
     for (size_t i = 0; i < 3; ++i)

--- a/src/lgfx/v1/platforms/esp32s3/Bus_Parallel16.cpp
+++ b/src/lgfx/v1/platforms/esp32s3/Bus_Parallel16.cpp
@@ -80,6 +80,14 @@ namespace lgfx
 
   bool Bus_Parallel16::init(void)
   {
+    // esp_lcd_new_i80_bus does not configure pad direction / open-drain, so
+    // normalize the data pins as push-pull GPIO outputs first (same
+    // normalization used by Bus_EPD).
+    for (int pin : _cfg.pin_data)
+    {
+      lgfx::pinMode(pin, pin_mode_t::output);
+    }
+
     _init_pin();
 
     for (size_t i = 0; i < 3; ++i)

--- a/src/lgfx/v1/platforms/esp32s3/Bus_Parallel8.cpp
+++ b/src/lgfx/v1/platforms/esp32s3/Bus_Parallel8.cpp
@@ -80,6 +80,14 @@ namespace lgfx
 
   bool Bus_Parallel8::init(void)
   {
+    // esp_lcd_new_i80_bus does not configure pad direction / open-drain, so
+    // normalize the data pins as push-pull GPIO outputs first (same
+    // normalization used by Bus_EPD).
+    for (int pin : _cfg.pin_data)
+    {
+      lgfx::pinMode(pin, pin_mode_t::output);
+    }
+
     _init_pin();
 
     for (size_t i = 0; i < 3; ++i)


### PR DESCRIPTION
Follow-up to #893. ESP-IDF v6 delegates pad state management (open-drain etc.) to the peripheral user, and an audit of the remaining init paths found three more places that relied on driver side effects that no longer exist on v6 — or never existed on any version:

1. **`spi::initQuad` (QSPI panels)** — same issue as #893: `spi_bus_initialize()` on v6 no longer clears the pad open-drain flag, and #893 covered only the single-bit `spi::init` path. The pad restoration is factored into a shared `clear_open_drain()` helper and applied to SCLK/IO0-3 as well.
2. **`Light_PWM::init` (PWM backlight)** — the LEDC driver never clears the open-drain flag (on any IDF version), and v6 no longer selects the GPIO function in IO_MUX either. The pin is now explicitly normalized as a push-pull GPIO output at the start of init, latched to the "off" level first to avoid a visible glitch.
3. **`Bus_Parallel8/16` on ESP32-S2/S3** — neither `esp_lcd_new_i80_bus` (S3; its `gpio_set_direction` call was removed in ESP-IDF v5.4) nor the plain GPIO matrix routing (S2) configures pad direction / open-drain on the data pins. The same `pinMode(output)` normalization already used by `Bus_EPD` is applied. The WR/RD/RS control pins were already normalized via `gpio_set_direction` and are unaffected.

A fourth commit makes `Light_PWM::init` report failure: it previously ignored the LEDC API results and always returned `true`. It now fails early for pins that cannot be driven as outputs and propagates LEDC setup errors. (`Panel_Device::init` ignores the return value, so panel initialization behavior is unchanged.)

## Verification

Each fix was verified A/B on hardware, with the pads deliberately set to open-drain before init (the state left behind by e.g. probing pins as inputs), checking the `GPIO_PINn.pad_driver` register after init:

- **initQuad**: ESP32-S3 device with a CO5300 QSPI panel + ESP-IDF v6.0.1 — without the fix the pads remain open-drain after init; with it they are restored to push-pull. No regression on v5.5.4.
- **Light_PWM**: ESP32 device with PWM backlight on GPIO32 + ESP-IDF v6.0.1 — same A/B result.
- **Bus_Parallel8 (S3)**: scope-free rig counting bus edges with PCNT — with the data pins left open-drain, a 0x00/0xFF test pattern produces 0 edges on D0/D7 while WR strobes normally; with the fix the expected edge counts appear.
- Builds: Arduino-ESP32 2.x / 3.x (esp32, esp32s3), ESP-IDF v6.0.1 (esp32, esp32s2, esp32s3), ESP-IDF v5.5.4 (esp32s3).
- CI on the fork: build workflows green.
