### PR TITLE
Panel_AMOLED: do not keep a framebuffer object whose init failed

### DIFF
--- a/src/lgfx/v1/panel/Panel_AMOLED.hpp
+++ b/src/lgfx/v1/panel/Panel_AMOLED.hpp
@@ -19,6 +19,8 @@
 
 #if defined (ESP_PLATFORM)
 
+#include <new>
+
 #include "Panel_Device.hpp"
 #include "Panel_FrameBufferBase.hpp"
 #include "../platforms/common.hpp"
@@ -88,11 +90,22 @@ namespace lgfx
             {
               if(_panel_fb)
                 return true;
-              _panel_fb = new Panel_AMOLED_Framebuffer(this);
-              _panel_fb->config(_cfg);
-              _panel_fb->setColorDepth(_write_depth);
-              _panel_fb->setRotation(getRotation());
-              return _panel_fb->init(false);
+              auto fb = new (std::nothrow) Panel_AMOLED_Framebuffer(this);
+              if (!fb)
+                return false;
+              fb->config(_cfg);
+              fb->setColorDepth(_write_depth);
+              fb->setRotation(getRotation());
+              // Keep _panel_fb null on failure: a leftover object without a
+              // buffer would make the next call report success and route
+              // display() through a framebuffer that does not exist.
+              if (!fb->init(false))
+              {
+                delete fb;
+                return false;
+              }
+              _panel_fb = fb;
+              return true;
             }
 
             void deinitPanelFb()


### PR DESCRIPTION
## Summary

`Panel_AMOLED::initPanelFb()` assigned `_panel_fb` before calling `init()`. When the PSRAM frame buffer allocation failed, the object stayed behind without a buffer, so:

- the next `initPanelFb()` call returned `true` immediately without allocating anything, and
- `display()` was routed through a frame buffer that does not exist.

A caller that adopts that panel after the "successful" retry (the CO5300-based board setup does exactly this) dereferences a null line buffer. The object is now created locally with `std::nothrow` (exceptions are disabled on the ESP32 targets, so a throwing `new` that fails would terminate instead of letting the caller fall back to direct drawing) and published to `_panel_fb` only after `init()` succeeds; on any failure it is released and the method returns `false` as documented.

## Verified

Test firmware on an ESP32-S3 board with a 468x468 CO5300 panel: exhaust PSRAM before init so the frame buffer allocation fails, free it, then call `initPanelFb()` again and adopt the returned panel.

| | first call (no PSRAM) | retry after freeing PSRAM | drawing through the adopted panel |
|---|---|---|---|
| before | returns `true` with a stale object | returns `true`, PSRAM usage unchanged (0 bytes) | `LoadProhibited` at address 0, reset loop |
| after | returns `false`, `getPanelFb()` is null | returns `true`, 442372 bytes allocated | works, no reset |

Normal boot with PSRAM available is unchanged. Fork CI green on this branch.
