### PR TITLE
Fix pinMode pulls not driven on ESP-IDF v6 (SOC_GPIO_SUPPORT_RTC_INDEPENDENT removed)

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -84,8 +84,16 @@ Contributors:
  #include <esp_arduino_version.h>
 #endif
 
-#ifndef SOC_GPIO_SUPPORT_RTC_INDEPENDENT
-#define SOC_GPIO_SUPPORT_RTC_INDEPENDENT 0
+// Whether the digital pads (pulls in IO_MUX) work independently of the RTC IO
+// domain; only the plain ESP32 needs the RTC-domain path for RTC-capable pins.
+// ESP-IDF v6 removed the SOC_GPIO_SUPPORT_RTC_INDEPENDENT macro, so derive
+// the value from the build target when it is absent.
+#if defined (SOC_GPIO_SUPPORT_RTC_INDEPENDENT)
+ #define LGFX_GPIO_RTC_INDEPENDENT SOC_GPIO_SUPPORT_RTC_INDEPENDENT
+#elif defined (CONFIG_IDF_TARGET) && !defined (CONFIG_IDF_TARGET_ESP32)
+ #define LGFX_GPIO_RTC_INDEPENDENT 1
+#else
+ #define LGFX_GPIO_RTC_INDEPENDENT 0
 #endif
 
 #if __has_include(<esp_private/gpio.h>)
@@ -416,7 +424,7 @@ namespace lgfx
     auto io_mux_val = *io_mux_reg; // &  ~(FUN_PU_M | FUN_PD_M | SLP_PU_M | SLP_PD_M | MCU_SEL_M);
 
 #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
-    if (!SOC_GPIO_SUPPORT_RTC_INDEPENDENT && rtc_gpio_is_valid_gpio(gpio_num)) {
+    if (!LGFX_GPIO_RTC_INDEPENDENT && rtc_gpio_is_valid_gpio(gpio_num)) {
       rtc_gpio_deinit(gpio_num);
       if (mode == pin_mode_t::input_pulldown)
       { rtc_gpio_pulldown_en((gpio_num_t)pin); }


### PR DESCRIPTION
ESP-IDF v6 removed the `SOC_GPIO_SUPPORT_RTC_INDEPENDENT` soc capability macro. `pinMode()` treated the missing macro as 0, which routes RTC-capable pins through the RTC-domain pull path that is only appropriate for the plain ESP32. On ESP32-S2/S3 (and other chips whose digital pads are independent of the RTC domain) that path does not drive the pad pulls at all: `input_pullup` left the IO_MUX `FUN_PU` bit clear and the line never rose. Anything relying on `pinMode` pulls without an external resistor — e.g. software I2C probing — silently loses its pull-ups on ESP-IDF v6.

## Fix

Map the capability to an internal `LGFX_GPIO_RTC_INDEPENDENT` macro: use the SoC-provided value when available (ESP-IDF v5 and earlier), otherwise derive it from the build target — only the plain ESP32 needs the RTC path. This mirrors the internal `GPIO_RTCIO_ARE_INDEPENDENT` logic ESP-IDF v6 itself uses, and avoids re-defining a macro that ESP-IDF has officially retired.

## Verification

Measured on ESP32-S3 hardware with a floating RTC-capable pin (GPIO4), applying `input_pullup` / `input_pulldown` / `input` and reading back the input level and the IO_MUX pull bits:

| | ESP-IDF v5.5.4 | v6.0.1 before | v6.0.1 after |
|---|---|---|---|
| `input_pullup` | high, `FUN_PU=1` | **low, `FUN_PU=0`** | high, `FUN_PU=1` |

- No regression on v5.5.4 (macro still provided by the SoC caps → same value as before)
- No behavior change for the plain ESP32 (derivation yields 0, matching the previous state)
- Builds: Arduino-ESP32 2.x / 3.x (esp32, esp32s3), ESP-IDF v6.0.1 (esp32, esp32s2, esp32s3), v5.5.4 (esp32s3)
- CI on the fork: build workflows green
