### PR TITLE
Prevent VLW spaces from erasing previous rows

### DIFF
--- a/src/lgfx/v1/lgfx_fonts.cpp
+++ b/src/lgfx/v1/lgfx_fonts.cpp
@@ -1910,14 +1910,19 @@ label_nextbyte: /// 次のデータを取得する;
     int32_t sy = 65536 * style->size_y;
     y += (metrics->y_offset * sy) >> 16;
 
-    if (!this->getUnicodeIndex(code, &gNum)) {
-      if (code != 0x20) {
-        return drawCharDummy(gfx, x, y, this->spaceWidth, metrics->height, style, filled_x);
-      }
-      // Some VLW exporters omit the space glyph; for such fonts, keep the
-      // guessed advance instead of rendering the missing-glyph box.
-      gNum = 0xFFFF;
+    if (code == 0x20) {
+      // A space only advances the cursor. Some VLW exporters emit a blank
+      // bitmap with offsets outside the line; drawing it can erase prior rows.
       buffer[2] = getSwap32(this->spaceWidth);
+      if (this->getUnicodeIndex(code, &gNum)) {
+        file->preRead();
+        file->seek(36 + gNum * 28); // xAdvance in the glyph header
+        file->read((uint8_t*)&buffer[2], 4);
+        file->postRead();
+      }
+      gNum = 0xFFFF;
+    } else if (!this->getUnicodeIndex(code, &gNum)) {
+      return drawCharDummy(gfx, x, y, this->spaceWidth, metrics->height, style, filled_x);
     } else {
       file->preRead();
       file->seek(28 + gNum * 28);


### PR DESCRIPTION
A space character in a VLW font only needs to advance the cursor. Some VLW exporters emit a blank bitmap for the space glyph whose offsets fall outside the current line, and `drawChar` drew that bitmap, which erased the rows above the text.

- Handle `0x20` before the glyph lookup. When the font has a space glyph, read its `xAdvance` from the glyph header; otherwise keep the guessed `spaceWidth`. The bitmap itself is never rendered.
- Other missing glyphs still go through `drawCharDummy` as before.

## Verification

- Fork CI: all build workflows green.
- No VLW font with a blank-bitmap space is at hand here, so the rendering change itself is not hardware-verified in this PR.
