### PR TITLE
lgfx_user: prefer driver/i2c_master.h over the legacy driver/i2c.h

### DIFF
--- a/src/lgfx_user/LGFX_ESP32S2_MakerabsParallelTFTwithTouch.hpp
+++ b/src/lgfx_user/LGFX_ESP32S2_MakerabsParallelTFTwithTouch.hpp
@@ -3,7 +3,11 @@
 #define LGFX_USE_V1
 
 #include <LovyanGFX.hpp>
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 // LGFX for Makerfabs ESP32-S2-Parallel-TFT-with-Touch
 // https://github.com/Makerfabs/Makerfabs-ESP32-S2-Parallel-TFT-with-Touch/

--- a/src/lgfx_user/LGFX_ESP32S3_RGB_ESP32-8048S043.h
+++ b/src/lgfx_user/LGFX_ESP32S3_RGB_ESP32-8048S043.h
@@ -5,7 +5,11 @@
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
 
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 class LGFX : public lgfx::LGFX_Device
 {

--- a/src/lgfx_user/LGFX_ESP32S3_RGB_MakerfabsParallelTFTwithTouch40.h
+++ b/src/lgfx_user/LGFX_ESP32S3_RGB_MakerfabsParallelTFTwithTouch40.h
@@ -4,7 +4,11 @@
 
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 class LGFX : public lgfx::LGFX_Device
 {

--- a/src/lgfx_user/LGFX_ESP32S3_RGB_MakerfabsParallelTFTwithTouch43.h
+++ b/src/lgfx_user/LGFX_ESP32S3_RGB_MakerfabsParallelTFTwithTouch43.h
@@ -4,7 +4,11 @@
 
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 class LGFX : public lgfx::LGFX_Device
 {

--- a/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C050.h
+++ b/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C050.h
@@ -3,7 +3,11 @@
 
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 // LGFX for Elecrow 5" 800x480 ESP32 RGB touch display (WZ8048C050)
 // https://www.elecrow.com/esp32-display-5-inch-hmi-display-rgb-tft-lcd-touch-screen-support-lvgl.html

--- a/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C070.h
+++ b/src/lgfx_user/LGFX_Elecrow_ESP32_Display_WZ8048C070.h
@@ -3,7 +3,11 @@
 
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 // LGFX for Elecrow 7" 800x480 ESP32 RGB touch display (WZ8048C070)
 // https://www.elecrow.com/esp32-display-7-inch-hmi-display-rgb-tft-lcd-touch-screen-support-lvgl.html

--- a/src/lgfx_user/LGFX_Makerfabs_MaTouchESP32S3ParallelTFTwithTouch7.h
+++ b/src/lgfx_user/LGFX_Makerfabs_MaTouchESP32S3ParallelTFTwithTouch7.h
@@ -4,7 +4,11 @@
 
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 class LGFX : public lgfx::LGFX_Device
 {

--- a/src/lgfx_user/LGFX_Sunton_ESP32-8048S050.h
+++ b/src/lgfx_user/LGFX_Sunton_ESP32-8048S050.h
@@ -5,7 +5,11 @@
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
 
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 class LGFX : public lgfx::LGFX_Device
 {

--- a/src/lgfx_user/LGFX_Sunton_ESP32-8048S070.h
+++ b/src/lgfx_user/LGFX_Sunton_ESP32-8048S070.h
@@ -5,7 +5,11 @@
 #include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
 #include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
 
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 
 class LGFX : public lgfx::LGFX_Device
 {


### PR DESCRIPTION
## Summary

The user configuration examples under `src/lgfx_user/` include the legacy `driver/i2c.h` only to get `i2c_port_t` / `I2C_NUM_x`.
ESP-IDF 6.x marks that header as EOL and emits a `CRITICAL WARNING` pragma on every include; it is scheduled for removal in IDF v7.

This change includes `driver/i2c_master.h` when it is available (IDF 5.2+) and falls back to `driver/i2c.h` otherwise (IDF 4.4 / Arduino core 2.x), the same pattern already used in `platforms/esp32/common.cpp` and `LGFX_AutoDetect_ESP32_all.hpp`.
No functional change; the I2C implementation itself does not use the legacy driver API.

## Verified

- ESP-IDF 6.1 (esp32s3): the `driver/i2c.h` EOL warning no longer appears, build passes
- Arduino core 2.0.3 (IDF 4.4, fallback path), Arduino core 3.3.9, ESP-IDF 5.5.1: build passes
- Fork CI green on this branch
